### PR TITLE
pull changes on subtree before push

### DIFF
--- a/.github/workflows/mobile_sdk_rs_push.yml
+++ b/.github/workflows/mobile_sdk_rs_push.yml
@@ -26,4 +26,5 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
       - name: Push subtree
         run: |
+          git subtree pull --prefix=mobile-sdk-rs/ https://github.com/spruceid/mobile-sdk-rs.git main
           git subtree push --prefix=mobile-sdk-rs/ https://github.com/spruceid/mobile-sdk-rs.git main


### PR DESCRIPTION
## Description

when the subtree does a tagged release, it pushes to its main branch. We need to pull latest changes before pushing.

