### PR TITLE
use SSI revision patch for pre-release

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -151,6 +151,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "arrayref"
@@ -321,6 +330,17 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "autocfg"
@@ -534,6 +554,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bls12_381_plus"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa37cf2a8c96054d2dc3d708efe35cc0347014af0d30b86c736b4388ff8491c"
+dependencies = [
+ "arrayref",
+ "elliptic-curve",
+ "ff 0.13.0",
+ "group 0.13.0",
+ "hex",
+ "pairing",
+ "rand_core",
+ "serde",
+ "sha2 0.10.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +655,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-license"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "653542a7f5db653bf79ee4b6455c23f8e6b8a9c38c6310fbe14528728c14bd19"
+dependencies = [
+ "ansi_term",
+ "anyhow",
+ "atty",
+ "cargo_metadata",
+ "clap 3.2.25",
+ "csv",
+ "getopts",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "toml 0.5.11",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,7 +704,7 @@ source = "git+https://github.com/spruceid/cbor-ld.git?rev=74a439a#74a439a94b54c7
 dependencies = [
  "chrono",
  "ciborium",
- "clap",
+ "clap 4.5.30",
  "env_logger 0.11.6",
  "hex",
  "iref",
@@ -669,7 +728,7 @@ source = "git+https://github.com/spruceid/cbor-ld?rev=bc04985#bc04985ca629c0fa13
 dependencies = [
  "chrono",
  "ciborium",
- "clap",
+ "clap 4.5.30",
  "env_logger 0.11.6",
  "hex",
  "iref",
@@ -784,12 +843,29 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+dependencies = [
+ "atty",
+ "bitflags 1.3.2",
+ "clap_derive 3.2.25",
+ "clap_lex 0.2.4",
+ "indexmap 1.9.3",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap"
 version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
 dependencies = [
  "clap_builder",
- "clap_derive",
+ "clap_derive 4.5.28",
 ]
 
 [[package]]
@@ -809,8 +885,21 @@ checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex",
+ "clap_lex 0.7.4",
  "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -823,6 +912,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1226,8 +1324,7 @@ dependencies = [
 [[package]]
 name = "did-ethr"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25479cd2f7f8b3bb6807d48f93bfd03ab40209c2252e7adaa5801ea40f721c5"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "hex",
  "iref",
@@ -1242,8 +1339,7 @@ dependencies = [
 [[package]]
 name = "did-ion"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b517161cf90f19530cf8085c21d074f694f099fb75606ce973e3c6c0b87a7b"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "base64 0.22.1",
  "iref",
@@ -1264,15 +1360,14 @@ dependencies = [
 [[package]]
 name = "did-jwk"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dadcb13e93947631908013b451a6083c258020ff59f0f6cf5d78c5f70eebf267"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "async-trait",
  "iref",
  "multibase 0.8.0",
  "serde_jcs",
  "serde_json",
- "ssi-crypto",
+ "ssi-crypto 0.2.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-dids-core",
  "ssi-jwk 0.3.1",
  "ssi-verification-methods",
@@ -1283,8 +1378,7 @@ dependencies = [
 [[package]]
 name = "did-method-key"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0aaad8e1d2d58265ea8f2f7ce34866f56091809603d3f698398a72cfa844681"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "bs58",
  "iref",
@@ -1294,9 +1388,9 @@ dependencies = [
  "serde_json",
  "simple_asn1",
  "ssi-dids-core",
- "ssi-json-ld",
+ "ssi-json-ld 0.3.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-jwk 0.3.1",
- "ssi-multicodec",
+ "ssi-multicodec 0.2.0 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "static-iref",
  "thiserror 1.0.69",
 ]
@@ -1304,8 +1398,7 @@ dependencies = [
 [[package]]
 name = "did-pkh"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa345a36ea3c651862b66e2961e6cb09bb9589bbf9eb224b2bc7faadab3c543"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "async-trait",
  "bech32",
@@ -1315,7 +1408,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ssi-caips",
- "ssi-crypto",
+ "ssi-crypto 0.2.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-dids-core",
  "ssi-jwk 0.3.1",
  "static-iref",
@@ -1325,8 +1418,7 @@ dependencies = [
 [[package]]
 name = "did-tz"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9484113bef969a422bcb6a7037a709198ad619ea8ebfb2ac8c4456df6a9f110a"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "async-trait",
  "bs58",
@@ -1336,7 +1428,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "ssi-core",
+ "ssi-core 0.2.2 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-dids-core",
  "ssi-jwk 0.3.1",
  "ssi-jws",
@@ -1348,8 +1440,7 @@ dependencies = [
 [[package]]
 name = "did-web"
 version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1982fc4ca703fd18934d9cc2721d13be3c4e0b45abe96fa086cf235b2bdf705c"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "http 0.2.12",
  "reqwest 0.11.27",
@@ -1397,6 +1488,12 @@ checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "ecdsa"
@@ -1478,9 +1575,9 @@ dependencies = [
  "base64ct",
  "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.0",
  "generic-array",
- "group",
+ "group 0.13.0",
  "hkdf",
  "pem-rfc7468 0.7.0",
  "pkcs8 0.10.2",
@@ -1550,8 +1647,11 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
+ "humantime",
+ "is-terminal",
  "log",
  "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -1602,10 +1702,21 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
+ "bitvec 1.0.1",
  "rand_core",
  "subtle",
 ]
@@ -1815,6 +1926,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,11 +1994,23 @@ dependencies = [
 
 [[package]]
 name = "group"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
+dependencies = [
+ "byteorder",
+ "ff 0.10.1",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.0",
  "rand_core",
  "subtle",
 ]
@@ -1991,9 +2123,24 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
 
 [[package]]
 name = "hex"
@@ -2488,6 +2635,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi 0.5.0",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2514,7 +2672,7 @@ dependencies = [
  "async-signature",
  "base64 0.13.1",
  "ciborium",
- "clap",
+ "clap 4.5.30",
  "clap-stdin",
  "const-oid 0.9.6",
  "coset",
@@ -2813,7 +2971,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bytecount",
- "clap",
+ "clap 4.5.30",
  "fancy-regex",
  "fraction",
  "getrandom 0.2.15",
@@ -3486,7 +3644,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -3560,7 +3718,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openid4vp"
 version = "0.1.0"
-source = "git+https://github.com/spruceid/openid4vp?rev=2212f78#2212f7858c6ea2e9c3396e81dfa504ed52b7834e"
+source = "git+https://github.com/spruceid/openid4vp?rev=2a2f0b7#2a2f0b7465be943cf5de110b5fe871ef2d9ef985"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3588,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "openid4vp-frontend"
 version = "0.1.0"
-source = "git+https://github.com/spruceid/openid4vp?rev=2212f78#2212f7858c6ea2e9c3396e81dfa504ed52b7834e"
+source = "git+https://github.com/spruceid/openid4vp?rev=2a2f0b7#2a2f0b7465be943cf5de110b5fe871ef2d9ef985"
 dependencies = [
  "serde",
  "serde_json",
@@ -3669,6 +3827,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3707,6 +3871,15 @@ dependencies = [
  "primeorder",
  "serdect",
  "sha2 0.10.8",
+]
+
+[[package]]
+name = "pairing"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
+dependencies = [
+ "group 0.13.0",
 ]
 
 [[package]]
@@ -3819,6 +3992,17 @@ dependencies = [
  "der 0.5.1",
  "pkcs8 0.8.0",
  "zeroize",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.9",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -4366,10 +4550,31 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "pkcs1",
+ "pkcs1 0.3.3",
  "pkcs8 0.8.0",
  "rand_core",
  "smallvec",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1 0.7.5",
+ "pkcs8 0.10.2",
+ "rand_core",
+ "sha2 0.10.8",
+ "signature",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -5075,21 +5280,20 @@ dependencies = [
 [[package]]
 name = "ssi"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed84479b615034f634b49d61cd587755dc8336ad376d1482bae77ac9f333e625"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "document-features",
  "ssi-caips",
  "ssi-claims",
- "ssi-core",
- "ssi-crypto",
+ "ssi-core 0.2.2 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-crypto 0.2.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-dids",
- "ssi-eip712",
- "ssi-json-ld",
+ "ssi-eip712 0.1.0 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-json-ld 0.3.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-jwk 0.3.1",
  "ssi-jws",
- "ssi-multicodec",
- "ssi-rdf",
+ "ssi-multicodec 0.2.0 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-rdf 0.1.0 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-security",
  "ssi-ssh",
  "ssi-status",
@@ -5100,10 +5304,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssi-bbs"
+version = "0.1.1"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
+dependencies = [
+ "rand",
+ "zkryptium",
+]
+
+[[package]]
 name = "ssi-caips"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8865e1ff9ba347a3edffe7da802211d8596d5e842bb7db7f15b74d6d925554fe"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "bs58",
  "linked-data",
@@ -5116,8 +5328,7 @@ dependencies = [
 [[package]]
 name = "ssi-claims"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882fedab37930ec0865e034f50edfc06c2d0dbc91f1478f75aa2362435cd6493"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "educe 0.4.23",
  "iref",
@@ -5128,14 +5339,14 @@ dependencies = [
  "rdf-types",
  "serde",
  "serde_json",
- "ssi-claims-core",
- "ssi-core",
+ "ssi-claims-core 0.1.3 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-core 0.2.2 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-cose",
- "ssi-crypto",
+ "ssi-crypto 0.2.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-data-integrity",
  "ssi-dids-core",
- "ssi-eip712",
- "ssi-json-ld",
+ "ssi-eip712 0.1.0 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-json-ld 0.3.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-jwk 0.3.1",
  "ssi-jws",
  "ssi-jwt",
@@ -5155,11 +5366,25 @@ checksum = "54a2c9fba21b4ac915f5596c8cb59d8820eefceb52bc222463ff2297369242c9"
 dependencies = [
  "chrono",
  "educe 0.4.23",
+ "ssi-core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-crypto 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-eip712 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-json-ld 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ssi-claims-core"
+version = "0.1.3"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
+dependencies = [
+ "chrono",
+ "educe 0.4.23",
  "serde",
- "ssi-core",
- "ssi-crypto",
- "ssi-eip712",
- "ssi-json-ld",
+ "ssi-core 0.2.2 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-crypto 0.2.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-eip712 0.1.0 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-json-ld 0.3.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "thiserror 1.0.69",
 ]
 
@@ -5168,6 +5393,11 @@ name = "ssi-contexts"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53b9b14b02742a39a37d33c79d5fc6b0db9656089eabb6b5dc554aa1ddf9aa69"
+
+[[package]]
+name = "ssi-contexts"
+version = "0.1.10"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 
 [[package]]
 name = "ssi-core"
@@ -5182,16 +5412,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssi-core"
+version = "0.2.2"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
+dependencies = [
+ "async-trait",
+ "pin-project",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ssi-cose"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ee235f4f264d324a9092b2a045ae0354133340060194d8c8b9ab62294a5690"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "ciborium",
  "coset",
  "serde",
- "ssi-claims-core",
- "ssi-crypto",
+ "ssi-claims-core 0.1.3 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-crypto 0.2.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "thiserror 1.0.69",
 ]
 
@@ -5204,14 +5444,11 @@ dependencies = [
  "async-trait",
  "bs58",
  "digest 0.9.0",
- "ed25519-dalek",
  "getrandom 0.2.15",
  "hex",
  "iref",
  "k256",
  "keccak-hash",
- "p256",
- "p384",
  "pin-project",
  "rand",
  "ripemd160",
@@ -5223,10 +5460,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssi-crypto"
+version = "0.2.1"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "blake2",
+ "bs58",
+ "digest 0.10.7",
+ "ed25519-dalek",
+ "getrandom 0.2.15",
+ "hex",
+ "iref",
+ "k256",
+ "p256",
+ "p384",
+ "pin-project",
+ "rand",
+ "ripemd160",
+ "serde",
+ "sha2 0.10.8",
+ "sha3",
+ "signature",
+ "ssi-bbs",
+ "static-iref",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
 name = "ssi-data-integrity"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eeb46aadfc38aae38084bd522c842685fa81209268a0d12cb5a3f163d9fe50d"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "chrono",
  "iref",
@@ -5235,17 +5501,17 @@ dependencies = [
  "rdf-types",
  "serde",
  "serde_json",
- "ssi-claims-core",
- "ssi-core",
- "ssi-crypto",
+ "ssi-claims-core 0.1.3 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-core 0.2.2 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-crypto 0.2.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-data-integrity-core",
  "ssi-data-integrity-suites",
  "ssi-di-sd-primitives",
- "ssi-eip712",
- "ssi-json-ld",
+ "ssi-eip712 0.1.0 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-json-ld 0.3.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-jwk 0.3.1",
  "ssi-jws",
- "ssi-rdf",
+ "ssi-rdf 0.1.0 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-security",
  "ssi-verification-methods",
  "thiserror 1.0.69",
@@ -5254,8 +5520,7 @@ dependencies = [
 [[package]]
 name = "ssi-data-integrity-core"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287f8720e147bef2add575bbb85dd01eda927b5fedfe4776902996cac2281210"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "chrono",
  "contextual",
@@ -5273,13 +5538,13 @@ dependencies = [
  "self_cell",
  "serde",
  "serde_json",
- "ssi-claims-core",
- "ssi-core",
- "ssi-crypto",
- "ssi-json-ld",
+ "ssi-claims-core 0.1.3 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-core 0.2.2 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-crypto 0.2.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-json-ld 0.3.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-jwk 0.3.1",
  "ssi-jws",
- "ssi-rdf",
+ "ssi-rdf 0.1.0 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-security",
  "ssi-verification-methods",
  "static-iref",
@@ -5290,8 +5555,7 @@ dependencies = [
 [[package]]
 name = "ssi-data-integrity-suites"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831305eb865ef2dc35e2dbf8b7dfd63062a61a8026cab1b391b473f43c0337db"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5319,18 +5583,18 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "ssi-caips",
- "ssi-claims-core",
- "ssi-contexts",
- "ssi-core",
- "ssi-crypto",
+ "ssi-claims-core 0.1.3 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-contexts 0.1.10",
+ "ssi-core 0.2.2 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-crypto 0.2.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-data-integrity-core",
  "ssi-di-sd-primitives",
- "ssi-eip712",
- "ssi-json-ld",
+ "ssi-eip712 0.1.0 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-json-ld 0.3.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-jwk 0.3.1",
  "ssi-jws",
- "ssi-multicodec",
- "ssi-rdf",
+ "ssi-multicodec 0.2.0 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-rdf 0.1.0 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-security",
  "ssi-verification-methods",
  "static-iref",
@@ -5341,8 +5605,7 @@ dependencies = [
 [[package]]
 name = "ssi-di-sd-primitives"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248fa61d9934e9cb1f8fd01b6410cb952d380d617eb57aab53c453da0ca10ab4"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "base64 0.22.1",
  "digest 0.10.7",
@@ -5354,9 +5617,9 @@ dependencies = [
  "rdf-types",
  "serde",
  "sha2 0.10.8",
- "ssi-core",
- "ssi-json-ld",
- "ssi-rdf",
+ "ssi-core 0.2.2 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-json-ld 0.3.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-rdf 0.1.0 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "thiserror 1.0.69",
  "uuid",
 ]
@@ -5364,8 +5627,7 @@ dependencies = [
 [[package]]
 name = "ssi-dids"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa6985ea4e7951bc2948f22f20b050c344bebe8a083f12c907f662719b51fe4"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "did-ethr",
  "did-ion",
@@ -5382,8 +5644,7 @@ dependencies = [
 [[package]]
 name = "ssi-dids-core"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90cf14742931846557cedc7dae3f4eb8e4e2198e038ed8339495ce1b977f3f3e"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "async-trait",
  "iref",
@@ -5393,10 +5654,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "ssi-claims-core",
- "ssi-core",
- "ssi-crypto",
- "ssi-json-ld",
+ "ssi-claims-core 0.1.3 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-core 0.2.2 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-crypto 0.2.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-json-ld 0.3.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-jwk 0.3.1",
  "ssi-jws",
  "ssi-verification-methods-core",
@@ -5424,6 +5685,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssi-eip712"
+version = "0.1.0"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
+dependencies = [
+ "hex",
+ "indexmap 2.7.1",
+ "iref",
+ "json-syntax",
+ "keccak-hash",
+ "linked-data",
+ "rdf-types",
+ "serde",
+ "serde_jcs",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ssi-json-ld"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5436,8 +5715,26 @@ dependencies = [
  "lazy_static",
  "linked-data",
  "serde",
- "ssi-contexts",
- "ssi-rdf",
+ "ssi-contexts 0.1.9",
+ "ssi-rdf 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static-iref",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ssi-json-ld"
+version = "0.3.1"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
+dependencies = [
+ "combination",
+ "iref",
+ "json-ld",
+ "json-syntax",
+ "lazy_static",
+ "linked-data",
+ "serde",
+ "ssi-contexts 0.1.10",
+ "ssi-rdf 0.1.0 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "static-iref",
  "thiserror 1.0.69",
 ]
@@ -5461,14 +5758,14 @@ dependencies = [
  "num-traits",
  "p256",
  "rand",
- "rsa",
+ "rsa 0.6.1",
  "serde",
  "serde_jcs",
  "serde_json",
  "simple_asn1",
- "ssi-claims-core",
- "ssi-crypto",
- "ssi-multicodec",
+ "ssi-claims-core 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-crypto 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-multicodec 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.69",
  "zeroize",
 ]
@@ -5476,8 +5773,7 @@ dependencies = [
 [[package]]
 name = "ssi-jwk"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45a88522d4387b27f58834efa6a86e70ab5c9a0a2fabf71975e18234cb6b223"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "base64 0.22.1",
  "blake2b_simd 0.5.11",
@@ -5495,14 +5791,14 @@ dependencies = [
  "p256",
  "p384",
  "rand",
- "rsa",
+ "rsa 0.9.8",
  "serde",
  "serde_jcs",
  "serde_json",
  "simple_asn1",
- "ssi-claims-core",
- "ssi-crypto",
- "ssi-multicodec",
+ "ssi-claims-core 0.1.3 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-crypto 0.2.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-multicodec 0.2.0 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "thiserror 1.0.69",
  "zeroize",
 ]
@@ -5510,8 +5806,7 @@ dependencies = [
 [[package]]
 name = "ssi-jws"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d401dfd6920723ed52d3af494d3c5f0a1c6c395c69195726eb3a765a30bf39"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "base64 0.22.1",
  "blake2",
@@ -5524,14 +5819,14 @@ dependencies = [
  "p256",
  "p384",
  "rand",
- "rsa",
+ "rsa 0.9.8",
  "serde",
  "serde_json",
  "sha2 0.10.8",
  "sha3",
- "ssi-claims-core",
- "ssi-core",
- "ssi-crypto",
+ "ssi-claims-core 0.1.3 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-core 0.2.2 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-crypto 0.2.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-jwk 0.3.1",
  "thiserror 1.0.69",
 ]
@@ -5539,8 +5834,7 @@ dependencies = [
 [[package]]
 name = "ssi-jwt"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9467f23147adb2e638e2597d15faa2672d22489b1f47e803e5ac53ef70d536f"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5552,9 +5846,9 @@ dependencies = [
  "serde_json",
  "serde_with 2.3.3",
  "slab",
- "ssi-claims-core",
- "ssi-core",
- "ssi-crypto",
+ "ssi-claims-core 0.1.3 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-core 0.2.2 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-crypto 0.2.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-jwk 0.3.1",
  "ssi-jws",
  "thiserror 1.0.69",
@@ -5565,6 +5859,16 @@ name = "ssi-multicodec"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fec8cbdadfc90aec4839fd79f03aa887364f5f210c3aecbf9c6f7d76ab79055"
+dependencies = [
+ "csv",
+ "thiserror 1.0.69",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "ssi-multicodec"
+version = "0.2.0"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "csv",
  "ed25519-dalek",
@@ -5587,14 +5891,27 @@ dependencies = [
  "linked-data",
  "rdf-types",
  "serde",
- "ssi-crypto",
+ "ssi-crypto 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ssi-rdf"
+version = "0.1.0"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
+dependencies = [
+ "combination",
+ "indexmap 2.7.1",
+ "iref",
+ "linked-data",
+ "rdf-types",
+ "serde",
+ "ssi-crypto 0.2.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
 ]
 
 [[package]]
 name = "ssi-sd-jwt"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e27d19b7993dc4d0b23bcdbf9978cebbed7d5b7fa19cabde55aa9a0c72c58f"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.7.1",
@@ -5602,8 +5919,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "ssi-claims-core",
- "ssi-core",
+ "ssi-claims-core 0.1.3 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-core 0.2.2 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-jwk 0.3.1",
  "ssi-jws",
  "ssi-jwt",
@@ -5613,8 +5930,7 @@ dependencies = [
 [[package]]
 name = "ssi-security"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f870a28eabccd4ae0e807122859bb83e36b87dd096ba01215abce524bddfc247"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "iref",
  "linked-data",
@@ -5627,8 +5943,7 @@ dependencies = [
 [[package]]
 name = "ssi-ssh"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e302e0f598849ba1feddc493bfd610e513a32688ce7cf03da2a73a461f948ce8"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "sshkeys",
  "ssi-jwk 0.3.1",
@@ -5637,9 +5952,8 @@ dependencies = [
 
 [[package]]
 name = "ssi-status"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe9d5f4f648f387e1da536502562024c337c7c1613e133fa3ba5c35ab2ba146"
+version = "0.3.1"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "base64 0.22.1",
  "flate2",
@@ -5651,9 +5965,9 @@ dependencies = [
  "reqwest 0.12.12",
  "serde",
  "serde_json",
- "ssi-claims-core",
+ "ssi-claims-core 0.1.3 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-data-integrity",
- "ssi-json-ld",
+ "ssi-json-ld 0.3.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-jwk 0.3.1",
  "ssi-jws",
  "ssi-jwt",
@@ -5666,8 +5980,7 @@ dependencies = [
 [[package]]
 name = "ssi-ucan"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2bea2e2123c06e3500153e15eb0ecc7f7ccf7256c646835e1762c5531581b7"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -5680,7 +5993,7 @@ dependencies = [
  "serde_json",
  "serde_with 1.14.0",
  "ssi-caips",
- "ssi-core",
+ "ssi-core 0.2.2 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-dids-core",
  "ssi-jwk 0.3.1",
  "ssi-jws",
@@ -5692,8 +6005,7 @@ dependencies = [
 [[package]]
 name = "ssi-vc"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6ed7b2515d7cfe13a85a2c2dcd8ed9d70a26164ba54a46af8e0626c25e08a9"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "base64 0.22.1",
  "bitvec 0.20.4",
@@ -5707,13 +6019,13 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "ssi-claims-core",
- "ssi-core",
+ "ssi-claims-core 0.1.3 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-core 0.2.2 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-data-integrity",
  "ssi-dids-core",
- "ssi-json-ld",
+ "ssi-json-ld 0.3.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-jwt",
- "ssi-rdf",
+ "ssi-rdf 0.1.0 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-verification-methods",
  "static-iref",
  "thiserror 1.0.69",
@@ -5723,16 +6035,15 @@ dependencies = [
 [[package]]
 name = "ssi-vc-jose-cose"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c8bb574b42fe1b2eaef562f26777aceafd5173be25fb4fde90c11dc2fe9615"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "base64 0.22.1",
  "ciborium",
  "serde",
  "serde_json",
- "ssi-claims-core",
+ "ssi-claims-core 0.1.3 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-cose",
- "ssi-json-ld",
+ "ssi-json-ld 0.3.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-jws",
  "ssi-jwt",
  "ssi-sd-jwt",
@@ -5744,8 +6055,7 @@ dependencies = [
 [[package]]
 name = "ssi-verification-methods"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7066e6489b3a33dce900e38d47501be1684e955965462372aaf5668245076bbc"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "async-trait",
  "derivative",
@@ -5768,13 +6078,13 @@ dependencies = [
  "sha2 0.10.8",
  "sha3",
  "ssi-caips",
- "ssi-claims-core",
- "ssi-core",
- "ssi-crypto",
- "ssi-eip712",
+ "ssi-claims-core 0.1.3 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-core 0.2.2 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-crypto 0.2.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-eip712 0.1.0 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-jwk 0.3.1",
  "ssi-jws",
- "ssi-multicodec",
+ "ssi-multicodec 0.2.0 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-security",
  "ssi-verification-methods-core",
  "static-iref",
@@ -5784,8 +6094,7 @@ dependencies = [
 [[package]]
 name = "ssi-verification-methods-core"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "946c7d45278ae6d60e07a55d9cf2fbd6d759bdb60d2990313eed6538d6b5d5fa"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "bs58",
  "educe 0.4.23",
@@ -5796,10 +6105,10 @@ dependencies = [
  "rdf-types",
  "serde",
  "serde_json",
- "ssi-claims-core",
- "ssi-core",
- "ssi-crypto",
- "ssi-json-ld",
+ "ssi-claims-core 0.1.3 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-core 0.2.2 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-crypto 0.2.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-json-ld 0.3.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-jwk 0.3.1",
  "ssi-jws",
  "static-iref",
@@ -5809,8 +6118,7 @@ dependencies = [
 [[package]]
 name = "ssi-zcap-ld"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187334be04d40753c8721394d053bf5b77c4cd775b2bfb3f7b834bbb045f7586"
+source = "git+https://github.com/spruceid/ssi?rev=82b0bf3#82b0bf3915cc285465c9dce74e7c5774a795ce4e"
 dependencies = [
  "async-trait",
  "iref",
@@ -5819,12 +6127,12 @@ dependencies = [
  "serde",
  "serde_json",
  "ssi-claims",
- "ssi-core",
+ "ssi-core 0.2.2 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-dids-core",
- "ssi-eip712",
- "ssi-json-ld",
+ "ssi-eip712 0.1.0 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
+ "ssi-json-ld 0.3.1 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-jwk 0.3.1",
- "ssi-rdf",
+ "ssi-rdf 0.1.0 (git+https://github.com/spruceid/ssi?rev=82b0bf3)",
  "ssi-verification-methods",
  "static-iref",
  "thiserror 1.0.69",
@@ -6030,6 +6338,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -6447,6 +6764,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6461,7 +6784,7 @@ dependencies = [
  "anyhow",
  "camino",
  "cargo_metadata",
- "clap",
+ "clap 4.5.30",
  "uniffi_bindgen",
  "uniffi_build",
  "uniffi_core",
@@ -6846,6 +7169,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -7260,4 +7592,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "zkryptium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c734c171ed591a19dc1127351eb1b4d91864d3e53b2b6e9992bffcb7febf364a"
+dependencies = [
+ "bls12_381_plus",
+ "cargo-license",
+ "digest 0.10.7",
+ "dotenv",
+ "elliptic-curve",
+ "env_logger 0.10.2",
+ "ff 0.13.0",
+ "group 0.10.0",
+ "hex",
+ "hkdf",
+ "log",
+ "rand",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "sha3",
+ "thiserror 1.0.69",
+ "zeroize",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,10 +21,10 @@ cose-rs = { git = "https://github.com/spruceid/cose-rs", rev = "0018c9b", featur
 ] }
 isomdl = { git = "https://github.com/spruceid/isomdl", rev = "6084a83" }
 oid4vci = { git = "https://github.com/spruceid/oid4vci-rs", rev = "3792565" }
-openid4vp = { git = "https://github.com/spruceid/openid4vp", rev = "2212f78" }
-ssi = { version = "0.10.2", features = ["secp256r1", "secp384r1"] }
+openid4vp = { git = "https://github.com/spruceid/openid4vp", rev = "2a2f0b7" }
+ssi = { version = "^0.10.2", features = ["secp256r1", "secp384r1"] }
 
-anyhow = "1.0.95"
+anyhow = "1.0.97"
 async-trait = "0.1"
 base64 = "0.22.0"
 cbor-ld = { git = "https://github.com/spruceid/cbor-ld", rev = "bc04985" }
@@ -81,3 +81,6 @@ wiremock = "0.6.3"
 
 [build-dependencies]
 uniffi = { version = "0.29.0", features = ["build"] }
+
+[patch.crates-io]
+ssi = { git = "https://github.com/spruceid/ssi", rev = "82b0bf3" }

--- a/rust/src/common.rs
+++ b/rust/src/common.rs
@@ -78,8 +78,8 @@ uniffi::custom_type!(Algorithm, String, {
     remote,
     try_lift: |alg| {
 match alg.as_ref() {
-    "ES256" => Ok(Algorithm::ES256),
-    "ES256K" => Ok(Algorithm::ES256K),
+    "ES256" => Ok(Algorithm::Es256),
+    "ES256K" => Ok(Algorithm::Es256K),
     _ => anyhow::bail!("unsupported uniffi custom type for Algorithm mapping: {alg}"),
 }
     },

--- a/rust/src/oid4vp/holder.rs
+++ b/rust/src/oid4vp/holder.rs
@@ -455,7 +455,7 @@ pub(crate) mod tests {
             self.jwk
                 .algorithm
                 .map(Algorithm::from)
-                .unwrap_or(Algorithm::ES256)
+                .unwrap_or(Algorithm::Es256)
         }
 
         async fn verification_method(&self) -> String {

--- a/rust/src/oid4vp/presentation.rs
+++ b/rust/src/oid4vp/presentation.rs
@@ -304,7 +304,7 @@ impl PresentationOptions<'_> {
     /// Return the crypto curve utils based on the signing algorithm, e.g. ES256.
     pub fn curve_utils(&self) -> Result<CryptoCurveUtils, PresentationError> {
         match self.signer.algorithm() {
-            ssi::crypto::Algorithm::ES256 => Ok(CryptoCurveUtils::secp256r1()),
+            ssi::crypto::Algorithm::Es256 => Ok(CryptoCurveUtils::secp256r1()),
             alg => Err(PresentationError::CryptographicSuite(format!(
                 "Unsupported curve utils for algorithm: {alg:?}"
             ))),
@@ -342,7 +342,7 @@ impl PresentationOptions<'_> {
         let resolver = VerificationMethodDIDResolver::new(AnyDidMethod::default());
 
         let mut proof_options = ProofOptions::new(
-            DateTimeStamp::now_ms(),
+            DateTimeStamp::now_ms().into(),
             self.verification_method_id().await?.into(),
             ProofPurpose::Authentication,
             Default::default(),


### PR DESCRIPTION
## Description

Use patched preview of ssi `0.10.3`. Use tagged release once available.

### Other changes

Updates anyhow dependency to match SSI.

### Other

Over 500 lines due to `Cargo.lock`

## Tested

Tested as a maven local release on android.
