### PR TITLE
return json string in vp token, not compact JWS

### DIFF
--- a/mobile-sdk-rs/src/credential/vcdm2_sd_jwt.rs
+++ b/mobile-sdk-rs/src/credential/vcdm2_sd_jwt.rs
@@ -105,8 +105,11 @@ impl VCDM2SdJwt {
         // without the selection of individual disclosed fields.
         //
         // We need to selectively disclosed fields.
-        let compact: &str = self.inner.as_ref();
-        VpTokenItem::String(compact.to_string())
+        let object = serde_json::to_string(&self.credential)
+            // SAFETY: we are serializing a JSON value (SpecializedJsonCredential),
+            // so this should always be valid.
+            .unwrap();
+        VpTokenItem::String(object)
     }
 }
 


### PR DESCRIPTION
## Description

Returns a JSON string in the vp token instead of compact JWS for SD-JWT presentation.

### Other changes



### Optional section



## Tested

