### PR TITLE
Add CredentialPack.clearPacks

### DIFF
--- a/mobile-sdk-kt/MobileSdk/src/main/java/com/spruceid/mobile/sdk/CredentialPack.kt
+++ b/mobile-sdk-kt/MobileSdk/src/main/java/com/spruceid/mobile/sdk/CredentialPack.kt
@@ -217,6 +217,19 @@ class CredentialPack {
 
     companion object {
         /**
+         * Clears all stored CredentialPacks.
+         */
+        fun clearPacks(storage: StorageManagerInterface) {
+            try {
+                storage.list()
+                    .filter { it.startsWith(CredentialPackContents.STORAGE_PREFIX) }
+                    .forEach { storage.remove(it) }
+            } catch (e: Exception) {
+                throw ClearingException("unable to clear CredentialPacks", e)
+            }
+        }
+
+        /**
          * List all CredentialPacks.
          *
          * These can then be individually loaded. For eager loading of all packs, see `loadPacks`.
@@ -361,3 +374,4 @@ class CredentialPackContents {
 class ParsingException(message: String, cause: Throwable?) : Exception(message, cause)
 class LoadingException(message: String, cause: Throwable) : Exception(message, cause)
 class SavingException(message: String, cause: Throwable) : Exception(message, cause)
+class ClearingException(message: String, cause: Throwable) : Exception(message, cause)

--- a/mobile-sdk-swift/Sources/MobileSdk/CredentialPack.swift
+++ b/mobile-sdk-swift/Sources/MobileSdk/CredentialPack.swift
@@ -236,6 +236,21 @@ struct CredentialPackContents {
         return CredentialPack(id: self.id, credentials: credentials)
     }
 
+    /// Clears all CredentialPacks.
+    public static func clear(storageManager: StorageManagerInterface) throws {
+        do {
+            try storageManager.list()
+                .filter { file in
+                    file.hasPrefix(Self.storagePrefix)
+                }
+                .forEach { file in
+                    try storageManager.remove(key: file)
+                }
+        } catch {
+            throw CredentialPackError.clearing(reason: error)
+        }
+    }
+
     /// Lists all CredentialPacks.
     ///
     /// These can then be individually loaded. For eager loading of all packs, see `CredentialPack.loadAll`.
@@ -312,6 +327,8 @@ enum CredentialPackError: Error {
     case missing(file: String)
     /// Failed to list CredentialPackContents from storage.
     case listing(reason: Error)
+    /// Failed to clear CredentialPacks from storage.
+    case clearing(reason: Error)
     /// Failed to remove CredentialPackContents from storage.
     case removing(reason: Error)
     /// Failed to save CredentialPackContents to storage.


### PR DESCRIPTION
## Description

Adds a `clearPacks` function to `CredentialPacks` to remove all stored credential packs.

This is different than `list/loadPacks` plus a `remove` call because in the event that the encryption key is not available anymore, it won't be able to load the files, so this just removes everything by looking at the prefix without a load.
