### PR TITLE
Fix iOS CI with mismatch swift and xcode versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,14 +81,12 @@ jobs:
         uses: mxcl/xcodebuild@v2
         with:
           platform: iOS
-          swift: ^6
           scheme: MobileSdk
           working-directory: ios/MobileSdk
       - name: Test Showcase
         uses: mxcl/xcodebuild@v2
         with:
           platform: iOS
-          swift: ^6
           scheme: debug
           working-directory: ios/Showcase
       - name: Lint MobileSdk

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,10 @@ let package = Package(
         .target(name: "SpruceIDMobileSdkRs"),
         .product(name: "Algorithms", package: "swift-algorithms"),
       ],
-      path: "./ios/MobileSdk/Sources/MobileSdk"
+      path: "./ios/MobileSdk/Sources/MobileSdk",
+      swiftSettings: [
+        .swiftLanguageMode(.v5)  // some of our code isn't concurrent-safe (e.g. OID4VCI.swift)
+      ]
     ),
     .testTarget(
       name: "SpruceIDMobileSdkTests",


### PR DESCRIPTION
## Description

Something must have changed in the macos-15 runner ahead of its GA release, because Swift and XCode versions appear to be different. Also, it appears the SDK wasn't Swift 6 compliant before even though it was using it? So I moved to Swift 5 for now.

### Other changes

N/A

### Optional section

N/A

## Tested

Didn't test manually, only relied on the CI.