### PR TITLE
18013-7: Handle missing requested fields.

### DIFF
--- a/mobile-sdk-rs/src/oid4vp/iso_18013_7/mod.rs
+++ b/mobile-sdk-rs/src/oid4vp/iso_18013_7/mod.rs
@@ -198,6 +198,7 @@ impl InProgressRequest180137 {
             &self.request,
             credential,
             approved_fields,
+            &request_match.missing_fields,
             field_map,
             mdoc_generated_nonce.clone(),
         )?;


### PR DESCRIPTION
## Description

When the mDL receives an 18013-7 request for a data element that it does not contain, it responds with the rest of the data elements and include the missing element in the "errors" structure.

### Other changes

N/A

### Optional section

* ~Reviewers, please pay special attention to...~
* ~If this PR exceeds 500 lines, please explain why~

## Tested

Tested end to end with 3rd party verifier:
![image](https://github.com/user-attachments/assets/77191b05-1b9c-4a3c-8dd2-be843e546433)

