### PR TITLE
use tokio async runtime for exported ffi methods

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6777,9 +6777,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniffi"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba62a57e90f9baed5ad02a71a0870180fa1cc35499093b2d21be2edfb68ec0f7"
+checksum = "fe34585ac0275accf6c284d0080cc2840f3898c551cda869ec291b5a4218712c"
 dependencies = [
  "anyhow",
  "camino",
@@ -6793,9 +6793,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2242f35214f1e0e3b47c495d340c69f649f9a9ece3a943a29e275686cc884533"
+checksum = "1a792af1424cc8b3c43b44c1a6cb7935ed1fbe5584a74f70e8bab9799740266d"
 dependencies = [
  "anyhow",
  "camino",
@@ -6817,9 +6817,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c887a6c9a2857d8dc2ab0c8d578e8aa4978145b4fd65ed44296341e89aebc3cc"
+checksum = "00c4138211f2ae951018fcce6a978e1fcd1a47c3fd0bc0d5472a520520060db1"
 dependencies = [
  "anyhow",
  "camino",
@@ -6828,23 +6828,22 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad9fbdeb7ae4daf8d0f7704a3b638c37018eb16bb701e30fa17a2dd3e2d39c1"
+checksum = "c18baace68a52666d33d12d73ca335ecf27a302202cefb53b1f974512bb72417"
 dependencies = [
  "anyhow",
  "async-compat",
  "bytes",
  "once_cell",
- "paste",
  "static_assertions",
 ]
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9dba1d78b9ce429439891089c223478043d52a1c3176a0fcea2b5573a7fcf"
+checksum = "f9902d4ed16c65e6c0222241024dd0bfeed07ea3deb7c470eb175e5f5ef406cd"
 dependencies = [
  "quote",
  "syn 2.0.98",
@@ -6852,9 +6851,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78dd5f8eefba5898b901086f5e7916da67b9a5286a01cc44e910cd75fa37c630"
+checksum = "9d82c82ef945c51082d8763635334b994e63e77650f09d0fae6d28dd08b1de83"
 dependencies = [
  "camino",
  "fs-err",
@@ -6869,9 +6868,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5965b1d4ffacef1eaa72fef9c00d2491641e87ad910f6c5859b9c503ddb16a"
+checksum = "8d6027b971c2aa86350dd180aee9819729c7b99bacd381534511ff29d2c09cea"
 dependencies = [
  "anyhow",
  "siphasher",
@@ -6880,9 +6879,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_testing"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b0f35750a3e1836f10f26e4eceba688748b8a1e94a6ee251c976099d984d4f"
+checksum = "6301bcb50098dabcd304485318ba73f0f4db5e5d9d3c385c60b967810344ce90"
 dependencies = [
  "anyhow",
  "camino",
@@ -6893,9 +6892,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279b82bac9a382c796a0d210bb8354a0b813499b28aa1de046c85d78ca389805"
+checksum = "52300b7a4ab02dc159a038a13d5bfe27aefbad300d91b0b501b3dda094c1e0a2"
 dependencies = [
  "anyhow",
  "textwrap",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -62,7 +62,7 @@ time = { version = "0.3.36", features = [
 time-macros = "0.2.18"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1.40"
-uniffi = { version = "0.29.0", features = ["cli", "tokio"] }
+uniffi = { version = "0.29.1", features = ["cli", "tokio"] }
 url = { version = "2.5", features = ["serde"] }
 urlencoding = "2.1.3"
 uuid = { version = "1.6.1", features = ["v4"] }

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -563,7 +563,7 @@ fileprivate struct FfiConverterData: FfiConverterRustBuffer {
 
 
 
-public protocol AsyncHttpClient: AnyObject {
+public protocol AsyncHttpClient: AnyObject, Sendable {
     
     func httpClient(request: HttpRequest) async throws  -> HttpResponse
     
@@ -582,6 +582,9 @@ open class AsyncHttpClientImpl: AsyncHttpClient, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -630,7 +633,7 @@ open func httpClient(request: HttpRequest)async throws  -> HttpResponse  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeHttpResponse_lift,
-            errorHandler: FfiConverterTypeHttpClientError.lift
+            errorHandler: FfiConverterTypeHttpClientError_lift
         )
 }
     
@@ -768,7 +771,7 @@ public func FfiConverterTypeAsyncHttpClient_lower(_ value: AsyncHttpClient) -> U
 
 
 
-public protocol CborIntegerProtocol: AnyObject {
+public protocol CborIntegerProtocol: AnyObject, Sendable {
     
     func lowerBytes()  -> UInt64
     
@@ -791,6 +794,9 @@ open class CborInteger: CborIntegerProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -905,7 +911,7 @@ public func FfiConverterTypeCborInteger_lower(_ value: CborInteger) -> UnsafeMut
 
 
 
-public protocol CborTagProtocol: AnyObject {
+public protocol CborTagProtocol: AnyObject, Sendable {
     
     func id()  -> UInt64
     
@@ -926,6 +932,9 @@ open class CborTag: CborTagProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1033,7 +1042,7 @@ public func FfiConverterTypeCborTag_lower(_ value: CborTag) -> UnsafeMutableRawP
 
 
 
-public protocol ClientProtocol: AnyObject {
+public protocol ClientProtocol: AnyObject, Sendable {
     
 }
 open class Client: ClientProtocol, @unchecked Sendable {
@@ -1050,6 +1059,9 @@ open class Client: ClientProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1143,7 +1155,7 @@ public func FfiConverterTypeClient_lower(_ value: Client) -> UnsafeMutableRawPoi
 
 
 
-public protocol CredentialIssuerMetadataProtocol: AnyObject {
+public protocol CredentialIssuerMetadataProtocol: AnyObject, Sendable {
     
 }
 open class CredentialIssuerMetadata: CredentialIssuerMetadataProtocol, @unchecked Sendable {
@@ -1160,6 +1172,9 @@ open class CredentialIssuerMetadata: CredentialIssuerMetadataProtocol, @unchecke
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1253,7 +1268,7 @@ public func FfiConverterTypeCredentialIssuerMetadata_lower(_ value: CredentialIs
 
 
 
-public protocol CredentialRequestProtocol: AnyObject {
+public protocol CredentialRequestProtocol: AnyObject, Sendable {
     
 }
 open class CredentialRequest: CredentialRequestProtocol, @unchecked Sendable {
@@ -1270,6 +1285,9 @@ open class CredentialRequest: CredentialRequestProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1366,7 +1384,7 @@ public func FfiConverterTypeCredentialRequest_lower(_ value: CredentialRequest) 
 /**
  * Utility functions for cryptographic curves
  */
-public protocol CryptoCurveUtilsProtocol: AnyObject {
+public protocol CryptoCurveUtilsProtocol: AnyObject, Sendable {
     
     /**
      * Returns null if the original signature encoding is not recognized.
@@ -1391,6 +1409,9 @@ open class CryptoCurveUtils: CryptoCurveUtilsProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1505,7 +1526,7 @@ public func FfiConverterTypeCryptoCurveUtils_lower(_ value: CryptoCurveUtils) ->
 
 
 
-public protocol CwtProtocol: AnyObject {
+public protocol CwtProtocol: AnyObject, Sendable {
     
     /**
      * The version of the Verifiable Credential Data Model that this credential conforms to.
@@ -1543,6 +1564,9 @@ open class Cwt: CwtProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1701,7 +1725,7 @@ public func FfiConverterTypeCwt_lower(_ value: Cwt) -> UnsafeMutableRawPointer {
 
 
 
-public protocol DelegatedVerifierProtocol: AnyObject {
+public protocol DelegatedVerifierProtocol: AnyObject, Sendable {
     
     func pollVerificationStatus(url: String) async throws  -> DelegatedVerifierStatusResponse
     
@@ -1732,6 +1756,9 @@ open class DelegatedVerifier: DelegatedVerifierProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1776,7 +1803,7 @@ public static func newClient(baseUrl: Url)async throws  -> DelegatedVerifier  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeDelegatedVerifier_lift,
-            errorHandler: FfiConverterTypeOid4vpVerifierError.lift
+            errorHandler: FfiConverterTypeOid4vpVerifierError_lift
         )
 }
     
@@ -1795,7 +1822,7 @@ open func pollVerificationStatus(url: String)async throws  -> DelegatedVerifierS
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeDelegatedVerifierStatusResponse_lift,
-            errorHandler: FfiConverterTypeOid4vpVerifierError.lift
+            errorHandler: FfiConverterTypeOid4vpVerifierError_lift
         )
 }
     
@@ -1822,7 +1849,7 @@ open func requestDelegatedVerification(url: String)async throws  -> DelegateInit
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeDelegateInitializationResponse_lift,
-            errorHandler: FfiConverterTypeOid4vpVerifierError.lift
+            errorHandler: FfiConverterTypeOid4vpVerifierError_lift
         )
 }
     
@@ -1884,7 +1911,7 @@ public func FfiConverterTypeDelegatedVerifier_lower(_ value: DelegatedVerifier) 
 
 
 
-public protocol DidMethodUtilsProtocol: AnyObject {
+public protocol DidMethodUtilsProtocol: AnyObject, Sendable {
     
     func didFromJwk(jwk: String) throws  -> String
     
@@ -1905,6 +1932,9 @@ open class DidMethodUtils: DidMethodUtilsProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1969,7 +1999,7 @@ open func vmFromJwk(jwk: String)async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeDidError.lift
+            errorHandler: FfiConverterTypeDidError_lift
         )
 }
     
@@ -2031,7 +2061,7 @@ public func FfiConverterTypeDidMethodUtils_lower(_ value: DidMethodUtils) -> Uns
 
 
 
-public protocol GrantsProtocol: AnyObject {
+public protocol GrantsProtocol: AnyObject, Sendable {
     
 }
 open class Grants: GrantsProtocol, @unchecked Sendable {
@@ -2048,6 +2078,9 @@ open class Grants: GrantsProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2147,7 +2180,7 @@ public func FfiConverterTypeGrants_lower(_ value: Grants) -> UnsafeMutableRawPoi
  * The Holder has the ability to generate Verifiable Presentations from
  * these credentials and share them with Verifiers.
  */
-public protocol HolderProtocol: AnyObject {
+public protocol HolderProtocol: AnyObject, Sendable {
     
     /**
      * Given an authorization request URL, return a permission request,
@@ -2181,6 +2214,9 @@ open class Holder: HolderProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2217,7 +2253,7 @@ public convenience init(vdcCollection: VdcCollection, trustedDids: [String], sig
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeHolder_lift,
-            errorHandler: FfiConverterTypeOID4VPError.lift
+            errorHandler: FfiConverterTypeOID4VPError_lift
         )
         
         .uniffiClonePointer()
@@ -2251,7 +2287,7 @@ public static func newWithCredentials(providedCredentials: [ParsedCredential], t
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeHolder_lift,
-            errorHandler: FfiConverterTypeOID4VPError.lift
+            errorHandler: FfiConverterTypeOID4VPError_lift
         )
 }
     
@@ -2277,7 +2313,7 @@ open func authorizationRequest(req: AuthRequest)async throws  -> PermissionReque
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypePermissionRequest_lift,
-            errorHandler: FfiConverterTypeOID4VPError.lift
+            errorHandler: FfiConverterTypeOID4VPError_lift
         )
 }
     
@@ -2294,7 +2330,7 @@ open func submitPermissionResponse(response: PermissionResponse)async throws  ->
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeUrl.lift,
-            errorHandler: FfiConverterTypeOID4VPError.lift
+            errorHandler: FfiConverterTypeOID4VPError_lift
         )
 }
     
@@ -2364,7 +2400,7 @@ public func FfiConverterTypeHolder_lower(_ value: Holder) -> UnsafeMutableRawPoi
  * `Arc` is wrapped with `IArc` to facilitate trait implementation from
  * `openidconnect` library used by request builders and client on `oid4vci-rs`.
  */
-public protocol IHttpClientProtocol: AnyObject {
+public protocol IHttpClientProtocol: AnyObject, Sendable {
     
 }
 /**
@@ -2389,6 +2425,9 @@ open class IHttpClient: IHttpClientProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2498,7 +2537,7 @@ public func FfiConverterTypeIHttpClient_lower(_ value: IHttpClient) -> UnsafeMut
 
 
 
-public protocol InProcessRecordProtocol: AnyObject {
+public protocol InProcessRecordProtocol: AnyObject, Sendable {
     
 }
 open class InProcessRecord: InProcessRecordProtocol, @unchecked Sendable {
@@ -2515,6 +2554,9 @@ open class InProcessRecord: InProcessRecordProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2608,7 +2650,7 @@ public func FfiConverterTypeInProcessRecord_lower(_ value: InProcessRecord) -> U
 
 
 
-public protocol InProgressRequest180137Protocol: AnyObject {
+public protocol InProgressRequest180137Protocol: AnyObject, Sendable {
     
     func matches()  -> [RequestMatch180137]
     
@@ -2629,6 +2671,9 @@ open class InProgressRequest180137: InProgressRequest180137Protocol, @unchecked 
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2684,7 +2729,7 @@ open func respond(approvedResponse: ApprovedResponse180137)async throws  -> Url?
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeUrl.lift,
-            errorHandler: FfiConverterTypeOID4VP180137Error.lift
+            errorHandler: FfiConverterTypeOID4VP180137Error_lift
         )
 }
     
@@ -2746,7 +2791,7 @@ public func FfiConverterTypeInProgressRequest180137_lower(_ value: InProgressReq
 
 
 
-public protocol IssuanceServiceClientProtocol: AnyObject {
+public protocol IssuanceServiceClientProtocol: AnyObject, Sendable {
     
     /**
      * Checks the status of an issuance request
@@ -2788,6 +2833,9 @@ open class IssuanceServiceClient: IssuanceServiceClientProtocol, @unchecked Send
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2861,7 +2909,7 @@ open func checkStatus(issuanceId: String, walletAttestation: String)async throws
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeCheckStatusResponse_lift,
-            errorHandler: FfiConverterTypeIssuanceServiceError.lift
+            errorHandler: FfiConverterTypeIssuanceServiceError_lift
         )
 }
     
@@ -2888,7 +2936,7 @@ open func newIssuance(walletAttestation: String)async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeIssuanceServiceError.lift
+            errorHandler: FfiConverterTypeIssuanceServiceError_lift
         )
 }
     
@@ -2953,7 +3001,7 @@ public func FfiConverterTypeIssuanceServiceClient_lower(_ value: IssuanceService
 /**
  * A verifiable credential secured as JSON.
  */
-public protocol JsonVcProtocol: AnyObject {
+public protocol JsonVcProtocol: AnyObject, Sendable {
     
     /**
      * Access the W3C VCDM credential as a JSON encoded UTF-8 string.
@@ -3010,6 +3058,9 @@ open class JsonVc: JsonVcProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3115,7 +3166,7 @@ open func status()async throws  -> Status  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeStatus_lift,
-            errorHandler: FfiConverterTypeStatusListError.lift
+            errorHandler: FfiConverterTypeStatusListError_lift
         )
 }
     
@@ -3211,7 +3262,7 @@ public func FfiConverterTypeJsonVc_lower(_ value: JsonVc) -> UnsafeMutableRawPoi
 /**
  * A verifiable credential secured as a JWT.
  */
-public protocol JwtVcProtocol: AnyObject {
+public protocol JwtVcProtocol: AnyObject, Sendable {
     
     /**
      * Access the W3C VCDM credential as a JSON encoded UTF-8 string.
@@ -3272,6 +3323,9 @@ open class JwtVc: JwtVcProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3476,7 +3530,7 @@ public func FfiConverterTypeJwtVc_lower(_ value: JwtVc) -> UnsafeMutableRawPoint
 /**
  * An interface that can provide access to cryptographic keypairs from the native crypto API.
  */
-public protocol KeyStore: AnyObject {
+public protocol KeyStore: AnyObject, Sendable {
     
     /**
      * Retrieve a cryptographic keypair by alias. The cryptographic key must be usable for
@@ -3502,6 +3556,9 @@ open class KeyStoreImpl: KeyStore, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3659,7 +3716,7 @@ public func FfiConverterTypeKeyStore_lower(_ value: KeyStore) -> UnsafeMutableRa
 
 
 
-public protocol MdlSessionManagerProtocol: AnyObject {
+public protocol MdlSessionManagerProtocol: AnyObject, Sendable {
     
 }
 open class MdlSessionManager: MdlSessionManagerProtocol, @unchecked Sendable {
@@ -3676,6 +3733,9 @@ open class MdlSessionManager: MdlSessionManagerProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3769,7 +3829,7 @@ public func FfiConverterTypeMDLSessionManager_lower(_ value: MdlSessionManager) 
 
 
 
-public protocol MdlPresentationSessionProtocol: AnyObject {
+public protocol MdlPresentationSessionProtocol: AnyObject, Sendable {
     
     /**
      * Constructs the response to be sent from the holder to the reader containing
@@ -3825,6 +3885,9 @@ open class MdlPresentationSession: MdlPresentationSessionProtocol, @unchecked Se
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3990,7 +4053,7 @@ public func FfiConverterTypeMdlPresentationSession_lower(_ value: MdlPresentatio
 
 
 
-public protocol MdocProtocol: AnyObject {
+public protocol MdocProtocol: AnyObject, Sendable {
     
     /**
      * Simple representation of mdoc namespace and data elements for display in the UI.
@@ -4024,6 +4087,9 @@ open class Mdoc: MdocProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4197,7 +4263,7 @@ public func FfiConverterTypeMdoc_lower(_ value: Mdoc) -> UnsafeMutableRawPointer
  *
  * Notably this supports requests which use the URI scheme `mdoc-openid4vp://`.
  */
-public protocol Oid4vp180137Protocol: AnyObject {
+public protocol Oid4vp180137Protocol: AnyObject, Sendable {
     
     func processRequest(url: Url) async throws  -> InProgressRequest180137
     
@@ -4221,6 +4287,9 @@ open class Oid4vp180137: Oid4vp180137Protocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4278,7 +4347,7 @@ open func processRequest(url: Url)async throws  -> InProgressRequest180137  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeInProgressRequest180137_lift,
-            errorHandler: FfiConverterTypeOID4VP180137Error.lift
+            errorHandler: FfiConverterTypeOID4VP180137Error_lift
         )
 }
     
@@ -4340,7 +4409,7 @@ public func FfiConverterTypeOID4VP180137_lower(_ value: Oid4vp180137) -> UnsafeM
 
 
 
-public protocol Oid4vciProtocol: AnyObject {
+public protocol Oid4vciProtocol: AnyObject, Sendable {
     
     func clearContextMap() throws 
     
@@ -4373,6 +4442,9 @@ open class Oid4vci: Oid4vciProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4464,7 +4536,7 @@ open func exchangeCredential(proofsOfPossession: [String], options: Oid4vciExcha
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeCredentialResponse.lift,
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
     
@@ -4481,7 +4553,7 @@ open func exchangeToken()async throws  -> String?  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionString.lift,
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
     
@@ -4505,7 +4577,7 @@ open func initiate(baseUrl: String, clientId: String, redirectUrl: String)async 
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
     
@@ -4528,7 +4600,7 @@ open func initiateWithOffer(credentialOffer: String, clientId: String, redirectU
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
     
@@ -4597,7 +4669,7 @@ public func FfiConverterTypeOid4vci_lower(_ value: Oid4vci) -> UnsafeMutableRawP
 
 
 
-public protocol Oid4vciMetadataProtocol: AnyObject {
+public protocol Oid4vciMetadataProtocol: AnyObject, Sendable {
     
     func authorizationServers()  -> [String]?
     
@@ -4628,6 +4700,9 @@ open class Oid4vciMetadata: Oid4vciMetadataProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4770,7 +4845,7 @@ public func FfiConverterTypeOid4vciMetadata_lower(_ value: Oid4vciMetadata) -> U
 
 
 
-public protocol Oid4vciSessionProtocol: AnyObject {
+public protocol Oid4vciSessionProtocol: AnyObject, Sendable {
     
 }
 open class Oid4vciSession: Oid4vciSessionProtocol, @unchecked Sendable {
@@ -4787,6 +4862,9 @@ open class Oid4vciSession: Oid4vciSessionProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4883,7 +4961,7 @@ public func FfiConverterTypeOid4vciSession_lower(_ value: Oid4vciSession) -> Uns
 /**
  * A credential that has been parsed as a known variant.
  */
-public protocol ParsedCredentialProtocol: AnyObject {
+public protocol ParsedCredentialProtocol: AnyObject, Sendable {
     
     /**
      * Return the credential as an CWT, if it is of that format.
@@ -4953,6 +5031,9 @@ open class ParsedCredential: ParsedCredentialProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5244,7 +5325,7 @@ public func FfiConverterTypeParsedCredential_lower(_ value: ParsedCredential) ->
 
 
 
-public protocol PermissionRequestProtocol: AnyObject {
+public protocol PermissionRequestProtocol: AnyObject, Sendable {
     
     /**
      * Return the client ID for the authorization request.
@@ -5305,6 +5386,9 @@ open class PermissionRequest: PermissionRequestProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5373,7 +5457,7 @@ open func createPermissionResponse(selectedCredentials: [PresentableCredential],
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypePermissionResponse_lift,
-            errorHandler: FfiConverterTypeOID4VPError.lift
+            errorHandler: FfiConverterTypeOID4VPError_lift
         )
 }
     
@@ -5491,7 +5575,7 @@ public func FfiConverterTypePermissionRequest_lower(_ value: PermissionRequest) 
  * The Requested Fields are created by calling the [PermissionRequest::requested_fields] method, and then
  * explicitly setting the permission to true or false, based on the holder's decision.
  */
-public protocol PermissionResponseProtocol: AnyObject {
+public protocol PermissionResponseProtocol: AnyObject, Sendable {
     
     /**
      * Return the selected credentials for the permission response.
@@ -5529,6 +5613,9 @@ open class PermissionResponse: PermissionResponseProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5648,7 +5735,7 @@ public func FfiConverterTypePermissionResponse_lower(_ value: PermissionResponse
 /**
  * A credential that has been parsed as a known variant.
  */
-public protocol PresentableCredentialProtocol: AnyObject {
+public protocol PresentableCredentialProtocol: AnyObject, Sendable {
     
     /**
      * Converts to the primitive ParsedCredential type
@@ -5679,6 +5766,9 @@ open class PresentableCredential: PresentableCredentialProtocol, @unchecked Send
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5796,7 +5886,7 @@ public func FfiConverterTypePresentableCredential_lower(_ value: PresentableCred
 /**
  * A viable match for the credential request.
  */
-public protocol RequestMatch180137Protocol: AnyObject {
+public protocol RequestMatch180137Protocol: AnyObject, Sendable {
     
     func credentialId()  -> Uuid
     
@@ -5820,6 +5910,9 @@ open class RequestMatch180137: RequestMatch180137Protocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5927,7 +6020,7 @@ public func FfiConverterTypeRequestMatch180137_lower(_ value: RequestMatch180137
 
 
 
-public protocol RequestedFieldProtocol: AnyObject {
+public protocol RequestedFieldProtocol: AnyObject, Sendable {
     
     /**
      * Return the unique ID for the request field.
@@ -5984,6 +6077,9 @@ open class RequestedField: RequestedFieldProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6160,7 +6256,7 @@ public func FfiConverterTypeRequestedField_lower(_ value: RequestedField) -> Uns
 /**
  * A cryptographic keypair that can be used for signing.
  */
-public protocol SigningKey: AnyObject {
+public protocol SigningKey: AnyObject, Sendable {
     
     /**
      * Generates a public JWK for this key.
@@ -6190,6 +6286,9 @@ open class SigningKeyImpl: SigningKey, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6386,7 +6485,7 @@ public func FfiConverterTypeSigningKey_lower(_ value: SigningKey) -> UnsafeMutab
  * and the purpose is the purpose of the credential, which is used
  * to interpret the value.
  */
-public protocol StatusProtocol: AnyObject {
+public protocol StatusProtocol: AnyObject, Sendable {
     
     /**
      * Return whether the credential status has a message.
@@ -6435,6 +6534,9 @@ open class Status: StatusProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6585,7 +6687,7 @@ public func FfiConverterTypeStatus_lower(_ value: Status) -> UnsafeMutableRawPoi
  * and the purpose is the purpose of the credential, which is used
  * to interpret the value.
  */
-public protocol Status20240406Protocol: AnyObject {
+public protocol Status20240406Protocol: AnyObject, Sendable {
     
     /**
      * Return whether the credential status has a message.
@@ -6634,6 +6736,9 @@ open class Status20240406: Status20240406Protocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6789,7 +6894,7 @@ public func FfiConverterTypeStatus20240406_lower(_ value: Status20240406) -> Uns
  * We use the older callback_interface to keep the required version level of our Android API
  * low.
  */
-public protocol StorageManagerInterface: AnyObject {
+public protocol StorageManagerInterface: AnyObject, Sendable {
     
     /**
      * Function: add
@@ -6855,6 +6960,9 @@ open class StorageManagerInterfaceImpl: StorageManagerInterface, @unchecked Send
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6913,7 +7021,7 @@ open func add(key: Key, value: Value)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeStorageManagerError.lift
+            errorHandler: FfiConverterTypeStorageManagerError_lift
         )
 }
     
@@ -6936,7 +7044,7 @@ open func get(key: Key)async throws  -> Value?  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeValue.lift,
-            errorHandler: FfiConverterTypeStorageManagerError.lift
+            errorHandler: FfiConverterTypeStorageManagerError_lift
         )
 }
     
@@ -6958,7 +7066,7 @@ open func list()async throws  -> [Key]  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeKey.lift,
-            errorHandler: FfiConverterTypeStorageManagerError.lift
+            errorHandler: FfiConverterTypeStorageManagerError_lift
         )
 }
     
@@ -6983,7 +7091,7 @@ open func remove(key: Key)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeStorageManagerError.lift
+            errorHandler: FfiConverterTypeStorageManagerError_lift
         )
 }
     
@@ -7240,7 +7348,7 @@ public func FfiConverterTypeStorageManagerInterface_lower(_ value: StorageManage
 
 
 
-public protocol SyncHttpClient: AnyObject {
+public protocol SyncHttpClient: AnyObject, Sendable {
     
     func httpClient(request: HttpRequest) throws  -> HttpResponse
     
@@ -7259,6 +7367,9 @@ open class SyncHttpClientImpl: SyncHttpClient, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -7412,7 +7523,7 @@ public func FfiConverterTypeSyncHttpClient_lower(_ value: SyncHttpClient) -> Uns
 
 
 
-public protocol TokenResponseProtocol: AnyObject {
+public protocol TokenResponseProtocol: AnyObject, Sendable {
     
 }
 open class TokenResponse: TokenResponseProtocol, @unchecked Sendable {
@@ -7429,6 +7540,9 @@ open class TokenResponse: TokenResponseProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -7522,7 +7636,7 @@ public func FfiConverterTypeTokenResponse_lower(_ value: TokenResponse) -> Unsaf
 
 
 
-public protocol Vcdm2SdJwtProtocol: AnyObject {
+public protocol Vcdm2SdJwtProtocol: AnyObject, Sendable {
     
     /**
      * Return the ID for the SdJwt instance.
@@ -7566,6 +7680,9 @@ open class Vcdm2SdJwt: Vcdm2SdJwtProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -7671,7 +7788,7 @@ open func status()async throws  -> [Status20240406]  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeStatus20240406.lift,
-            errorHandler: FfiConverterTypeStatusListError.lift
+            errorHandler: FfiConverterTypeStatusListError_lift
         )
 }
     
@@ -7749,7 +7866,7 @@ public func FfiConverterTypeVCDM2SdJwt_lower(_ value: Vcdm2SdJwt) -> UnsafeMutab
  *
  * This is the main interface to credentials.
  */
-public protocol VdcCollectionProtocol: AnyObject {
+public protocol VdcCollectionProtocol: AnyObject, Sendable {
     
     /**
      * Add a credential to the set.
@@ -7801,6 +7918,9 @@ open class VdcCollection: VdcCollectionProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -7863,7 +7983,7 @@ open func add(credential: Credential)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVdcCollectionError.lift
+            errorHandler: FfiConverterTypeVdcCollectionError_lift
         )
 }
     
@@ -7883,7 +8003,7 @@ open func allEntries()async throws  -> [Uuid]  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeUuid.lift,
-            errorHandler: FfiConverterTypeVdcCollectionError.lift
+            errorHandler: FfiConverterTypeVdcCollectionError_lift
         )
 }
     
@@ -7903,7 +8023,7 @@ open func allEntriesByType(ctype: CredentialType)async throws  -> [Uuid]  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeUuid.lift,
-            errorHandler: FfiConverterTypeVdcCollectionError.lift
+            errorHandler: FfiConverterTypeVdcCollectionError_lift
         )
 }
     
@@ -7923,7 +8043,7 @@ open func delete(id: Uuid)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVdcCollectionError.lift
+            errorHandler: FfiConverterTypeVdcCollectionError_lift
         )
 }
     
@@ -7964,7 +8084,7 @@ open func get(id: Uuid)async throws  -> Credential?  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeCredential.lift,
-            errorHandler: FfiConverterTypeVdcCollectionError.lift
+            errorHandler: FfiConverterTypeVdcCollectionError_lift
         )
 }
     
@@ -8026,7 +8146,7 @@ public func FfiConverterTypeVdcCollection_lower(_ value: VdcCollection) -> Unsaf
 
 
 
-public protocol WalletServiceClientProtocol: AnyObject {
+public protocol WalletServiceClientProtocol: AnyObject, Sendable {
     
     /**
      * Helper method to get an authorization header with the current token
@@ -8065,6 +8185,9 @@ open class WalletServiceClient: WalletServiceClientProtocol, @unchecked Sendable
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -8161,7 +8284,7 @@ open func login(jwk: String)async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeWalletServiceError.lift
+            errorHandler: FfiConverterTypeWalletServiceError_lift
         )
 }
     
@@ -9908,7 +10031,7 @@ extension AuthenticationStatus: Equatable, Hashable {}
 
 
 
-public enum CborLdEncodingError {
+public enum CborLdEncodingError: Swift.Error {
 
     
     
@@ -10224,7 +10347,7 @@ extension ClaimValue: Equatable, Hashable {}
 
 
 
-public enum CredentialDecodingError {
+public enum CredentialDecodingError: Swift.Error {
 
     
     
@@ -10367,7 +10490,7 @@ extension CredentialDecodingError: Foundation.LocalizedError {
 
 
 
-public enum CredentialEncodingError {
+public enum CredentialEncodingError: Swift.Error {
 
     
     
@@ -10588,7 +10711,7 @@ extension CredentialFormat: Equatable, Hashable {}
 
 
 
-public enum CredentialPresentationError {
+public enum CredentialPresentationError: Swift.Error {
 
     
     
@@ -10671,7 +10794,7 @@ extension CredentialPresentationError: Foundation.LocalizedError {
 
 
 
-public enum CryptoError {
+public enum CryptoError: Swift.Error {
 
     
     
@@ -10744,7 +10867,7 @@ extension CryptoError: Foundation.LocalizedError {
 
 
 
-public enum CwtError {
+public enum CwtError: Swift.Error {
 
     
     
@@ -11096,7 +11219,7 @@ extension DelegatedVerifierStatus: Equatable, Hashable {}
 
 
 
-public enum DidError {
+public enum DidError: Swift.Error {
 
     
     
@@ -11260,7 +11383,7 @@ extension DidMethod: Equatable, Hashable {}
 
 
 
-public enum HttpClientError {
+public enum HttpClientError: Swift.Error {
 
     
     
@@ -11398,7 +11521,7 @@ extension HttpClientError: Foundation.LocalizedError {
 /**
  * Represents errors that may occur during issuance operations
  */
-public enum IssuanceServiceError {
+public enum IssuanceServiceError: Swift.Error {
 
     
     
@@ -11528,7 +11651,7 @@ extension IssuanceServiceError: Foundation.LocalizedError {
 
 
 
-public enum JsonVcEncodingError {
+public enum JsonVcEncodingError: Swift.Error {
 
     
     
@@ -11597,7 +11720,7 @@ extension JsonVcEncodingError: Foundation.LocalizedError {
 
 
 
-public enum JsonVcInitError {
+public enum JsonVcInitError: Swift.Error {
 
     
     
@@ -11684,7 +11807,7 @@ extension JsonVcInitError: Foundation.LocalizedError {
 
 
 
-public enum JwtVcInitError {
+public enum JwtVcInitError: Swift.Error {
 
     
     
@@ -11795,7 +11918,7 @@ extension JwtVcInitError: Foundation.LocalizedError {
 
 
 
-public enum KeyTransformationError {
+public enum KeyTransformationError: Swift.Error {
 
     
     
@@ -11898,7 +12021,7 @@ extension KeyTransformationError: Foundation.LocalizedError {
 
 
 
-public enum MdlReaderResponseError {
+public enum MdlReaderResponseError: Swift.Error {
 
     
     
@@ -11995,7 +12118,7 @@ extension MdlReaderResponseError: Foundation.LocalizedError {
 
 
 
-public enum MdlReaderResponseSerializeError {
+public enum MdlReaderResponseSerializeError: Swift.Error {
 
     
     
@@ -12068,7 +12191,7 @@ extension MdlReaderResponseSerializeError: Foundation.LocalizedError {
 
 
 
-public enum MdlReaderSessionError {
+public enum MdlReaderSessionError: Swift.Error {
 
     
     
@@ -12244,7 +12367,7 @@ extension MDocItem: Equatable, Hashable {}
 
 
 
-public enum MdlUtilError {
+public enum MdlUtilError: Swift.Error {
 
     
     
@@ -12317,7 +12440,7 @@ extension MdlUtilError: Foundation.LocalizedError {
 
 
 
-public enum MdocEncodingError {
+public enum MdocEncodingError: Swift.Error {
 
     
     
@@ -12386,7 +12509,7 @@ extension MdocEncodingError: Foundation.LocalizedError {
 
 
 
-public enum MdocInitError {
+public enum MdocInitError: Swift.Error {
 
     
     
@@ -12501,7 +12624,7 @@ extension MdocInitError: Foundation.LocalizedError {
 
 
 
-public enum Oid4vp180137Error {
+public enum Oid4vp180137Error: Swift.Error {
 
     
     
@@ -12598,7 +12721,7 @@ extension Oid4vp180137Error: Foundation.LocalizedError {
  * The [OID4VPError] enum represents the errors that can occur
  * when using the oid4vp foreign library.
  */
-public enum Oid4vpError {
+public enum Oid4vpError: Swift.Error {
 
     
     
@@ -12977,7 +13100,7 @@ extension Oid4vpError: Foundation.LocalizedError {
 
 
 
-public enum Oid4vciError {
+public enum Oid4vciError: Swift.Error {
 
     
     
@@ -13138,7 +13261,7 @@ extension Oid4vciError: Foundation.LocalizedError {
 
 
 
-public enum Oid4vpVerifierError {
+public enum Oid4vpVerifierError: Swift.Error {
 
     
     
@@ -13304,7 +13427,7 @@ extension Outcome: Equatable, Hashable {}
 
 
 
-public enum PermissionRequestError {
+public enum PermissionRequestError: Swift.Error {
 
     
     
@@ -13498,7 +13621,7 @@ extension PermissionRequestError: Foundation.LocalizedError {
 
 
 
-public enum PopError {
+public enum PopError: Swift.Error {
 
     
     
@@ -13603,7 +13726,7 @@ extension PopError: Foundation.LocalizedError {
 
 
 
-public enum PresentationError {
+public enum PresentationError: Swift.Error {
 
     
     
@@ -13716,7 +13839,7 @@ extension PresentationError: Foundation.LocalizedError {
 
 
 
-public enum RequestError {
+public enum RequestError: Swift.Error {
 
     
     
@@ -13789,7 +13912,7 @@ extension RequestError: Foundation.LocalizedError {
 
 
 
-public enum ResponseError {
+public enum ResponseError: Swift.Error {
 
     
     
@@ -13868,7 +13991,7 @@ extension ResponseError: Foundation.LocalizedError {
 
 
 
-public enum SdJwtError {
+public enum SdJwtError: Swift.Error {
 
     
     
@@ -13987,7 +14110,7 @@ extension SdJwtError: Foundation.LocalizedError {
 
 
 
-public enum SessionError {
+public enum SessionError: Swift.Error {
 
     
     
@@ -14060,7 +14183,7 @@ extension SessionError: Foundation.LocalizedError {
 
 
 
-public enum SignatureError {
+public enum SignatureError: Swift.Error {
 
     
     
@@ -14149,7 +14272,7 @@ extension SignatureError: Foundation.LocalizedError {
 
 
 
-public enum StatusListError {
+public enum StatusListError: Swift.Error {
 
     
     
@@ -14233,7 +14356,7 @@ extension StatusListError: Foundation.LocalizedError {
  *
  * Represents errors that may occur during storage management operations
  */
-public enum StorageManagerError {
+public enum StorageManagerError: Swift.Error {
 
     
     
@@ -14343,7 +14466,7 @@ extension StorageManagerError: Foundation.LocalizedError {
 
 
 
-public enum TerminationError {
+public enum TerminationError: Swift.Error {
 
     
     
@@ -14416,7 +14539,7 @@ extension TerminationError: Foundation.LocalizedError {
 
 
 
-public enum VcbVerificationError {
+public enum VcbVerificationError: Swift.Error {
 
     
     
@@ -14495,7 +14618,7 @@ extension VcbVerificationError: Foundation.LocalizedError {
 
 
 
-public enum VcVerificationError {
+public enum VcVerificationError: Swift.Error {
 
     
     
@@ -14568,7 +14691,7 @@ extension VcVerificationError: Foundation.LocalizedError {
 
 
 
-public enum VpError {
+public enum VpError: Swift.Error {
 
     
     
@@ -14730,7 +14853,7 @@ extension VcdmVersion: Equatable, Hashable {}
 
 
 
-public enum VdcCollectionError {
+public enum VdcCollectionError: Swift.Error {
 
     
     
@@ -14920,7 +15043,7 @@ extension VerificationResult: Equatable, Hashable {}
 
 
 
-public enum WalletServiceError {
+public enum WalletServiceError: Swift.Error {
 
     
     
@@ -15074,7 +15197,7 @@ extension WalletServiceError: Foundation.LocalizedError {
 
 
 
-public protocol Crypto: AnyObject {
+public protocol Crypto: AnyObject, Sendable {
     
     func p256Verify(certificateDer: Data, payload: Data, signature: Data)  -> VerificationResult
     
@@ -15207,7 +15330,7 @@ public func FfiConverterCallbackInterfaceCrypto_lower(_ v: Crypto) -> UInt64 {
  * For example, in the case of `JwtVc` credential format,
  * the signing payload consists of the JWT header and payload (JWS).
  */
-public protocol PresentationSigner: AnyObject {
+public protocol PresentationSigner: AnyObject, Sendable {
     
     /**
      * Sign the payload with the private key and return the signature.
@@ -17320,7 +17443,7 @@ public func cborLdEncodeToBytes(credentialStr: String, loader: [String: String]?
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterData.lift,
-            errorHandler: FfiConverterTypeCborLdEncodingError.lift
+            errorHandler: FfiConverterTypeCborLdEncodingError_lift
         )
 }
 public func decodeRevealSdJwt(input: String)throws  -> String  {
@@ -17369,7 +17492,7 @@ public func generatePopPrepare(audience: String, nonce: String?, didMethod: DidM
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterData.lift,
-            errorHandler: FfiConverterTypePopError.lift
+            errorHandler: FfiConverterTypePopError_lift
         )
 }
 /**
@@ -17430,7 +17553,7 @@ public func initializeMdlPresentation(mdocId: Uuid, uuid: Uuid, storageManager: 
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeMdlPresentationSession_lift,
-            errorHandler: FfiConverterTypeSessionError.lift
+            errorHandler: FfiConverterTypeSessionError_lift
         )
 }
 /**
@@ -17476,7 +17599,7 @@ public func oid4vciExchangeCredential(session: Oid4vciSession, proofsOfPossessio
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeCredentialResponse.lift,
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
 public func oid4vciExchangeToken(session: Oid4vciSession, httpClient: IHttpClient)async throws  -> String?  {
@@ -17490,7 +17613,7 @@ public func oid4vciExchangeToken(session: Oid4vciSession, httpClient: IHttpClien
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionString.lift,
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
 public func oid4vciGetMetadata(session: Oid4vciSession)throws  -> Oid4vciMetadata  {
@@ -17511,7 +17634,7 @@ public func oid4vciInitiate(baseUrl: String, clientId: String, redirectUrl: Stri
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeOid4vciSession_lift,
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
 public func oid4vciInitiateWithOffer(credentialOffer: String, clientId: String, redirectUrl: String, httpClient: IHttpClient)async throws  -> Oid4vciSession  {
@@ -17525,7 +17648,7 @@ public func oid4vciInitiateWithOffer(credentialOffer: String, clientId: String, 
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeOid4vciSession_lift,
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
 public func vcToSignedVp(vc: String, keyStr: String)async throws  -> String  {
@@ -17539,7 +17662,7 @@ public func vcToSignedVp(vc: String, keyStr: String)async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeVPError.lift
+            errorHandler: FfiConverterTypeVPError_lift
         )
 }
 public func verifiedResponseAsJsonString(response: MdlReaderResponseData)throws  -> String  {
@@ -17560,7 +17683,7 @@ public func verifyJsonVcString(json: String)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVCVerificationError.lift
+            errorHandler: FfiConverterTypeVCVerificationError_lift
         )
 }
 public func verifyJwtVp(jwtVp: String)async throws   {
@@ -17574,7 +17697,7 @@ public func verifyJwtVp(jwtVp: String)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVPError.lift
+            errorHandler: FfiConverterTypeVPError_lift
         )
 }
 public func verifyPdf417Barcode(payload: String)async throws   {
@@ -17588,7 +17711,7 @@ public func verifyPdf417Barcode(payload: String)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVCBVerificationError.lift
+            errorHandler: FfiConverterTypeVCBVerificationError_lift
         )
 }
 public func verifyVcbQrcodeAgainstMrz(mrzPayload: String, qrPayload: String)async throws   {
@@ -17602,7 +17725,7 @@ public func verifyVcbQrcodeAgainstMrz(mrzPayload: String, qrPayload: String)asyn
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVCBVerificationError.lift
+            errorHandler: FfiConverterTypeVCBVerificationError_lift
         )
 }
 

--- a/rust/src/oid4vci/wrapper.rs
+++ b/rust/src/oid4vci/wrapper.rs
@@ -59,7 +59,7 @@ impl Oid4vci {
     }
 }
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl Oid4vci {
     #[uniffi::constructor(name = "new")]
     fn new_default() -> Arc<Self> {

--- a/rust/src/oid4vp/iso_18013_7/requested_values.rs
+++ b/rust/src/oid4vp/iso_18013_7/requested_values.rs
@@ -175,7 +175,7 @@ fn find_match(input_descriptor: &InputDescriptor, credential: &Mdoc) -> Result<R
                     .location()
                     .iter()
                     .filter_map(|element| element.as_name())
-                    .last();
+                    .next_back();
 
                 let displayable_name = match found_name {
                     Some(name) => name.to_string(),

--- a/rust/src/proof_of_possession/mod.rs
+++ b/rust/src/proof_of_possession/mod.rs
@@ -18,7 +18,7 @@ mod error;
 
 // TODO: consider unifying prepare and complete fns by using a trait for
 // signing/crypto functions similar to `HttpClient` for requests
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 pub async fn generate_pop_prepare(
     audience: String,
     nonce: Option<String>,


### PR DESCRIPTION
## Description

This PR adds `async_runtime = "tokio"` to the uniffi export macros.

Noticed on `0.10.2` release that these errors related to the async runtime for some oid4vci methods.

## Tested

Testing in camv mobile