### PR TITLE
Rust Changes to OID4VCI for Custom Profiles

### DIFF
--- a/mobile-sdk-rs/Cargo.lock
+++ b/mobile-sdk-rs/Cargo.lock
@@ -3482,7 +3482,7 @@ dependencies = [
 [[package]]
 name = "oid4vci"
 version = "0.1.0"
-source = "git+https://github.com/spruceid/oid4vci-rs?rev=3717043#3717043909b7ef766b340a58306d2325e61216df"
+source = "git+https://github.com/spruceid/oid4vci-rs?rev=e97b01e#e97b01e9fa230d6da08cc765c3674330c0c0fa32"
 dependencies = [
  "anyhow",
  "async-signature",
@@ -3493,6 +3493,7 @@ dependencies = [
  "percent-encoding",
  "rand",
  "serde",
+ "serde_cbor",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",

--- a/mobile-sdk-rs/Cargo.toml
+++ b/mobile-sdk-rs/Cargo.toml
@@ -20,7 +20,7 @@ cose-rs = { git = "https://github.com/spruceid/cose-rs", rev = "0018c9b", featur
     "time",
 ] }
 isomdl = { git = "https://github.com/spruceid/isomdl", rev = "1f4f762" }
-oid4vci = { git = "https://github.com/spruceid/oid4vci-rs", rev = "3717043" }
+oid4vci = { git = "https://github.com/spruceid/oid4vci-rs", rev = "e97b01e" }
 openid4vp = { git = "https://github.com/spruceid/openid4vp", rev = "335c843" }
 ssi = { version = "0.10.1", features = ["secp256r1", "secp384r1"] }
 

--- a/mobile-sdk-rs/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/mobile-sdk-rs/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -10910,11 +10910,11 @@ public func establishSession(uri: String, requestedItems: [String: [String: Bool
     )
 })
 }
-public func generatePopComplete(signingInput: Data, signature: Data)throws  -> String {
+public func generatePopComplete(signingInput: Data, signatureDer: Data)throws  -> String {
     return try  FfiConverterString.lift(try rustCallWithError(FfiConverterTypeOid4vciError.lift) {
     uniffi_mobile_sdk_rs_fn_func_generate_pop_complete(
         FfiConverterData.lower(signingInput),
-        FfiConverterData.lower(signature),$0
+        FfiConverterData.lower(signatureDer),$0
     )
 })
 }
@@ -11147,7 +11147,7 @@ private var initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_func_establish_session() != 26937) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mobile_sdk_rs_checksum_func_generate_pop_complete() != 56778) {
+    if (uniffi_mobile_sdk_rs_checksum_func_generate_pop_complete() != 41207) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_func_generate_pop_prepare() != 54105) {

--- a/mobile-sdk-rs/src/oid4vci/session.rs
+++ b/mobile-sdk-rs/src/oid4vci/session.rs
@@ -1,12 +1,5 @@
 use futures::lock::Mutex;
-use oid4vci::{
-    core::{
-        client, metadata,
-        profiles::{self},
-    },
-    credential_offer::CredentialOfferGrants,
-    token,
-};
+use oid4vci::{credential_offer::CredentialOfferGrants, profiles::metadata, token};
 
 use crate::credential::CredentialFormat;
 
@@ -33,7 +26,7 @@ impl Oid4vciSession {
         }
     }
 
-    pub fn get_client(&self) -> &client::Client {
+    pub fn get_client(&self) -> &oid4vci::profiles::client::Client {
         &self.client.0
     }
 
@@ -68,7 +61,7 @@ impl Oid4vciSession {
 
     pub fn get_credential_requests(
         &self,
-    ) -> Result<Vec<profiles::CoreProfilesCredentialRequest>, Oid4vciError> {
+    ) -> Result<Vec<oid4vci::profiles::ProfilesCredentialRequest>, Oid4vciError> {
         self.credential_request
             .try_lock()
             .ok_or(Oid4vciError::LockError("credential_request".into()))?
@@ -81,7 +74,7 @@ impl Oid4vciSession {
 
     pub fn set_credential_request(
         &self,
-        credential_request: profiles::CoreProfilesCredentialRequest,
+        credential_request: oid4vci::profiles::ProfilesCredentialRequest,
     ) -> Result<(), Oid4vciError> {
         *(self
             .credential_request
@@ -94,7 +87,7 @@ impl Oid4vciSession {
 
     pub fn set_credential_requests(
         &self,
-        credential_requests: Vec<profiles::CoreProfilesCredentialRequest>,
+        credential_requests: Vec<oid4vci::profiles::ProfilesCredentialRequest>,
     ) -> Result<(), Oid4vciError> {
         *(self
             .credential_request
@@ -136,17 +129,17 @@ macro_rules! wrap_external_type {
     };
 }
 
-wrap_external_type!(client::Client, Client);
+wrap_external_type!(oid4vci::profiles::client::Client, Client);
 wrap_external_type!(metadata::CredentialIssuerMetadata, CredentialIssuerMetadata);
 wrap_external_type!(
-    Vec<profiles::CoreProfilesCredentialRequest>,
+    Vec<oid4vci::profiles::ProfilesCredentialRequest>,
     CredentialRequest
 );
 wrap_external_type!(token::Response, TokenResponse);
 wrap_external_type!(CredentialOfferGrants, Grants);
 
-impl From<profiles::CoreProfilesCredentialRequest> for CredentialRequest {
-    fn from(value: profiles::CoreProfilesCredentialRequest) -> Self {
+impl From<oid4vci::profiles::ProfilesCredentialRequest> for CredentialRequest {
+    fn from(value: oid4vci::profiles::ProfilesCredentialRequest) -> Self {
         CredentialRequest(vec![value])
     }
 }

--- a/mobile-sdk-rs/src/oid4vp/holder.rs
+++ b/mobile-sdk-rs/src/oid4vp/holder.rs
@@ -356,11 +356,13 @@ pub(crate) mod tests {
         pub async fn sign_jwt(&self, payload: Vec<u8>) -> Result<Vec<u8>, PresentationError> {
             let sig = self
                 .jwk
-                .sign(payload)
+                .sign_bytes(&payload)
                 .await
                 .expect("failed to sign Jws Payload");
 
-            Ok(sig.as_bytes().to_vec())
+            p256::ecdsa::Signature::from_slice(&sig)
+                .map(|sig| sig.to_der().as_bytes().to_vec())
+                .map_err(|e| PresentationError::Signing(format!("{e:?}")))
         }
     }
 

--- a/mobile-sdk-rs/src/oid4vp/presentation.rs
+++ b/mobile-sdk-rs/src/oid4vp/presentation.rs
@@ -206,7 +206,7 @@ pub struct PresentationOptions<'a> {
     pub(crate) context_map: Option<HashMap<String, String>>,
 }
 
-impl<'a> MessageSigner<WithProtocol<Algorithm, AnyProtocol>> for PresentationOptions<'a> {
+impl MessageSigner<WithProtocol<Algorithm, AnyProtocol>> for PresentationOptions<'_> {
     #[allow(async_fn_in_trait)]
     async fn sign(
         self,
@@ -247,7 +247,7 @@ impl<'a> MessageSigner<WithProtocol<Algorithm, AnyProtocol>> for PresentationOpt
     }
 }
 
-impl<'a, M> ssi::verification_methods::Signer<M> for PresentationOptions<'a>
+impl<M> ssi::verification_methods::Signer<M> for PresentationOptions<'_>
 where
     M: ssi::verification_methods::VerificationMethod,
 {


### PR DESCRIPTION
## Description
Makes updates to mobile-sdk-rs taking into account the changes made to `oid4vci-rs` to unify the `core` and `custom` profiles under a single {de}serializable type.

## Tested
Tested by incorporating the changes into the Android showcase app and claiming a credential issued by credible over OID4VCI
