### PR TITLE
fetch and merge changes on main before pushing a re-release tag

### DIFF
--- a/mobile-sdk-rs/.github/workflows/release.yml
+++ b/mobile-sdk-rs/.github/workflows/release.yml
@@ -58,6 +58,8 @@ jobs:
       run: |
         git config user.name github-actions
         git config user.email github-actions@github.com
+        git fetch origin
+        git merge origin/main
         git add Package.swift SpruceIDMobileSdkRs.podspec SpruceIDMobileSdkRsRustFramework.podspec
         git commit -m "Release ${{ github.event.inputs.version }}"
         git push


### PR DESCRIPTION
## Description

When a workflow release job fails and we want to re-run a tagged release, we need to fetch and merge changes on main before pushing the tag.

## Tested

Trying to check if this will resolve re-running a tagged release. Have not verified yet.
