### PR TITLE
Use latest OID4VP version with input descriptor path changes

### DIFF
--- a/mobile-sdk-rs/Cargo.lock
+++ b/mobile-sdk-rs/Cargo.lock
@@ -2542,6 +2542,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
+
+[[package]]
 name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2890,17 +2896,6 @@ dependencies = [
  "smallstr",
  "smallvec",
  "utf8-decode",
-]
-
-[[package]]
-name = "jsonpath_lib"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
-dependencies = [
- "log",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -3620,14 +3615,13 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openid4vp"
 version = "0.1.0"
-source = "git+https://github.com/spruceid/openid4vp?rev=372f5f5#372f5f59c3176786cda6ebcdf41944c5ff7fb932"
+source = "git+https://github.com/spruceid/openid4vp?rev=4a76572#4a765727593463163bab37cd5d963a91dfb765ba"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.21.7",
  "http 1.1.0",
  "json-syntax",
- "jsonpath_lib",
  "jsonschema",
  "openid4vp-frontend",
  "p256",
@@ -3635,8 +3629,10 @@ dependencies = [
  "reqwest 0.12.8",
  "serde",
  "serde_json",
+ "serde_json_path",
  "serde_urlencoded",
  "ssi",
+ "thiserror",
  "tokio",
  "tracing",
  "url",
@@ -3647,7 +3643,7 @@ dependencies = [
 [[package]]
 name = "openid4vp-frontend"
 version = "0.1.0"
-source = "git+https://github.com/spruceid/openid4vp?rev=372f5f5#372f5f59c3176786cda6ebcdf41944c5ff7fb932"
+source = "git+https://github.com/spruceid/openid4vp?rev=4a76572#4a765727593463163bab37cd5d963a91dfb765ba"
 dependencies = [
  "serde",
  "serde_json",
@@ -4735,11 +4731,63 @@ version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
- "indexmap 2.6.0",
  "itoa",
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_json_path"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bc0207b6351893eafa1e39aa9aea452abb6425ca7b02dd64faf29109e7a33ba"
+dependencies = [
+ "inventory",
+ "nom",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_json_path_core",
+ "serde_json_path_macros",
+ "thiserror",
+]
+
+[[package]]
+name = "serde_json_path_core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d64fe53ce1aaa31bea2b2b46d3b6ab6a37e61854bedcbd9f174e188f3f7d79"
+dependencies = [
+ "inventory",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "serde_json_path_macros"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a31e8177a443fd3e94917f12946ae7891dfb656e6d4c5e79b8c5d202fbcb723"
+dependencies = [
+ "inventory",
+ "once_cell",
+ "serde_json_path_core",
+ "serde_json_path_macros_internal",
+]
+
+[[package]]
+name = "serde_json_path_macros_internal"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75dde5a1d2ed78dfc411fc45592f72d3694436524d3353683ecb3d22009731dc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5995,18 +6043,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/mobile-sdk-rs/Cargo.toml
+++ b/mobile-sdk-rs/Cargo.toml
@@ -21,7 +21,7 @@ cose-rs = { git = "https://github.com/spruceid/cose-rs", rev = "0018c9b", featur
 ] }
 isomdl = { git = "https://github.com/spruceid/isomdl", rev = "1f4f762" }
 oid4vci = { git = "https://github.com/spruceid/oid4vci-rs", rev = "d95fe3a" }
-openid4vp = { git = "https://github.com/spruceid/openid4vp", rev = "372f5f5" }
+openid4vp = { git = "https://github.com/spruceid/openid4vp", rev = "4a76572" }
 ssi = { version = "0.9", features = ["secp256r1", "secp384r1"] }
 
 async-trait = "0.1"
@@ -41,7 +41,7 @@ reqwest = { version = "0.11", features = ["blocking"] }
 serde = { version = "1.0.204", features = ["derive"] }
 serde_cbor = "0.11.2"
 serde_json = "1.0.111"
-thiserror = "1.0.56"
+thiserror = "1.0.65"
 signature = "2.2.0"
 ssi-contexts = "0.1.6"
 time = { version = "0.3.36", features = [

--- a/mobile-sdk-rs/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/mobile-sdk-rs/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -3211,7 +3211,7 @@ public protocol PermissionRequestProtocol : AnyObject {
     /**
      * Construct a new permission response for the given credential.
      */
-    func createPermissionResponse(selectedCredential: ParsedCredential)  -> PermissionResponse
+    func createPermissionResponse(selectedCredentials: [ParsedCredential])  -> PermissionResponse
     
     /**
      * Return the filtered list of credentials that matched
@@ -3277,10 +3277,10 @@ open class PermissionRequest:
     /**
      * Construct a new permission response for the given credential.
      */
-open func createPermissionResponse(selectedCredential: ParsedCredential) -> PermissionResponse {
+open func createPermissionResponse(selectedCredentials: [ParsedCredential]) -> PermissionResponse {
     return try!  FfiConverterTypePermissionResponse.lift(try! rustCall() {
     uniffi_mobile_sdk_rs_fn_method_permissionrequest_create_permission_response(self.uniffiClonePointer(),
-        FfiConverterTypeParsedCredential.lower(selectedCredential),$0
+        FfiConverterSequenceTypeParsedCredential.lower(selectedCredentials),$0
     )
 })
 }
@@ -3481,12 +3481,17 @@ public protocol RequestedFieldProtocol : AnyObject {
     /**
      * Return the field name
      */
-    func name()  -> String
+    func name()  -> String?
     
     /**
      * Return the purpose of the requested field.
      */
     func purpose()  -> String?
+    
+    /**
+     * Return the stringified JSON raw fields.
+     */
+    func rawFields()  -> [String]
     
     /**
      * Return the field required status
@@ -3544,8 +3549,8 @@ open class RequestedField:
     /**
      * Return the field name
      */
-open func name() -> String {
-    return try!  FfiConverterString.lift(try! rustCall() {
+open func name() -> String? {
+    return try!  FfiConverterOptionString.lift(try! rustCall() {
     uniffi_mobile_sdk_rs_fn_method_requestedfield_name(self.uniffiClonePointer(),$0
     )
 })
@@ -3557,6 +3562,16 @@ open func name() -> String {
 open func purpose() -> String? {
     return try!  FfiConverterOptionString.lift(try! rustCall() {
     uniffi_mobile_sdk_rs_fn_method_requestedfield_purpose(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Return the stringified JSON raw fields.
+     */
+open func rawFields() -> [String] {
+    return try!  FfiConverterSequenceString.lift(try! rustCall() {
+    uniffi_mobile_sdk_rs_fn_method_requestedfield_raw_fields(self.uniffiClonePointer(),$0
     )
 })
 }
@@ -5491,6 +5506,8 @@ public enum CredentialEncodingError {
     )
     case SdJwt(SdJwtError
     )
+    case VpToken(String
+    )
 }
 
 
@@ -5512,6 +5529,9 @@ public struct FfiConverterTypeCredentialEncodingError: FfiConverterRustBuffer {
             )
         case 3: return .SdJwt(
             try FfiConverterTypeSdJwtError.read(from: &buf)
+            )
+        case 4: return .VpToken(
+            try FfiConverterString.read(from: &buf)
             )
 
          default: throw UniffiInternalError.unexpectedEnumCase
@@ -5538,6 +5558,11 @@ public struct FfiConverterTypeCredentialEncodingError: FfiConverterRustBuffer {
         case let .SdJwt(v1):
             writeInt(&buf, Int32(3))
             FfiConverterTypeSdJwtError.write(v1, into: &buf)
+            
+        
+        case let .VpToken(v1):
+            writeInt(&buf, Int32(4))
+            FfiConverterString.write(v1, into: &buf)
             
         }
     }
@@ -6646,6 +6671,8 @@ public enum Oid4vpError {
     case RequestSignerNotFound
     case MetadataInitialization(String
     )
+    case PermissionResponse(PermissionResponseError
+    )
 }
 
 
@@ -6725,6 +6752,9 @@ public struct FfiConverterTypeOID4VPError: FfiConverterRustBuffer {
         case 24: return .RequestSignerNotFound
         case 25: return .MetadataInitialization(
             try FfiConverterString.read(from: &buf)
+            )
+        case 26: return .PermissionResponse(
+            try FfiConverterTypePermissionResponseError.read(from: &buf)
             )
 
          default: throw UniffiInternalError.unexpectedEnumCase
@@ -6857,6 +6887,11 @@ public struct FfiConverterTypeOID4VPError: FfiConverterRustBuffer {
         case let .MetadataInitialization(v1):
             writeInt(&buf, Int32(25))
             FfiConverterString.write(v1, into: &buf)
+            
+        
+        case let .PermissionResponse(v1):
+            writeInt(&buf, Int32(26))
+            FfiConverterTypePermissionResponseError.write(v1, into: &buf)
             
         }
     }
@@ -7194,6 +7229,68 @@ public struct FfiConverterTypePermissionRequestError: FfiConverterRustBuffer {
 extension PermissionRequestError: Equatable, Hashable {}
 
 extension PermissionRequestError: Foundation.LocalizedError {
+    public var errorDescription: String? {
+        String(reflecting: self)
+    }
+}
+
+
+public enum PermissionResponseError {
+
+    
+    
+    case JsonPathParse(String
+    )
+    case CredentialEncoding(CredentialEncodingError
+    )
+}
+
+
+public struct FfiConverterTypePermissionResponseError: FfiConverterRustBuffer {
+    typealias SwiftType = PermissionResponseError
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PermissionResponseError {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        
+
+        
+        case 1: return .JsonPathParse(
+            try FfiConverterString.read(from: &buf)
+            )
+        case 2: return .CredentialEncoding(
+            try FfiConverterTypeCredentialEncodingError.read(from: &buf)
+            )
+
+         default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: PermissionResponseError, into buf: inout [UInt8]) {
+        switch value {
+
+        
+
+        
+        
+        case let .JsonPathParse(v1):
+            writeInt(&buf, Int32(1))
+            FfiConverterString.write(v1, into: &buf)
+            
+        
+        case let .CredentialEncoding(v1):
+            writeInt(&buf, Int32(2))
+            FfiConverterTypeCredentialEncodingError.write(v1, into: &buf)
+            
+        }
+    }
+}
+
+
+extension PermissionResponseError: Equatable, Hashable {}
+
+extension PermissionResponseError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
@@ -9631,7 +9728,7 @@ private var initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_method_parsedcredential_type() != 60750) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mobile_sdk_rs_checksum_method_permissionrequest_create_permission_response() != 11132) {
+    if (uniffi_mobile_sdk_rs_checksum_method_permissionrequest_create_permission_response() != 23487) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_permissionrequest_credentials() != 38374) {
@@ -9643,10 +9740,13 @@ private var initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_method_permissionrequest_requested_fields() != 48174) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mobile_sdk_rs_checksum_method_requestedfield_name() != 28018) {
+    if (uniffi_mobile_sdk_rs_checksum_method_requestedfield_name() != 19474) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_requestedfield_purpose() != 46977) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mobile_sdk_rs_checksum_method_requestedfield_raw_fields() != 44847) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_requestedfield_required() != 14409) {

--- a/mobile-sdk-rs/src/credential/json_vc.rs
+++ b/mobile-sdk-rs/src/credential/json_vc.rs
@@ -129,7 +129,7 @@ impl JsonVc {
         }
 
         // Check the JSON-encoded credential against the definition.
-        definition.check_credential_validation(&self.raw)
+        definition.is_credential_match(&self.raw)
     }
 
     /// Returns the requested fields given a presentation definition.

--- a/mobile-sdk-rs/src/credential/vcdm2_sd_jwt.rs
+++ b/mobile-sdk-rs/src/credential/vcdm2_sd_jwt.rs
@@ -3,7 +3,9 @@ use crate::{oid4vp::permission_request::RequestedField, CredentialType, KeyAlias
 
 use std::sync::Arc;
 
-use openid4vp::core::presentation_definition::PresentationDefinition;
+use openid4vp::core::{
+    presentation_definition::PresentationDefinition, response::parameters::VpTokenItem,
+};
 use ssi::{
     claims::{
         sd_jwt::SdJwtBuf,
@@ -71,7 +73,7 @@ impl VCDM2SdJwt {
         };
 
         // Check the JSON-encoded credential against the definition.
-        definition.check_credential_validation(&json)
+        definition.is_credential_match(&json)
     }
 
     /// Return the requested fields for the SD-JWT credential.
@@ -92,6 +94,19 @@ impl VCDM2SdJwt {
             .map(Into::into)
             .map(Arc::new)
             .collect()
+    }
+
+    /// Return the credential as a VpToken
+    pub fn as_vp_token(&self) -> VpTokenItem {
+        // TODO: need to provide the "filtered" (disclosed) fields of the
+        // credential to be encoded into the VpToken.
+        //
+        // Currently, this is encoding the entire revealed SD-JWT,
+        // without the selection of individual disclosed fields.
+        //
+        // We need to selectively disclosed fields.
+        let compact: &str = self.inner.as_ref();
+        VpTokenItem::String(compact.to_string())
     }
 }
 

--- a/mobile-sdk-rs/src/oid4vp/error.rs
+++ b/mobile-sdk-rs/src/oid4vp/error.rs
@@ -1,5 +1,7 @@
 // use super::request_signer::RequestSignerError;
 
+use super::permission_request::PermissionResponseError;
+
 /// The [OID4VPError] enum represents the errors that can occur
 /// when using the oid4vp foreign library.
 #[derive(thiserror::Error, Debug, uniffi::Error)]
@@ -54,6 +56,8 @@ pub enum OID4VPError {
     RequestSignerNotFound,
     #[error("Failed to initialize metadata: {0}")]
     MetadataInitialization(String),
+    #[error(transparent)]
+    PermissionResponse(#[from] PermissionResponseError),
 }
 
 // Handle unexpected errors when calling a foreign callback


### PR DESCRIPTION
This PR uses the latest changes to openid4vp in review: https://github.com/spruceid/openid4vp/pull/33

Other changes in this PR include moving the creation of the vp token to methods on the respective credential types (e.g., JwtVc, SdJwt). NOTE: I still need to push a PR for selective disclosure for SD-JWTs to follow in another PR for improving the vp token for SdJwts.

