### PR TITLE
add fetch and merge before sed command in release workflow

### DIFF
--- a/mobile-sdk-rs/.github/workflows/release.yml
+++ b/mobile-sdk-rs/.github/workflows/release.yml
@@ -46,6 +46,14 @@ jobs:
       run: |
         zip -9 -r RustFramework.xcframework.zip MobileSdkRs/RustFramework.xcframework
         echo "XCF_CHECKSUM=`swift package compute-checksum RustFramework.xcframework.zip`" >> $GITHUB_ENV
+    
+    - name: Git fetch and merge
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git fetch origin
+        git merge origin/main
+    
     - name: Update Swift Package definition
       run: |
         sed -i '' 's/.binaryTarget.*/.binaryTarget(name: "RustFramework", url: "https:\/\/github.com\/spruceid\/mobile-sdk-rs\/releases\/download\/${{ github.event.inputs.version }}\/RustFramework.xcframework.zip", checksum: "${{ env.XCF_CHECKSUM }}"),/' Package.swift
@@ -58,8 +66,6 @@ jobs:
       run: |
         git config user.name github-actions
         git config user.email github-actions@github.com
-        git fetch origin
-        git merge origin/main
         git add Package.swift SpruceIDMobileSdkRs.podspec SpruceIDMobileSdkRsRustFramework.podspec
         git commit -m "Release ${{ github.event.inputs.version }}"
         git push


### PR DESCRIPTION
## Description

Moving the git fetch and merge for main branch changes before the `sed` replace script.

## Tested

Testing on a CI release workflow when CocoaPods fails and needs a re-run.