### PR TITLE
Add cbor_ld_encode_to_bytes function

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -663,6 +663,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbor-ld"
+version = "0.2.0"
+source = "git+https://github.com/spruceid/cbor-ld?rev=bc04985#bc04985ca629c0fa131b447b4fff6bcfe02d9f03"
+dependencies = [
+ "chrono",
+ "ciborium",
+ "clap",
+ "env_logger 0.11.6",
+ "hex",
+ "iref",
+ "json-ld",
+ "lazy_static",
+ "log",
+ "multibase 0.9.1",
+ "serde",
+ "static-iref",
+ "thiserror 1.0.69",
+ "tokio",
+ "toml 0.8.20",
+ "uuid",
+ "xsd-types",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3275,6 +3299,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
+ "cbor-ld 0.2.0 (git+https://github.com/spruceid/cbor-ld?rev=bc04985)",
  "ciborium",
  "cose-rs 0.1.0 (git+https://github.com/spruceid/cose-rs?rev=0018c9b)",
  "either",
@@ -6799,7 +6824,7 @@ name = "w3c-vc-barcodes"
 version = "0.1.0"
 source = "git+https://github.com/spruceid/w3c-vc-barcodes?rev=9aeb38d#9aeb38d7471a7c4c7ff8247564d4443bc4bee004"
 dependencies = [
- "cbor-ld",
+ "cbor-ld 0.2.0 (git+https://github.com/spruceid/cbor-ld.git?rev=74a439a)",
  "csv",
  "iref",
  "json-syntax",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,6 +27,7 @@ ssi = { version = "0.10.2", features = ["secp256r1", "secp384r1"] }
 anyhow = "1.0.95"
 async-trait = "0.1"
 base64 = "0.22.0"
+cbor-ld = { git = "https://github.com/spruceid/cbor-ld", rev = "bc04985" }
 ciborium = "0.2.2"
 either = "1.13"
 futures = "0.3"

--- a/rust/src/cborld.rs
+++ b/rust/src/cborld.rs
@@ -1,0 +1,68 @@
+use cbor_ld::EncodeError;
+use json_syntax::Parse;
+use ssi::json_ld::{InvalidIri, IriBuf, NoLoader, RemoteDocument};
+use std::{collections::HashMap, str::FromStr};
+
+#[derive(Debug, uniffi::Error, thiserror::Error)]
+pub enum CborLdEncodingError {
+    #[error("JsonLD parsing error: {0}")]
+    JsonParse(String),
+
+    #[error("CborLD encode error: {0}")]
+    CborEncode(String),
+}
+
+impl From<InvalidIri<String>> for CborLdEncodingError {
+    fn from(value: InvalidIri<String>) -> Self {
+        Self::CborEncode(format!("ssi::json_ld::InvalidIri: {}", value.to_string()))
+    }
+}
+
+impl From<EncodeError> for CborLdEncodingError {
+    fn from(value: EncodeError) -> Self {
+        Self::CborEncode(format!("cbor_ld::EncodeError: {}", value.to_string()))
+    }
+}
+
+impl From<ssi::json_ld::syntax::parse::Error> for CborLdEncodingError {
+    fn from(value: ssi::json_ld::syntax::parse::Error) -> Self {
+        Self::JsonParse(format!(
+            "json_ld::syntax::parse::Error: {}",
+            value.to_string()
+        ))
+    }
+}
+
+#[uniffi::export]
+pub async fn cbor_ld_encode_to_bytes(
+    credential_str: String,
+    loader: Option<HashMap<String, String>>,
+) -> Result<Vec<u8>, CborLdEncodingError> {
+    let credential = cbor_ld::JsonValue::from_str(&credential_str)?;
+
+    let cborld = if let Some(map) = loader {
+        let loader = map
+            .into_iter()
+            .map(
+                |(k, v)| match (IriBuf::new(k), json_syntax::Value::parse_str(&v)) {
+                    (Ok(k), Ok((v, _))) => Ok((
+                        k.to_owned(),
+                        RemoteDocument::new(
+                            Some(k),
+                            Some("application/ld+json".parse().unwrap()),
+                            v,
+                        ),
+                    )),
+                    (Err(e), _) => Err(e.into()),
+                    (_, Err(e)) => Err(e.into()),
+                },
+            )
+            .collect::<Result<HashMap<IriBuf, RemoteDocument<IriBuf>>, CborLdEncodingError>>()?;
+
+        cbor_ld::encode_to_bytes(&credential, loader).await?
+    } else {
+        cbor_ld::encode_to_bytes(&credential, NoLoader).await?
+    };
+
+    Ok(cborld)
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,5 +1,6 @@
 uniffi::setup_scaffolding!();
 
+pub mod cborld;
 pub mod common;
 pub mod context;
 pub mod credential;


### PR DESCRIPTION
## Description

Adds a function to get the CBOR-LD encoded bytes for a JSON-LD string.

## Tested

Tested through app usage by replacing a QRCode containing CBOR-LD encoded data with the new encoding function.