### PR TITLE
call handleMdocOid4vpUrl() instead of handleOid4vpUrl for mdoc deeplink

### DIFF
--- a/mobile-sdk-ios-app/Targets/AppUIKit/Sources/ContentView.swift
+++ b/mobile-sdk-ios-app/Targets/AppUIKit/Sources/ContentView.swift
@@ -145,7 +145,7 @@ public struct ContentView: View {
             case "openid-credential-offer":
                 handleOid4vciUrl(url: url)
             case "mdoc-openid4vp":
-                handleOid4vpUrl(url: url)
+                handleMdocOid4vpUrl(url: url)
             default:
                 return
             }


### PR DESCRIPTION
## Description

We are accidentally sending a mdoc-openid4vp deep link to the regular w3c oid4vp flow. This fixes that.

### Other changes

n.a.

### Optional section

n.a.
 
## Tested

not explicitly tested
