### PR TITLE
Update push workflows to use monorepo GitHub app.

### DIFF
--- a/.github/workflows/mobile_sdk_ios_app_push.yml
+++ b/.github/workflows/mobile_sdk_ios_app_push.yml
@@ -10,10 +10,15 @@ jobs:
   push:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.MONOREPO_GH_APP_ID }}
+          private-key: ${{ secrets.MONOREPO_GH_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.MONOREPO_GITHUB_ACCESS_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Push subtree
         run: |
           git subtree push --prefix=mobile-sdk-ios-app/ https://github.com/spruceid/mobile-sdk-ios-app.git main

--- a/.github/workflows/mobile_sdk_kt_push.yml
+++ b/.github/workflows/mobile_sdk_kt_push.yml
@@ -10,10 +10,15 @@ jobs:
   push:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.MONOREPO_GH_APP_ID }}
+          private-key: ${{ secrets.MONOREPO_GH_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.MONOREPO_GITHUB_ACCESS_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Push subtree
         run: |
           git subtree push --prefix=mobile-sdk-kt/ https://github.com/spruceid/mobile-sdk-kt.git main

--- a/.github/workflows/mobile_sdk_rs_push.yml
+++ b/.github/workflows/mobile_sdk_rs_push.yml
@@ -10,10 +10,15 @@ jobs:
   push:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.MONOREPO_GH_APP_ID }}
+          private-key: ${{ secrets.MONOREPO_GH_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.MONOREPO_GITHUB_ACCESS_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Push subtree
         run: |
           git subtree push --prefix=mobile-sdk-rs/ https://github.com/spruceid/mobile-sdk-rs.git main

--- a/.github/workflows/mobile_sdk_swift_push.yml
+++ b/.github/workflows/mobile_sdk_swift_push.yml
@@ -10,10 +10,15 @@ jobs:
   push:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.MONOREPO_GH_APP_ID }}
+          private-key: ${{ secrets.MONOREPO_GH_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.MONOREPO_GITHUB_ACCESS_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Push subtree
         run: |
           git subtree push --prefix=mobile-sdk-swift/ https://github.com/spruceid/mobile-sdk-swift.git main


### PR DESCRIPTION
Migrate away from using personal access tokens to push sub-repos.