### PR TITLE
Add new contexts for VC Playground VCDM2.0 credentials

### DIFF
--- a/mobile-sdk-kt/example/src/main/res/raw/w3id_org_citizenship_v4rc1.json
+++ b/mobile-sdk-kt/example/src/main/res/raw/w3id_org_citizenship_v4rc1.json
@@ -1,0 +1,254 @@
+{
+  "@context": {
+    "@protected": true,
+
+    "image": { "@id": "https://schema.org/image", "@type": "@id" },
+
+    "QuantitativeValue": {
+      "@id": "https://schema.org/QuantitativeValue",
+      "@context": {
+        "@protected": true,
+
+        "unitCode": "https://schema.org/unitCode",
+        "value": "https://schema.org/value"
+      }
+    },
+
+    "PostalAddress": {
+      "@id": "https://schema.org/PostalAddress",
+      "@context": {
+        "@protected": true,
+
+        "addressCountry": "https://schema.org/addressCountry",
+        "addressLocality": "https://schema.org/addressLocality",
+        "addressRegion": "https://schema.org/addressRegion"
+      }
+    },
+
+    "Person": {
+      "@id": "https://schema.org/Person",
+
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "additionalName": "https://schema.org/additionalName",
+        "birthCountry": "https://w3id.org/citizenship#birthCountry",
+        "birthDate": {
+          "@id": "https://schema.org/birthDate",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "familyName": "https://schema.org/familyName",
+        "gender": "https://schema.org/gender",
+        "givenName": "https://schema.org/givenName",
+        "height": "https://schema.org/height",
+        "image": { "@id": "https://schema.org/image", "@type": "@id" },
+        "maritalStatus": "https://w3id.org/citizenship#maritalStatus",
+        "marriageCertificateNumber": "https://w3id.org/citizenship#marriageCertificateNumber",
+        "marriageLocation": {
+          "@id": "https://w3id.org/citizenship#marriageLocation",
+          "@type": "@id"
+        }
+      }
+    },
+
+    "PermanentResident": {
+      "@id": "https://w3id.org/citizenship#PermanentResident",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "commuterClassification": "https://w3id.org/citizenship#commuterClassification",
+        "formerNationality": "https://w3id.org/citizenship#formerNationality",
+        "permanentResidentCard": {
+          "@id": "https://w3id.org/citizenship#permanentResidentCard",
+          "@type": "@id"
+        },
+        "residence": {
+          "@id": "https://w3id.org/citizenship#residence",
+          "@type": "@id"
+        },
+        "residentSince": {
+          "@id": "https://w3id.org/citizenship#residentSince",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        }
+      }
+    },
+
+    "PermanentResidentCard": {
+      "@id": "https://w3id.org/citizenship#PermanentResidentCard",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "filingLocation": {
+          "@id": "https://w3id.org/citizenship#filingLocation",
+          "@type": "@id"
+        },
+        "identifier": "https://schema.org/identifier",
+        "lprCategory": "https://w3id.org/citizenship#lprCategory",
+        "lprNumber": "https://w3id.org/citizenship#lprNumber",
+        "mrzHash": {
+          "@id": "https://w3id.org/citizenship#mrzHash",
+          "@type": "https://w3id.org/security#multibase"
+        }
+      }
+    },
+
+    "PermanentResidentCardCredential": "https://w3id.org/citizenship#PermanentResidentCardCredential",
+
+    "EmployablePerson": {
+      "@id": "https://w3id.org/citizenship#EmployablePerson",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "commuterClassification": "https://w3id.org/citizenship#commuterClassification",
+        "employmentAuthorizationDocument": {
+          "@id": "https://w3id.org/citizenship#employmentAuthorizationDocument",
+          "@type": "@id"
+        },
+        "formerNationality": "https://w3id.org/citizenship#formerNationality",
+        "residence": {
+          "@id": "https://w3id.org/citizenship#residence",
+          "@type": "@id"
+        },
+        "residentSince": {
+          "@id": "https://w3id.org/citizenship#residentSince",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        }
+      }
+    },
+
+    "EmploymentAuthorizationDocument": {
+      "@id": "https://w3id.org/citizenship#EmploymentAuthorizationDocument",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "filingLocation": {
+          "@id": "https://w3id.org/citizenship#filingLocation",
+          "@type": "@id"
+        },
+        "identifier": "https://schema.org/identifier",
+        "lprCategory": "https://w3id.org/citizenship#lprCategory",
+        "lprNumber": "https://w3id.org/citizenship#lprNumber",
+        "mrzHash": {
+          "@id": "https://w3id.org/citizenship#mrzHash",
+          "@type": "https://w3id.org/security#multibase"
+        }
+      }
+    },
+
+    "EmploymentAuthorizationDocumentCredential": "https://w3id.org/citizenship#EmploymentAuthorizationDocumentCredential",
+
+    "NaturalizedPerson": {
+      "@id": "https://w3id.org/citizenship#NaturalizedPerson",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "formerNationality": "https://w3id.org/citizenship#formerNationality",
+        "certificateOfNaturalization": {
+          "@id": "https://w3id.org/citizenship#certificateOfNaturalization",
+          "@type": "@id"
+        },
+        "residence": {
+          "@id": "https://w3id.org/citizenship#residence",
+          "@type": "@id"
+        },
+        "residentSince": {
+          "@id": "https://w3id.org/citizenship#residentSince",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "commuterClassification": "https://w3id.org/citizenship#commuterClassification"
+      }
+    },
+
+    "CertificateOfNaturalization": {
+      "@id": "https://w3id.org/citizenship#CertificateOfNaturalization",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "ceremonyDate": {
+          "@id": "https://w3id.org/citizenship#ceremonyDate",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "ceremonyLocation": {
+          "@id": "https://w3id.org/citizenship#ceremonyLocation",
+          "@type": "@id"
+        },
+        "filingLocation": {
+          "@id": "https://w3id.org/citizenship#filingLocation",
+          "@type": "@id"
+        },
+        "naturalizationLocation": {
+          "@id": "https://w3id.org/citizenship#naturalizationLocation",
+          "@type": "@id"
+        },
+        "naturalizedBy": "https://w3id.org/citizenship#naturalizedBy",
+        "identifier": "https://schema.org/identifier",
+        "insRegistrationNumber": "https://w3id.org/citizenship#insRegistrationNumber"
+      }
+    },
+
+    "CertificateOfNaturalizationCredential": "https://w3id.org/citizenship#CertificateOfNaturalizationCredential",
+
+    "Citizen": {
+      "@id": "https://w3id.org/citizenship#Citizen",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "certificateOfCitizenship": {
+          "@id": "https://w3id.org/citizenship#certificateOfCitizenship",
+          "@type": "@id"
+        }
+      }
+    },
+
+    "CertificateOfCitizenship": {
+      "@id": "https://w3id.org/citizenship#CertificateOfCitizenship",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "filingLocation": {
+          "@id": "https://w3id.org/citizenship#filingLocation",
+          "@type": "@id"
+        },
+        "identifier": "https://schema.org/identifier",
+        "ceremonyDate": {
+          "@id": "https://w3id.org/citizenship#ceremonyDate",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "ceremonyLocation": {
+          "@id": "https://w3id.org/citizenship#ceremonyLocation",
+          "@type": "@id"
+        },
+        "cisRegistrationNumber": "https://w3id.org/citizenship#cisRegistrationNumber"
+      }
+    },
+
+    "CertificateOfCitizenshipCredential": "https://w3id.org/citizenship#CertificateOfCitizenshipCredential"
+  }
+}

--- a/mobile-sdk-kt/example/src/main/res/raw/w3id_org_vc_render_method_v2rc1
+++ b/mobile-sdk-kt/example/src/main/res/raw/w3id_org_vc_render_method_v2rc1
@@ -1,0 +1,39 @@
+{
+  "@context": {
+    "@protected": true,
+    "id": "@id",
+    "type": "@type",
+    "SvgRenderingTemplate2023": {
+      "@id": "https://w3id.org/vc/render-method#SvgRenderingTemplate2023",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "css3MediaQuery": {
+          "@id": "https://w3id.org/vc/render-method#css3MediaQuery"
+        },
+        "digestMultibase": {
+          "@id": "https://w3id.org/security#digestMultibase",
+          "@type": "https://w3id.org/security#multibase"
+        },
+        "name": "https://schema.org/name"
+      }
+    },
+    "SvgRenderingTemplate2024": {
+      "@id": "https://w3id.org/vc/render-method#SvgRenderingTemplate2024",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "digestMultibase": {
+          "@id": "https://w3id.org/security#digestMultibase",
+          "@type": "https://w3id.org/security#multibase"
+        },
+        "mediaQuery": "https://w3id.org/vc/render-method#mediaQuery",
+        "mediaType": "https://schema.org/encodingFormat",
+        "name": "https://schema.org/name",
+        "template": "https://w3id.org/vc/render-method#template"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds updated contexts for VC Playgroun VCDM 2.0 credentials, allowing the demo wallet to successfully scan the VCDM 2.0 versions of "Employment Authorization Document" and "Certificate of Naturalization" credentials. This is necessary to demonstrate the demo wallet passing VCDM 2.0 verification.
