### PR TITLE
Add presentation signing function

### DIFF
--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -563,7 +563,7 @@ fileprivate struct FfiConverterData: FfiConverterRustBuffer {
 
 
 
-public protocol AsyncHttpClient: AnyObject, Sendable {
+public protocol AsyncHttpClient: AnyObject {
     
     func httpClient(request: HttpRequest) async throws  -> HttpResponse
     
@@ -582,9 +582,6 @@ open class AsyncHttpClientImpl: AsyncHttpClient, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -633,7 +630,7 @@ open func httpClient(request: HttpRequest)async throws  -> HttpResponse  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeHttpResponse_lift,
-            errorHandler: FfiConverterTypeHttpClientError_lift
+            errorHandler: FfiConverterTypeHttpClientError.lift
         )
 }
     
@@ -771,7 +768,7 @@ public func FfiConverterTypeAsyncHttpClient_lower(_ value: AsyncHttpClient) -> U
 
 
 
-public protocol CborIntegerProtocol: AnyObject, Sendable {
+public protocol CborIntegerProtocol: AnyObject {
     
     func lowerBytes()  -> UInt64
     
@@ -794,9 +791,6 @@ open class CborInteger: CborIntegerProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -911,7 +905,7 @@ public func FfiConverterTypeCborInteger_lower(_ value: CborInteger) -> UnsafeMut
 
 
 
-public protocol CborTagProtocol: AnyObject, Sendable {
+public protocol CborTagProtocol: AnyObject {
     
     func id()  -> UInt64
     
@@ -932,9 +926,6 @@ open class CborTag: CborTagProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1042,7 +1033,7 @@ public func FfiConverterTypeCborTag_lower(_ value: CborTag) -> UnsafeMutableRawP
 
 
 
-public protocol ClientProtocol: AnyObject, Sendable {
+public protocol ClientProtocol: AnyObject {
     
 }
 open class Client: ClientProtocol, @unchecked Sendable {
@@ -1059,9 +1050,6 @@ open class Client: ClientProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1155,7 +1143,7 @@ public func FfiConverterTypeClient_lower(_ value: Client) -> UnsafeMutableRawPoi
 
 
 
-public protocol CredentialIssuerMetadataProtocol: AnyObject, Sendable {
+public protocol CredentialIssuerMetadataProtocol: AnyObject {
     
 }
 open class CredentialIssuerMetadata: CredentialIssuerMetadataProtocol, @unchecked Sendable {
@@ -1172,9 +1160,6 @@ open class CredentialIssuerMetadata: CredentialIssuerMetadataProtocol, @unchecke
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1268,7 +1253,7 @@ public func FfiConverterTypeCredentialIssuerMetadata_lower(_ value: CredentialIs
 
 
 
-public protocol CredentialRequestProtocol: AnyObject, Sendable {
+public protocol CredentialRequestProtocol: AnyObject {
     
 }
 open class CredentialRequest: CredentialRequestProtocol, @unchecked Sendable {
@@ -1285,9 +1270,6 @@ open class CredentialRequest: CredentialRequestProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1384,7 +1366,7 @@ public func FfiConverterTypeCredentialRequest_lower(_ value: CredentialRequest) 
 /**
  * Utility functions for cryptographic curves
  */
-public protocol CryptoCurveUtilsProtocol: AnyObject, Sendable {
+public protocol CryptoCurveUtilsProtocol: AnyObject {
     
     /**
      * Returns null if the original signature encoding is not recognized.
@@ -1409,9 +1391,6 @@ open class CryptoCurveUtils: CryptoCurveUtilsProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1526,7 +1505,7 @@ public func FfiConverterTypeCryptoCurveUtils_lower(_ value: CryptoCurveUtils) ->
 
 
 
-public protocol CwtProtocol: AnyObject, Sendable {
+public protocol CwtProtocol: AnyObject {
     
     /**
      * The version of the Verifiable Credential Data Model that this credential conforms to.
@@ -1564,9 +1543,6 @@ open class Cwt: CwtProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1725,7 +1701,7 @@ public func FfiConverterTypeCwt_lower(_ value: Cwt) -> UnsafeMutableRawPointer {
 
 
 
-public protocol DelegatedVerifierProtocol: AnyObject, Sendable {
+public protocol DelegatedVerifierProtocol: AnyObject {
     
     func pollVerificationStatus(url: String) async throws  -> DelegatedVerifierStatusResponse
     
@@ -1756,9 +1732,6 @@ open class DelegatedVerifier: DelegatedVerifierProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1803,7 +1776,7 @@ public static func newClient(baseUrl: Url)async throws  -> DelegatedVerifier  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeDelegatedVerifier_lift,
-            errorHandler: FfiConverterTypeOid4vpVerifierError_lift
+            errorHandler: FfiConverterTypeOid4vpVerifierError.lift
         )
 }
     
@@ -1822,7 +1795,7 @@ open func pollVerificationStatus(url: String)async throws  -> DelegatedVerifierS
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeDelegatedVerifierStatusResponse_lift,
-            errorHandler: FfiConverterTypeOid4vpVerifierError_lift
+            errorHandler: FfiConverterTypeOid4vpVerifierError.lift
         )
 }
     
@@ -1849,7 +1822,7 @@ open func requestDelegatedVerification(url: String)async throws  -> DelegateInit
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeDelegateInitializationResponse_lift,
-            errorHandler: FfiConverterTypeOid4vpVerifierError_lift
+            errorHandler: FfiConverterTypeOid4vpVerifierError.lift
         )
 }
     
@@ -1911,7 +1884,7 @@ public func FfiConverterTypeDelegatedVerifier_lower(_ value: DelegatedVerifier) 
 
 
 
-public protocol DidMethodUtilsProtocol: AnyObject, Sendable {
+public protocol DidMethodUtilsProtocol: AnyObject {
     
     func didFromJwk(jwk: String) throws  -> String
     
@@ -1932,9 +1905,6 @@ open class DidMethodUtils: DidMethodUtilsProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1999,7 +1969,7 @@ open func vmFromJwk(jwk: String)async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeDidError_lift
+            errorHandler: FfiConverterTypeDidError.lift
         )
 }
     
@@ -2061,7 +2031,7 @@ public func FfiConverterTypeDidMethodUtils_lower(_ value: DidMethodUtils) -> Uns
 
 
 
-public protocol GrantsProtocol: AnyObject, Sendable {
+public protocol GrantsProtocol: AnyObject {
     
 }
 open class Grants: GrantsProtocol, @unchecked Sendable {
@@ -2078,9 +2048,6 @@ open class Grants: GrantsProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2180,7 +2147,7 @@ public func FfiConverterTypeGrants_lower(_ value: Grants) -> UnsafeMutableRawPoi
  * The Holder has the ability to generate Verifiable Presentations from
  * these credentials and share them with Verifiers.
  */
-public protocol HolderProtocol: AnyObject, Sendable {
+public protocol HolderProtocol: AnyObject {
     
     /**
      * Given an authorization request URL, return a permission request,
@@ -2214,9 +2181,6 @@ open class Holder: HolderProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2253,7 +2217,7 @@ public convenience init(vdcCollection: VdcCollection, trustedDids: [String], sig
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeHolder_lift,
-            errorHandler: FfiConverterTypeOID4VPError_lift
+            errorHandler: FfiConverterTypeOID4VPError.lift
         )
         
         .uniffiClonePointer()
@@ -2287,7 +2251,7 @@ public static func newWithCredentials(providedCredentials: [ParsedCredential], t
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeHolder_lift,
-            errorHandler: FfiConverterTypeOID4VPError_lift
+            errorHandler: FfiConverterTypeOID4VPError.lift
         )
 }
     
@@ -2313,7 +2277,7 @@ open func authorizationRequest(req: AuthRequest)async throws  -> PermissionReque
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypePermissionRequest_lift,
-            errorHandler: FfiConverterTypeOID4VPError_lift
+            errorHandler: FfiConverterTypeOID4VPError.lift
         )
 }
     
@@ -2330,7 +2294,7 @@ open func submitPermissionResponse(response: PermissionResponse)async throws  ->
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeUrl.lift,
-            errorHandler: FfiConverterTypeOID4VPError_lift
+            errorHandler: FfiConverterTypeOID4VPError.lift
         )
 }
     
@@ -2400,7 +2364,7 @@ public func FfiConverterTypeHolder_lower(_ value: Holder) -> UnsafeMutableRawPoi
  * `Arc` is wrapped with `IArc` to facilitate trait implementation from
  * `openidconnect` library used by request builders and client on `oid4vci-rs`.
  */
-public protocol IHttpClientProtocol: AnyObject, Sendable {
+public protocol IHttpClientProtocol: AnyObject {
     
 }
 /**
@@ -2425,9 +2389,6 @@ open class IHttpClient: IHttpClientProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2537,7 +2498,7 @@ public func FfiConverterTypeIHttpClient_lower(_ value: IHttpClient) -> UnsafeMut
 
 
 
-public protocol InProcessRecordProtocol: AnyObject, Sendable {
+public protocol InProcessRecordProtocol: AnyObject {
     
 }
 open class InProcessRecord: InProcessRecordProtocol, @unchecked Sendable {
@@ -2554,9 +2515,6 @@ open class InProcessRecord: InProcessRecordProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2650,7 +2608,7 @@ public func FfiConverterTypeInProcessRecord_lower(_ value: InProcessRecord) -> U
 
 
 
-public protocol InProgressRequest180137Protocol: AnyObject, Sendable {
+public protocol InProgressRequest180137Protocol: AnyObject {
     
     func matches()  -> [RequestMatch180137]
     
@@ -2671,9 +2629,6 @@ open class InProgressRequest180137: InProgressRequest180137Protocol, @unchecked 
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2729,7 +2684,7 @@ open func respond(approvedResponse: ApprovedResponse180137)async throws  -> Url?
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeUrl.lift,
-            errorHandler: FfiConverterTypeOID4VP180137Error_lift
+            errorHandler: FfiConverterTypeOID4VP180137Error.lift
         )
 }
     
@@ -2791,7 +2746,7 @@ public func FfiConverterTypeInProgressRequest180137_lower(_ value: InProgressReq
 
 
 
-public protocol IssuanceServiceClientProtocol: AnyObject, Sendable {
+public protocol IssuanceServiceClientProtocol: AnyObject {
     
     /**
      * Checks the status of an issuance request
@@ -2833,9 +2788,6 @@ open class IssuanceServiceClient: IssuanceServiceClientProtocol, @unchecked Send
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2909,7 +2861,7 @@ open func checkStatus(issuanceId: String, walletAttestation: String)async throws
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeCheckStatusResponse_lift,
-            errorHandler: FfiConverterTypeIssuanceServiceError_lift
+            errorHandler: FfiConverterTypeIssuanceServiceError.lift
         )
 }
     
@@ -2936,7 +2888,7 @@ open func newIssuance(walletAttestation: String)async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeIssuanceServiceError_lift
+            errorHandler: FfiConverterTypeIssuanceServiceError.lift
         )
 }
     
@@ -2998,10 +2950,153 @@ public func FfiConverterTypeIssuanceServiceClient_lower(_ value: IssuanceService
 
 
 
+public protocol JsonLdPresentationBuilderProtocol: AnyObject {
+    
+    func issuePresentation(credentials: [ParsedCredential]) async throws  -> String
+    
+}
+open class JsonLdPresentationBuilder: JsonLdPresentationBuilderProtocol, @unchecked Sendable {
+    fileprivate let pointer: UnsafeMutableRawPointer!
+
+    /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public struct NoPointer {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    // This constructor can be used to instantiate a fake object.
+    // - Parameter noPointer: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    //
+    // - Warning:
+    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public init(noPointer: NoPointer) {
+        self.pointer = nil
+    }
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public func uniffiClonePointer() -> UnsafeMutableRawPointer {
+        return try! rustCall { uniffi_mobile_sdk_rs_fn_clone_jsonldpresentationbuilder(self.pointer, $0) }
+    }
+public convenience init(id: String, holder: String, proofPurpose: String, challenge: String?, domain: String?, signer: PresentationSigner, contextMap: [String: String]?) {
+    let pointer =
+        try! rustCall() {
+    uniffi_mobile_sdk_rs_fn_constructor_jsonldpresentationbuilder_new(
+        FfiConverterString.lower(id),
+        FfiConverterString.lower(holder),
+        FfiConverterString.lower(proofPurpose),
+        FfiConverterOptionString.lower(challenge),
+        FfiConverterOptionString.lower(domain),
+        FfiConverterCallbackInterfacePresentationSigner_lower(signer),
+        FfiConverterOptionDictionaryStringString.lower(contextMap),$0
+    )
+}
+    self.init(unsafeFromRawPointer: pointer)
+}
+
+    deinit {
+        guard let pointer = pointer else {
+            return
+        }
+
+        try! rustCall { uniffi_mobile_sdk_rs_fn_free_jsonldpresentationbuilder(pointer, $0) }
+    }
+
+    
+
+    
+open func issuePresentation(credentials: [ParsedCredential])async throws  -> String  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_mobile_sdk_rs_fn_method_jsonldpresentationbuilder_issue_presentation(
+                    self.uniffiClonePointer(),
+                    FfiConverterSequenceTypeParsedCredential.lower(credentials)
+                )
+            },
+            pollFunc: ffi_mobile_sdk_rs_rust_future_poll_rust_buffer,
+            completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
+            freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterString.lift,
+            errorHandler: FfiConverterTypePresentationBuilderError.lift
+        )
+}
+    
+
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeJsonLdPresentationBuilder: FfiConverter {
+
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = JsonLdPresentationBuilder
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> JsonLdPresentationBuilder {
+        return JsonLdPresentationBuilder(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: JsonLdPresentationBuilder) -> UnsafeMutableRawPointer {
+        return value.uniffiClonePointer()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> JsonLdPresentationBuilder {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if (ptr == nil) {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: JsonLdPresentationBuilder, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeJsonLdPresentationBuilder_lift(_ pointer: UnsafeMutableRawPointer) throws -> JsonLdPresentationBuilder {
+    return try FfiConverterTypeJsonLdPresentationBuilder.lift(pointer)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeJsonLdPresentationBuilder_lower(_ value: JsonLdPresentationBuilder) -> UnsafeMutableRawPointer {
+    return FfiConverterTypeJsonLdPresentationBuilder.lower(value)
+}
+
+
+
+
+
+
 /**
  * A verifiable credential secured as JSON.
  */
-public protocol JsonVcProtocol: AnyObject, Sendable {
+public protocol JsonVcProtocol: AnyObject {
     
     /**
      * Access the W3C VCDM credential as a JSON encoded UTF-8 string.
@@ -3058,9 +3153,6 @@ open class JsonVc: JsonVcProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3166,7 +3258,7 @@ open func status()async throws  -> Status  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeStatus_lift,
-            errorHandler: FfiConverterTypeStatusListError_lift
+            errorHandler: FfiConverterTypeStatusListError.lift
         )
 }
     
@@ -3262,7 +3354,7 @@ public func FfiConverterTypeJsonVc_lower(_ value: JsonVc) -> UnsafeMutableRawPoi
 /**
  * A verifiable credential secured as a JWT.
  */
-public protocol JwtVcProtocol: AnyObject, Sendable {
+public protocol JwtVcProtocol: AnyObject {
     
     /**
      * Access the W3C VCDM credential as a JSON encoded UTF-8 string.
@@ -3323,9 +3415,6 @@ open class JwtVc: JwtVcProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3530,7 +3619,7 @@ public func FfiConverterTypeJwtVc_lower(_ value: JwtVc) -> UnsafeMutableRawPoint
 /**
  * An interface that can provide access to cryptographic keypairs from the native crypto API.
  */
-public protocol KeyStore: AnyObject, Sendable {
+public protocol KeyStore: AnyObject {
     
     /**
      * Retrieve a cryptographic keypair by alias. The cryptographic key must be usable for
@@ -3556,9 +3645,6 @@ open class KeyStoreImpl: KeyStore, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3716,7 +3802,7 @@ public func FfiConverterTypeKeyStore_lower(_ value: KeyStore) -> UnsafeMutableRa
 
 
 
-public protocol MdlSessionManagerProtocol: AnyObject, Sendable {
+public protocol MdlSessionManagerProtocol: AnyObject {
     
 }
 open class MdlSessionManager: MdlSessionManagerProtocol, @unchecked Sendable {
@@ -3733,9 +3819,6 @@ open class MdlSessionManager: MdlSessionManagerProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3829,7 +3912,7 @@ public func FfiConverterTypeMDLSessionManager_lower(_ value: MdlSessionManager) 
 
 
 
-public protocol MdlPresentationSessionProtocol: AnyObject, Sendable {
+public protocol MdlPresentationSessionProtocol: AnyObject {
     
     /**
      * Constructs the response to be sent from the holder to the reader containing
@@ -3885,9 +3968,6 @@ open class MdlPresentationSession: MdlPresentationSessionProtocol, @unchecked Se
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4053,7 +4133,7 @@ public func FfiConverterTypeMdlPresentationSession_lower(_ value: MdlPresentatio
 
 
 
-public protocol MdocProtocol: AnyObject, Sendable {
+public protocol MdocProtocol: AnyObject {
     
     /**
      * Simple representation of mdoc namespace and data elements for display in the UI.
@@ -4087,9 +4167,6 @@ open class Mdoc: MdocProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4263,7 +4340,7 @@ public func FfiConverterTypeMdoc_lower(_ value: Mdoc) -> UnsafeMutableRawPointer
  *
  * Notably this supports requests which use the URI scheme `mdoc-openid4vp://`.
  */
-public protocol Oid4vp180137Protocol: AnyObject, Sendable {
+public protocol Oid4vp180137Protocol: AnyObject {
     
     func processRequest(url: Url) async throws  -> InProgressRequest180137
     
@@ -4287,9 +4364,6 @@ open class Oid4vp180137: Oid4vp180137Protocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4347,7 +4421,7 @@ open func processRequest(url: Url)async throws  -> InProgressRequest180137  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeInProgressRequest180137_lift,
-            errorHandler: FfiConverterTypeOID4VP180137Error_lift
+            errorHandler: FfiConverterTypeOID4VP180137Error.lift
         )
 }
     
@@ -4409,7 +4483,7 @@ public func FfiConverterTypeOID4VP180137_lower(_ value: Oid4vp180137) -> UnsafeM
 
 
 
-public protocol Oid4vciProtocol: AnyObject, Sendable {
+public protocol Oid4vciProtocol: AnyObject {
     
     func clearContextMap() throws 
     
@@ -4442,9 +4516,6 @@ open class Oid4vci: Oid4vciProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4536,7 +4607,7 @@ open func exchangeCredential(proofsOfPossession: [String], options: Oid4vciExcha
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeCredentialResponse.lift,
-            errorHandler: FfiConverterTypeOid4vciError_lift
+            errorHandler: FfiConverterTypeOid4vciError.lift
         )
 }
     
@@ -4553,7 +4624,7 @@ open func exchangeToken()async throws  -> String?  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionString.lift,
-            errorHandler: FfiConverterTypeOid4vciError_lift
+            errorHandler: FfiConverterTypeOid4vciError.lift
         )
 }
     
@@ -4577,7 +4648,7 @@ open func initiate(baseUrl: String, clientId: String, redirectUrl: String)async 
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeOid4vciError_lift
+            errorHandler: FfiConverterTypeOid4vciError.lift
         )
 }
     
@@ -4600,7 +4671,7 @@ open func initiateWithOffer(credentialOffer: String, clientId: String, redirectU
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeOid4vciError_lift
+            errorHandler: FfiConverterTypeOid4vciError.lift
         )
 }
     
@@ -4669,7 +4740,7 @@ public func FfiConverterTypeOid4vci_lower(_ value: Oid4vci) -> UnsafeMutableRawP
 
 
 
-public protocol Oid4vciMetadataProtocol: AnyObject, Sendable {
+public protocol Oid4vciMetadataProtocol: AnyObject {
     
     func authorizationServers()  -> [String]?
     
@@ -4700,9 +4771,6 @@ open class Oid4vciMetadata: Oid4vciMetadataProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4845,7 +4913,7 @@ public func FfiConverterTypeOid4vciMetadata_lower(_ value: Oid4vciMetadata) -> U
 
 
 
-public protocol Oid4vciSessionProtocol: AnyObject, Sendable {
+public protocol Oid4vciSessionProtocol: AnyObject {
     
 }
 open class Oid4vciSession: Oid4vciSessionProtocol, @unchecked Sendable {
@@ -4862,9 +4930,6 @@ open class Oid4vciSession: Oid4vciSessionProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4961,7 +5026,7 @@ public func FfiConverterTypeOid4vciSession_lower(_ value: Oid4vciSession) -> Uns
 /**
  * A credential that has been parsed as a known variant.
  */
-public protocol ParsedCredentialProtocol: AnyObject, Sendable {
+public protocol ParsedCredentialProtocol: AnyObject {
     
     /**
      * Return the credential as an CWT, if it is of that format.
@@ -5031,9 +5096,6 @@ open class ParsedCredential: ParsedCredentialProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5325,7 +5387,7 @@ public func FfiConverterTypeParsedCredential_lower(_ value: ParsedCredential) ->
 
 
 
-public protocol PermissionRequestProtocol: AnyObject, Sendable {
+public protocol PermissionRequestProtocol: AnyObject {
     
     /**
      * Return the client ID for the authorization request.
@@ -5386,9 +5448,6 @@ open class PermissionRequest: PermissionRequestProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5457,7 +5516,7 @@ open func createPermissionResponse(selectedCredentials: [PresentableCredential],
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypePermissionResponse_lift,
-            errorHandler: FfiConverterTypeOID4VPError_lift
+            errorHandler: FfiConverterTypeOID4VPError.lift
         )
 }
     
@@ -5575,7 +5634,7 @@ public func FfiConverterTypePermissionRequest_lower(_ value: PermissionRequest) 
  * The Requested Fields are created by calling the [PermissionRequest::requested_fields] method, and then
  * explicitly setting the permission to true or false, based on the holder's decision.
  */
-public protocol PermissionResponseProtocol: AnyObject, Sendable {
+public protocol PermissionResponseProtocol: AnyObject {
     
     /**
      * Return the selected credentials for the permission response.
@@ -5613,9 +5672,6 @@ open class PermissionResponse: PermissionResponseProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5735,7 +5791,7 @@ public func FfiConverterTypePermissionResponse_lower(_ value: PermissionResponse
 /**
  * A credential that has been parsed as a known variant.
  */
-public protocol PresentableCredentialProtocol: AnyObject, Sendable {
+public protocol PresentableCredentialProtocol: AnyObject {
     
     /**
      * Converts to the primitive ParsedCredential type
@@ -5766,9 +5822,6 @@ open class PresentableCredential: PresentableCredentialProtocol, @unchecked Send
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5886,7 +5939,7 @@ public func FfiConverterTypePresentableCredential_lower(_ value: PresentableCred
 /**
  * A viable match for the credential request.
  */
-public protocol RequestMatch180137Protocol: AnyObject, Sendable {
+public protocol RequestMatch180137Protocol: AnyObject {
     
     func credentialId()  -> Uuid
     
@@ -5910,9 +5963,6 @@ open class RequestMatch180137: RequestMatch180137Protocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6020,7 +6070,7 @@ public func FfiConverterTypeRequestMatch180137_lower(_ value: RequestMatch180137
 
 
 
-public protocol RequestedFieldProtocol: AnyObject, Sendable {
+public protocol RequestedFieldProtocol: AnyObject {
     
     /**
      * Return the unique ID for the request field.
@@ -6077,9 +6127,6 @@ open class RequestedField: RequestedFieldProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6256,7 +6303,7 @@ public func FfiConverterTypeRequestedField_lower(_ value: RequestedField) -> Uns
 /**
  * A cryptographic keypair that can be used for signing.
  */
-public protocol SigningKey: AnyObject, Sendable {
+public protocol SigningKey: AnyObject {
     
     /**
      * Generates a public JWK for this key.
@@ -6286,9 +6333,6 @@ open class SigningKeyImpl: SigningKey, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6485,7 +6529,7 @@ public func FfiConverterTypeSigningKey_lower(_ value: SigningKey) -> UnsafeMutab
  * and the purpose is the purpose of the credential, which is used
  * to interpret the value.
  */
-public protocol StatusProtocol: AnyObject, Sendable {
+public protocol StatusProtocol: AnyObject {
     
     /**
      * Return whether the credential status has a message.
@@ -6534,9 +6578,6 @@ open class Status: StatusProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6687,7 +6728,7 @@ public func FfiConverterTypeStatus_lower(_ value: Status) -> UnsafeMutableRawPoi
  * and the purpose is the purpose of the credential, which is used
  * to interpret the value.
  */
-public protocol Status20240406Protocol: AnyObject, Sendable {
+public protocol Status20240406Protocol: AnyObject {
     
     /**
      * Return whether the credential status has a message.
@@ -6736,9 +6777,6 @@ open class Status20240406: Status20240406Protocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6894,7 +6932,7 @@ public func FfiConverterTypeStatus20240406_lower(_ value: Status20240406) -> Uns
  * We use the older callback_interface to keep the required version level of our Android API
  * low.
  */
-public protocol StorageManagerInterface: AnyObject, Sendable {
+public protocol StorageManagerInterface: AnyObject {
     
     /**
      * Function: add
@@ -6960,9 +6998,6 @@ open class StorageManagerInterfaceImpl: StorageManagerInterface, @unchecked Send
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -7021,7 +7056,7 @@ open func add(key: Key, value: Value)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeStorageManagerError_lift
+            errorHandler: FfiConverterTypeStorageManagerError.lift
         )
 }
     
@@ -7044,7 +7079,7 @@ open func get(key: Key)async throws  -> Value?  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeValue.lift,
-            errorHandler: FfiConverterTypeStorageManagerError_lift
+            errorHandler: FfiConverterTypeStorageManagerError.lift
         )
 }
     
@@ -7066,7 +7101,7 @@ open func list()async throws  -> [Key]  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeKey.lift,
-            errorHandler: FfiConverterTypeStorageManagerError_lift
+            errorHandler: FfiConverterTypeStorageManagerError.lift
         )
 }
     
@@ -7091,7 +7126,7 @@ open func remove(key: Key)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeStorageManagerError_lift
+            errorHandler: FfiConverterTypeStorageManagerError.lift
         )
 }
     
@@ -7348,7 +7383,7 @@ public func FfiConverterTypeStorageManagerInterface_lower(_ value: StorageManage
 
 
 
-public protocol SyncHttpClient: AnyObject, Sendable {
+public protocol SyncHttpClient: AnyObject {
     
     func httpClient(request: HttpRequest) throws  -> HttpResponse
     
@@ -7367,9 +7402,6 @@ open class SyncHttpClientImpl: SyncHttpClient, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -7523,7 +7555,7 @@ public func FfiConverterTypeSyncHttpClient_lower(_ value: SyncHttpClient) -> Uns
 
 
 
-public protocol TokenResponseProtocol: AnyObject, Sendable {
+public protocol TokenResponseProtocol: AnyObject {
     
 }
 open class TokenResponse: TokenResponseProtocol, @unchecked Sendable {
@@ -7540,9 +7572,6 @@ open class TokenResponse: TokenResponseProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -7636,7 +7665,7 @@ public func FfiConverterTypeTokenResponse_lower(_ value: TokenResponse) -> Unsaf
 
 
 
-public protocol Vcdm2SdJwtProtocol: AnyObject, Sendable {
+public protocol Vcdm2SdJwtProtocol: AnyObject {
     
     /**
      * Return the ID for the SdJwt instance.
@@ -7680,9 +7709,6 @@ open class Vcdm2SdJwt: Vcdm2SdJwtProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -7788,7 +7814,7 @@ open func status()async throws  -> [Status20240406]  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeStatus20240406.lift,
-            errorHandler: FfiConverterTypeStatusListError_lift
+            errorHandler: FfiConverterTypeStatusListError.lift
         )
 }
     
@@ -7866,7 +7892,7 @@ public func FfiConverterTypeVCDM2SdJwt_lower(_ value: Vcdm2SdJwt) -> UnsafeMutab
  *
  * This is the main interface to credentials.
  */
-public protocol VdcCollectionProtocol: AnyObject, Sendable {
+public protocol VdcCollectionProtocol: AnyObject {
     
     /**
      * Add a credential to the set.
@@ -7918,9 +7944,6 @@ open class VdcCollection: VdcCollectionProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -7983,7 +8006,7 @@ open func add(credential: Credential)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVdcCollectionError_lift
+            errorHandler: FfiConverterTypeVdcCollectionError.lift
         )
 }
     
@@ -8003,7 +8026,7 @@ open func allEntries()async throws  -> [Uuid]  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeUuid.lift,
-            errorHandler: FfiConverterTypeVdcCollectionError_lift
+            errorHandler: FfiConverterTypeVdcCollectionError.lift
         )
 }
     
@@ -8023,7 +8046,7 @@ open func allEntriesByType(ctype: CredentialType)async throws  -> [Uuid]  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeUuid.lift,
-            errorHandler: FfiConverterTypeVdcCollectionError_lift
+            errorHandler: FfiConverterTypeVdcCollectionError.lift
         )
 }
     
@@ -8043,7 +8066,7 @@ open func delete(id: Uuid)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVdcCollectionError_lift
+            errorHandler: FfiConverterTypeVdcCollectionError.lift
         )
 }
     
@@ -8084,7 +8107,7 @@ open func get(id: Uuid)async throws  -> Credential?  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeCredential.lift,
-            errorHandler: FfiConverterTypeVdcCollectionError_lift
+            errorHandler: FfiConverterTypeVdcCollectionError.lift
         )
 }
     
@@ -8146,7 +8169,7 @@ public func FfiConverterTypeVdcCollection_lower(_ value: VdcCollection) -> Unsaf
 
 
 
-public protocol WalletServiceClientProtocol: AnyObject, Sendable {
+public protocol WalletServiceClientProtocol: AnyObject {
     
     /**
      * Helper method to get an authorization header with the current token
@@ -8190,9 +8213,6 @@ open class WalletServiceClient: WalletServiceClientProtocol, @unchecked Sendable
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -8309,7 +8329,7 @@ open func nonce()async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeWalletServiceError_lift
+            errorHandler: FfiConverterTypeWalletServiceError.lift
         )
 }
     
@@ -10056,7 +10076,7 @@ extension AuthenticationStatus: Equatable, Hashable {}
 
 
 
-public enum CborLdEncodingError: Swift.Error {
+public enum CborLdEncodingError {
 
     
     
@@ -10372,7 +10392,7 @@ extension ClaimValue: Equatable, Hashable {}
 
 
 
-public enum CredentialDecodingError: Swift.Error {
+public enum CredentialDecodingError {
 
     
     
@@ -10515,7 +10535,7 @@ extension CredentialDecodingError: Foundation.LocalizedError {
 
 
 
-public enum CredentialEncodingError: Swift.Error {
+public enum CredentialEncodingError {
 
     
     
@@ -10736,7 +10756,7 @@ extension CredentialFormat: Equatable, Hashable {}
 
 
 
-public enum CredentialPresentationError: Swift.Error {
+public enum CredentialPresentationError {
 
     
     
@@ -10819,7 +10839,7 @@ extension CredentialPresentationError: Foundation.LocalizedError {
 
 
 
-public enum CryptoError: Swift.Error {
+public enum CryptoError {
 
     
     
@@ -10892,7 +10912,7 @@ extension CryptoError: Foundation.LocalizedError {
 
 
 
-public enum CwtError: Swift.Error {
+public enum CwtError {
 
     
     
@@ -11244,7 +11264,7 @@ extension DelegatedVerifierStatus: Equatable, Hashable {}
 
 
 
-public enum DidError: Swift.Error {
+public enum DidError {
 
     
     
@@ -11408,7 +11428,7 @@ extension DidMethod: Equatable, Hashable {}
 
 
 
-public enum HttpClientError: Swift.Error {
+public enum HttpClientError {
 
     
     
@@ -11546,7 +11566,7 @@ extension HttpClientError: Foundation.LocalizedError {
 /**
  * Represents errors that may occur during issuance operations
  */
-public enum IssuanceServiceError: Swift.Error {
+public enum IssuanceServiceError {
 
     
     
@@ -11676,7 +11696,7 @@ extension IssuanceServiceError: Foundation.LocalizedError {
 
 
 
-public enum JsonVcEncodingError: Swift.Error {
+public enum JsonVcEncodingError {
 
     
     
@@ -11745,7 +11765,7 @@ extension JsonVcEncodingError: Foundation.LocalizedError {
 
 
 
-public enum JsonVcInitError: Swift.Error {
+public enum JsonVcInitError {
 
     
     
@@ -11832,7 +11852,7 @@ extension JsonVcInitError: Foundation.LocalizedError {
 
 
 
-public enum JwtVcInitError: Swift.Error {
+public enum JwtVcInitError {
 
     
     
@@ -11943,7 +11963,7 @@ extension JwtVcInitError: Foundation.LocalizedError {
 
 
 
-public enum KeyTransformationError: Swift.Error {
+public enum KeyTransformationError {
 
     
     
@@ -12046,7 +12066,7 @@ extension KeyTransformationError: Foundation.LocalizedError {
 
 
 
-public enum MdlReaderResponseError: Swift.Error {
+public enum MdlReaderResponseError {
 
     
     
@@ -12143,7 +12163,7 @@ extension MdlReaderResponseError: Foundation.LocalizedError {
 
 
 
-public enum MdlReaderResponseSerializeError: Swift.Error {
+public enum MdlReaderResponseSerializeError {
 
     
     
@@ -12216,7 +12236,7 @@ extension MdlReaderResponseSerializeError: Foundation.LocalizedError {
 
 
 
-public enum MdlReaderSessionError: Swift.Error {
+public enum MdlReaderSessionError {
 
     
     
@@ -12392,7 +12412,7 @@ extension MDocItem: Equatable, Hashable {}
 
 
 
-public enum MdlUtilError: Swift.Error {
+public enum MdlUtilError {
 
     
     
@@ -12465,7 +12485,7 @@ extension MdlUtilError: Foundation.LocalizedError {
 
 
 
-public enum MdocEncodingError: Swift.Error {
+public enum MdocEncodingError {
 
     
     
@@ -12534,7 +12554,7 @@ extension MdocEncodingError: Foundation.LocalizedError {
 
 
 
-public enum MdocInitError: Swift.Error {
+public enum MdocInitError {
 
     
     
@@ -12649,7 +12669,7 @@ extension MdocInitError: Foundation.LocalizedError {
 
 
 
-public enum Oid4vp180137Error: Swift.Error {
+public enum Oid4vp180137Error {
 
     
     
@@ -12746,7 +12766,7 @@ extension Oid4vp180137Error: Foundation.LocalizedError {
  * The [OID4VPError] enum represents the errors that can occur
  * when using the oid4vp foreign library.
  */
-public enum Oid4vpError: Swift.Error {
+public enum Oid4vpError {
 
     
     
@@ -13125,7 +13145,7 @@ extension Oid4vpError: Foundation.LocalizedError {
 
 
 
-public enum Oid4vciError: Swift.Error {
+public enum Oid4vciError {
 
     
     
@@ -13286,7 +13306,7 @@ extension Oid4vciError: Foundation.LocalizedError {
 
 
 
-public enum Oid4vpVerifierError: Swift.Error {
+public enum Oid4vpVerifierError {
 
     
     
@@ -13452,7 +13472,7 @@ extension Outcome: Equatable, Hashable {}
 
 
 
-public enum PermissionRequestError: Swift.Error {
+public enum PermissionRequestError {
 
     
     
@@ -13646,7 +13666,7 @@ extension PermissionRequestError: Foundation.LocalizedError {
 
 
 
-public enum PopError: Swift.Error {
+public enum PopError {
 
     
     
@@ -13751,7 +13771,136 @@ extension PopError: Foundation.LocalizedError {
 
 
 
-public enum PresentationError: Swift.Error {
+public enum PresentationBuilderError {
+
+    
+    
+    case DidError(message: String)
+    
+    case UrlParseError(message: String)
+    
+    case DidUrlParseError(message: String)
+    
+    case SerializationError(message: String)
+    
+    case ConversionError(message: String)
+    
+    case IriBufError(message: String)
+    
+    case UriBufError(message: String)
+    
+    case Context(message: String)
+    
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypePresentationBuilderError: FfiConverterRustBuffer {
+    typealias SwiftType = PresentationBuilderError
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PresentationBuilderError {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        
+
+        
+        case 1: return .DidError(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 2: return .UrlParseError(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 3: return .DidUrlParseError(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 4: return .SerializationError(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 5: return .ConversionError(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 6: return .IriBufError(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 7: return .UriBufError(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 8: return .Context(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: PresentationBuilderError, into buf: inout [UInt8]) {
+        switch value {
+
+        
+
+        
+        case .DidError(_ /* message is ignored*/):
+            writeInt(&buf, Int32(1))
+        case .UrlParseError(_ /* message is ignored*/):
+            writeInt(&buf, Int32(2))
+        case .DidUrlParseError(_ /* message is ignored*/):
+            writeInt(&buf, Int32(3))
+        case .SerializationError(_ /* message is ignored*/):
+            writeInt(&buf, Int32(4))
+        case .ConversionError(_ /* message is ignored*/):
+            writeInt(&buf, Int32(5))
+        case .IriBufError(_ /* message is ignored*/):
+            writeInt(&buf, Int32(6))
+        case .UriBufError(_ /* message is ignored*/):
+            writeInt(&buf, Int32(7))
+        case .Context(_ /* message is ignored*/):
+            writeInt(&buf, Int32(8))
+
+        
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePresentationBuilderError_lift(_ buf: RustBuffer) throws -> PresentationBuilderError {
+    return try FfiConverterTypePresentationBuilderError.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePresentationBuilderError_lower(_ value: PresentationBuilderError) -> RustBuffer {
+    return FfiConverterTypePresentationBuilderError.lower(value)
+}
+
+
+extension PresentationBuilderError: Equatable, Hashable {}
+
+
+
+extension PresentationBuilderError: Foundation.LocalizedError {
+    public var errorDescription: String? {
+        String(reflecting: self)
+    }
+}
+
+
+
+public enum PresentationError {
 
     
     
@@ -13864,7 +14013,7 @@ extension PresentationError: Foundation.LocalizedError {
 
 
 
-public enum RequestError: Swift.Error {
+public enum RequestError {
 
     
     
@@ -13937,7 +14086,7 @@ extension RequestError: Foundation.LocalizedError {
 
 
 
-public enum ResponseError: Swift.Error {
+public enum ResponseError {
 
     
     
@@ -14016,7 +14165,7 @@ extension ResponseError: Foundation.LocalizedError {
 
 
 
-public enum SdJwtError: Swift.Error {
+public enum SdJwtError {
 
     
     
@@ -14135,7 +14284,7 @@ extension SdJwtError: Foundation.LocalizedError {
 
 
 
-public enum SessionError: Swift.Error {
+public enum SessionError {
 
     
     
@@ -14208,7 +14357,7 @@ extension SessionError: Foundation.LocalizedError {
 
 
 
-public enum SignatureError: Swift.Error {
+public enum SignatureError {
 
     
     
@@ -14297,7 +14446,7 @@ extension SignatureError: Foundation.LocalizedError {
 
 
 
-public enum StatusListError: Swift.Error {
+public enum StatusListError {
 
     
     
@@ -14381,7 +14530,7 @@ extension StatusListError: Foundation.LocalizedError {
  *
  * Represents errors that may occur during storage management operations
  */
-public enum StorageManagerError: Swift.Error {
+public enum StorageManagerError {
 
     
     
@@ -14491,7 +14640,7 @@ extension StorageManagerError: Foundation.LocalizedError {
 
 
 
-public enum TerminationError: Swift.Error {
+public enum TerminationError {
 
     
     
@@ -14564,7 +14713,7 @@ extension TerminationError: Foundation.LocalizedError {
 
 
 
-public enum VcbVerificationError: Swift.Error {
+public enum VcbVerificationError {
 
     
     
@@ -14643,7 +14792,7 @@ extension VcbVerificationError: Foundation.LocalizedError {
 
 
 
-public enum VcVerificationError: Swift.Error {
+public enum VcVerificationError {
 
     
     
@@ -14716,7 +14865,7 @@ extension VcVerificationError: Foundation.LocalizedError {
 
 
 
-public enum VpError: Swift.Error {
+public enum VpError {
 
     
     
@@ -14878,7 +15027,7 @@ extension VcdmVersion: Equatable, Hashable {}
 
 
 
-public enum VdcCollectionError: Swift.Error {
+public enum VdcCollectionError {
 
     
     
@@ -15068,7 +15217,7 @@ extension VerificationResult: Equatable, Hashable {}
 
 
 
-public enum WalletServiceError: Swift.Error {
+public enum WalletServiceError {
 
     
     
@@ -15222,7 +15371,7 @@ extension WalletServiceError: Foundation.LocalizedError {
 
 
 
-public protocol Crypto: AnyObject, Sendable {
+public protocol Crypto: AnyObject {
     
     func p256Verify(certificateDer: Data, payload: Data, signature: Data)  -> VerificationResult
     
@@ -15355,7 +15504,7 @@ public func FfiConverterCallbackInterfaceCrypto_lower(_ v: Crypto) -> UInt64 {
  * For example, in the case of `JwtVc` credential format,
  * the signing payload consists of the JWT header and payload (JWS).
  */
-public protocol PresentationSigner: AnyObject, Sendable {
+public protocol PresentationSigner: AnyObject {
     
     /**
      * Sign the payload with the private key and return the signature.
@@ -17468,7 +17617,7 @@ public func cborLdEncodeToBytes(credentialStr: String, loader: [String: String]?
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterData.lift,
-            errorHandler: FfiConverterTypeCborLdEncodingError_lift
+            errorHandler: FfiConverterTypeCborLdEncodingError.lift
         )
 }
 public func decodeRevealSdJwt(input: String)throws  -> String  {
@@ -17517,7 +17666,7 @@ public func generatePopPrepare(audience: String, nonce: String?, didMethod: DidM
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterData.lift,
-            errorHandler: FfiConverterTypePopError_lift
+            errorHandler: FfiConverterTypePopError.lift
         )
 }
 /**
@@ -17578,7 +17727,7 @@ public func initializeMdlPresentation(mdocId: Uuid, uuid: Uuid, storageManager: 
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeMdlPresentationSession_lift,
-            errorHandler: FfiConverterTypeSessionError_lift
+            errorHandler: FfiConverterTypeSessionError.lift
         )
 }
 /**
@@ -17624,7 +17773,7 @@ public func oid4vciExchangeCredential(session: Oid4vciSession, proofsOfPossessio
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeCredentialResponse.lift,
-            errorHandler: FfiConverterTypeOid4vciError_lift
+            errorHandler: FfiConverterTypeOid4vciError.lift
         )
 }
 public func oid4vciExchangeToken(session: Oid4vciSession, httpClient: IHttpClient)async throws  -> String?  {
@@ -17638,7 +17787,7 @@ public func oid4vciExchangeToken(session: Oid4vciSession, httpClient: IHttpClien
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionString.lift,
-            errorHandler: FfiConverterTypeOid4vciError_lift
+            errorHandler: FfiConverterTypeOid4vciError.lift
         )
 }
 public func oid4vciGetMetadata(session: Oid4vciSession)throws  -> Oid4vciMetadata  {
@@ -17659,7 +17808,7 @@ public func oid4vciInitiate(baseUrl: String, clientId: String, redirectUrl: Stri
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeOid4vciSession_lift,
-            errorHandler: FfiConverterTypeOid4vciError_lift
+            errorHandler: FfiConverterTypeOid4vciError.lift
         )
 }
 public func oid4vciInitiateWithOffer(credentialOffer: String, clientId: String, redirectUrl: String, httpClient: IHttpClient)async throws  -> Oid4vciSession  {
@@ -17673,7 +17822,7 @@ public func oid4vciInitiateWithOffer(credentialOffer: String, clientId: String, 
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeOid4vciSession_lift,
-            errorHandler: FfiConverterTypeOid4vciError_lift
+            errorHandler: FfiConverterTypeOid4vciError.lift
         )
 }
 public func vcToSignedVp(vc: String, keyStr: String)async throws  -> String  {
@@ -17687,7 +17836,7 @@ public func vcToSignedVp(vc: String, keyStr: String)async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeVPError_lift
+            errorHandler: FfiConverterTypeVPError.lift
         )
 }
 public func verifiedResponseAsJsonString(response: MdlReaderResponseData)throws  -> String  {
@@ -17708,7 +17857,7 @@ public func verifyJsonVcString(json: String)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVCVerificationError_lift
+            errorHandler: FfiConverterTypeVCVerificationError.lift
         )
 }
 public func verifyJwtVp(jwtVp: String)async throws   {
@@ -17722,7 +17871,7 @@ public func verifyJwtVp(jwtVp: String)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVPError_lift
+            errorHandler: FfiConverterTypeVPError.lift
         )
 }
 public func verifyPdf417Barcode(payload: String)async throws   {
@@ -17736,7 +17885,7 @@ public func verifyPdf417Barcode(payload: String)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVCBVerificationError_lift
+            errorHandler: FfiConverterTypeVCBVerificationError.lift
         )
 }
 public func verifyVcbQrcodeAgainstMrz(mrzPayload: String, qrPayload: String)async throws   {
@@ -17750,7 +17899,7 @@ public func verifyVcbQrcodeAgainstMrz(mrzPayload: String, qrPayload: String)asyn
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVCBVerificationError_lift
+            errorHandler: FfiConverterTypeVCBVerificationError.lift
         )
 }
 
@@ -17905,6 +18054,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_issuanceserviceclient_new_issuance() != 231) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mobile_sdk_rs_checksum_method_jsonldpresentationbuilder_issue_presentation() != 17531) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_jsonvc_credential_as_json_encoded_utf8_string() != 36585) {
@@ -18250,6 +18402,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_constructor_issuanceserviceclient_new() != 39224) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mobile_sdk_rs_checksum_constructor_jsonldpresentationbuilder_new() != 15501) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_constructor_jsonvc_new_from_json() != 40674) {

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -563,7 +563,7 @@ fileprivate struct FfiConverterData: FfiConverterRustBuffer {
 
 
 
-public protocol AsyncHttpClient: AnyObject {
+public protocol AsyncHttpClient: AnyObject, Sendable {
     
     func httpClient(request: HttpRequest) async throws  -> HttpResponse
     
@@ -582,6 +582,9 @@ open class AsyncHttpClientImpl: AsyncHttpClient, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -630,7 +633,7 @@ open func httpClient(request: HttpRequest)async throws  -> HttpResponse  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeHttpResponse_lift,
-            errorHandler: FfiConverterTypeHttpClientError.lift
+            errorHandler: FfiConverterTypeHttpClientError_lift
         )
 }
     
@@ -768,7 +771,7 @@ public func FfiConverterTypeAsyncHttpClient_lower(_ value: AsyncHttpClient) -> U
 
 
 
-public protocol CborIntegerProtocol: AnyObject {
+public protocol CborIntegerProtocol: AnyObject, Sendable {
     
     func lowerBytes()  -> UInt64
     
@@ -791,6 +794,9 @@ open class CborInteger: CborIntegerProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -905,7 +911,7 @@ public func FfiConverterTypeCborInteger_lower(_ value: CborInteger) -> UnsafeMut
 
 
 
-public protocol CborTagProtocol: AnyObject {
+public protocol CborTagProtocol: AnyObject, Sendable {
     
     func id()  -> UInt64
     
@@ -926,6 +932,9 @@ open class CborTag: CborTagProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1033,7 +1042,7 @@ public func FfiConverterTypeCborTag_lower(_ value: CborTag) -> UnsafeMutableRawP
 
 
 
-public protocol ClientProtocol: AnyObject {
+public protocol ClientProtocol: AnyObject, Sendable {
     
 }
 open class Client: ClientProtocol, @unchecked Sendable {
@@ -1050,6 +1059,9 @@ open class Client: ClientProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1143,7 +1155,7 @@ public func FfiConverterTypeClient_lower(_ value: Client) -> UnsafeMutableRawPoi
 
 
 
-public protocol CredentialIssuerMetadataProtocol: AnyObject {
+public protocol CredentialIssuerMetadataProtocol: AnyObject, Sendable {
     
 }
 open class CredentialIssuerMetadata: CredentialIssuerMetadataProtocol, @unchecked Sendable {
@@ -1160,6 +1172,9 @@ open class CredentialIssuerMetadata: CredentialIssuerMetadataProtocol, @unchecke
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1253,7 +1268,7 @@ public func FfiConverterTypeCredentialIssuerMetadata_lower(_ value: CredentialIs
 
 
 
-public protocol CredentialRequestProtocol: AnyObject {
+public protocol CredentialRequestProtocol: AnyObject, Sendable {
     
 }
 open class CredentialRequest: CredentialRequestProtocol, @unchecked Sendable {
@@ -1270,6 +1285,9 @@ open class CredentialRequest: CredentialRequestProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1366,7 +1384,7 @@ public func FfiConverterTypeCredentialRequest_lower(_ value: CredentialRequest) 
 /**
  * Utility functions for cryptographic curves
  */
-public protocol CryptoCurveUtilsProtocol: AnyObject {
+public protocol CryptoCurveUtilsProtocol: AnyObject, Sendable {
     
     /**
      * Returns null if the original signature encoding is not recognized.
@@ -1391,6 +1409,9 @@ open class CryptoCurveUtils: CryptoCurveUtilsProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1505,7 +1526,7 @@ public func FfiConverterTypeCryptoCurveUtils_lower(_ value: CryptoCurveUtils) ->
 
 
 
-public protocol CwtProtocol: AnyObject {
+public protocol CwtProtocol: AnyObject, Sendable {
     
     /**
      * The version of the Verifiable Credential Data Model that this credential conforms to.
@@ -1543,6 +1564,9 @@ open class Cwt: CwtProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1701,7 +1725,7 @@ public func FfiConverterTypeCwt_lower(_ value: Cwt) -> UnsafeMutableRawPointer {
 
 
 
-public protocol DelegatedVerifierProtocol: AnyObject {
+public protocol DelegatedVerifierProtocol: AnyObject, Sendable {
     
     func pollVerificationStatus(url: String) async throws  -> DelegatedVerifierStatusResponse
     
@@ -1732,6 +1756,9 @@ open class DelegatedVerifier: DelegatedVerifierProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1776,7 +1803,7 @@ public static func newClient(baseUrl: Url)async throws  -> DelegatedVerifier  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeDelegatedVerifier_lift,
-            errorHandler: FfiConverterTypeOid4vpVerifierError.lift
+            errorHandler: FfiConverterTypeOid4vpVerifierError_lift
         )
 }
     
@@ -1795,7 +1822,7 @@ open func pollVerificationStatus(url: String)async throws  -> DelegatedVerifierS
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeDelegatedVerifierStatusResponse_lift,
-            errorHandler: FfiConverterTypeOid4vpVerifierError.lift
+            errorHandler: FfiConverterTypeOid4vpVerifierError_lift
         )
 }
     
@@ -1822,7 +1849,7 @@ open func requestDelegatedVerification(url: String)async throws  -> DelegateInit
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeDelegateInitializationResponse_lift,
-            errorHandler: FfiConverterTypeOid4vpVerifierError.lift
+            errorHandler: FfiConverterTypeOid4vpVerifierError_lift
         )
 }
     
@@ -1884,7 +1911,7 @@ public func FfiConverterTypeDelegatedVerifier_lower(_ value: DelegatedVerifier) 
 
 
 
-public protocol DidMethodUtilsProtocol: AnyObject {
+public protocol DidMethodUtilsProtocol: AnyObject, Sendable {
     
     func didFromJwk(jwk: String) throws  -> String
     
@@ -1905,6 +1932,9 @@ open class DidMethodUtils: DidMethodUtilsProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1969,7 +1999,7 @@ open func vmFromJwk(jwk: String)async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeDidError.lift
+            errorHandler: FfiConverterTypeDidError_lift
         )
 }
     
@@ -2031,7 +2061,7 @@ public func FfiConverterTypeDidMethodUtils_lower(_ value: DidMethodUtils) -> Uns
 
 
 
-public protocol GrantsProtocol: AnyObject {
+public protocol GrantsProtocol: AnyObject, Sendable {
     
 }
 open class Grants: GrantsProtocol, @unchecked Sendable {
@@ -2048,6 +2078,9 @@ open class Grants: GrantsProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2147,7 +2180,7 @@ public func FfiConverterTypeGrants_lower(_ value: Grants) -> UnsafeMutableRawPoi
  * The Holder has the ability to generate Verifiable Presentations from
  * these credentials and share them with Verifiers.
  */
-public protocol HolderProtocol: AnyObject {
+public protocol HolderProtocol: AnyObject, Sendable {
     
     /**
      * Given an authorization request URL, return a permission request,
@@ -2181,6 +2214,9 @@ open class Holder: HolderProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2217,7 +2253,7 @@ public convenience init(vdcCollection: VdcCollection, trustedDids: [String], sig
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeHolder_lift,
-            errorHandler: FfiConverterTypeOID4VPError.lift
+            errorHandler: FfiConverterTypeOID4VPError_lift
         )
         
         .uniffiClonePointer()
@@ -2251,7 +2287,7 @@ public static func newWithCredentials(providedCredentials: [ParsedCredential], t
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeHolder_lift,
-            errorHandler: FfiConverterTypeOID4VPError.lift
+            errorHandler: FfiConverterTypeOID4VPError_lift
         )
 }
     
@@ -2277,7 +2313,7 @@ open func authorizationRequest(req: AuthRequest)async throws  -> PermissionReque
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypePermissionRequest_lift,
-            errorHandler: FfiConverterTypeOID4VPError.lift
+            errorHandler: FfiConverterTypeOID4VPError_lift
         )
 }
     
@@ -2294,7 +2330,7 @@ open func submitPermissionResponse(response: PermissionResponse)async throws  ->
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeUrl.lift,
-            errorHandler: FfiConverterTypeOID4VPError.lift
+            errorHandler: FfiConverterTypeOID4VPError_lift
         )
 }
     
@@ -2364,7 +2400,7 @@ public func FfiConverterTypeHolder_lower(_ value: Holder) -> UnsafeMutableRawPoi
  * `Arc` is wrapped with `IArc` to facilitate trait implementation from
  * `openidconnect` library used by request builders and client on `oid4vci-rs`.
  */
-public protocol IHttpClientProtocol: AnyObject {
+public protocol IHttpClientProtocol: AnyObject, Sendable {
     
 }
 /**
@@ -2389,6 +2425,9 @@ open class IHttpClient: IHttpClientProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2498,7 +2537,7 @@ public func FfiConverterTypeIHttpClient_lower(_ value: IHttpClient) -> UnsafeMut
 
 
 
-public protocol InProcessRecordProtocol: AnyObject {
+public protocol InProcessRecordProtocol: AnyObject, Sendable {
     
 }
 open class InProcessRecord: InProcessRecordProtocol, @unchecked Sendable {
@@ -2515,6 +2554,9 @@ open class InProcessRecord: InProcessRecordProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2608,7 +2650,7 @@ public func FfiConverterTypeInProcessRecord_lower(_ value: InProcessRecord) -> U
 
 
 
-public protocol InProgressRequest180137Protocol: AnyObject {
+public protocol InProgressRequest180137Protocol: AnyObject, Sendable {
     
     func matches()  -> [RequestMatch180137]
     
@@ -2629,6 +2671,9 @@ open class InProgressRequest180137: InProgressRequest180137Protocol, @unchecked 
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2684,7 +2729,7 @@ open func respond(approvedResponse: ApprovedResponse180137)async throws  -> Url?
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeUrl.lift,
-            errorHandler: FfiConverterTypeOID4VP180137Error.lift
+            errorHandler: FfiConverterTypeOID4VP180137Error_lift
         )
 }
     
@@ -2746,7 +2791,7 @@ public func FfiConverterTypeInProgressRequest180137_lower(_ value: InProgressReq
 
 
 
-public protocol IssuanceServiceClientProtocol: AnyObject {
+public protocol IssuanceServiceClientProtocol: AnyObject, Sendable {
     
     /**
      * Checks the status of an issuance request
@@ -2788,6 +2833,9 @@ open class IssuanceServiceClient: IssuanceServiceClientProtocol, @unchecked Send
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2861,7 +2909,7 @@ open func checkStatus(issuanceId: String, walletAttestation: String)async throws
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeCheckStatusResponse_lift,
-            errorHandler: FfiConverterTypeIssuanceServiceError.lift
+            errorHandler: FfiConverterTypeIssuanceServiceError_lift
         )
 }
     
@@ -2888,7 +2936,7 @@ open func newIssuance(walletAttestation: String)async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeIssuanceServiceError.lift
+            errorHandler: FfiConverterTypeIssuanceServiceError_lift
         )
 }
     
@@ -2950,7 +2998,7 @@ public func FfiConverterTypeIssuanceServiceClient_lower(_ value: IssuanceService
 
 
 
-public protocol JsonLdPresentationBuilderProtocol: AnyObject {
+public protocol JsonLdPresentationBuilderProtocol: AnyObject, Sendable {
     
     func issuePresentation(credentials: [ParsedCredential]) async throws  -> String
     
@@ -2969,6 +3017,9 @@ open class JsonLdPresentationBuilder: JsonLdPresentationBuilderProtocol, @unchec
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3031,7 +3082,7 @@ open func issuePresentation(credentials: [ParsedCredential])async throws  -> Str
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypePresentationBuilderError.lift
+            errorHandler: FfiConverterTypePresentationBuilderError_lift
         )
 }
     
@@ -3096,7 +3147,7 @@ public func FfiConverterTypeJsonLdPresentationBuilder_lower(_ value: JsonLdPrese
 /**
  * A verifiable credential secured as JSON.
  */
-public protocol JsonVcProtocol: AnyObject {
+public protocol JsonVcProtocol: AnyObject, Sendable {
     
     /**
      * Access the W3C VCDM credential as a JSON encoded UTF-8 string.
@@ -3153,6 +3204,9 @@ open class JsonVc: JsonVcProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3258,7 +3312,7 @@ open func status()async throws  -> Status  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeStatus_lift,
-            errorHandler: FfiConverterTypeStatusListError.lift
+            errorHandler: FfiConverterTypeStatusListError_lift
         )
 }
     
@@ -3354,7 +3408,7 @@ public func FfiConverterTypeJsonVc_lower(_ value: JsonVc) -> UnsafeMutableRawPoi
 /**
  * A verifiable credential secured as a JWT.
  */
-public protocol JwtVcProtocol: AnyObject {
+public protocol JwtVcProtocol: AnyObject, Sendable {
     
     /**
      * Access the W3C VCDM credential as a JSON encoded UTF-8 string.
@@ -3415,6 +3469,9 @@ open class JwtVc: JwtVcProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3619,7 +3676,7 @@ public func FfiConverterTypeJwtVc_lower(_ value: JwtVc) -> UnsafeMutableRawPoint
 /**
  * An interface that can provide access to cryptographic keypairs from the native crypto API.
  */
-public protocol KeyStore: AnyObject {
+public protocol KeyStore: AnyObject, Sendable {
     
     /**
      * Retrieve a cryptographic keypair by alias. The cryptographic key must be usable for
@@ -3645,6 +3702,9 @@ open class KeyStoreImpl: KeyStore, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3802,7 +3862,7 @@ public func FfiConverterTypeKeyStore_lower(_ value: KeyStore) -> UnsafeMutableRa
 
 
 
-public protocol MdlSessionManagerProtocol: AnyObject {
+public protocol MdlSessionManagerProtocol: AnyObject, Sendable {
     
 }
 open class MdlSessionManager: MdlSessionManagerProtocol, @unchecked Sendable {
@@ -3819,6 +3879,9 @@ open class MdlSessionManager: MdlSessionManagerProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3912,7 +3975,7 @@ public func FfiConverterTypeMDLSessionManager_lower(_ value: MdlSessionManager) 
 
 
 
-public protocol MdlPresentationSessionProtocol: AnyObject {
+public protocol MdlPresentationSessionProtocol: AnyObject, Sendable {
     
     /**
      * Constructs the response to be sent from the holder to the reader containing
@@ -3968,6 +4031,9 @@ open class MdlPresentationSession: MdlPresentationSessionProtocol, @unchecked Se
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4133,7 +4199,7 @@ public func FfiConverterTypeMdlPresentationSession_lower(_ value: MdlPresentatio
 
 
 
-public protocol MdocProtocol: AnyObject {
+public protocol MdocProtocol: AnyObject, Sendable {
     
     /**
      * Simple representation of mdoc namespace and data elements for display in the UI.
@@ -4167,6 +4233,9 @@ open class Mdoc: MdocProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4340,7 +4409,7 @@ public func FfiConverterTypeMdoc_lower(_ value: Mdoc) -> UnsafeMutableRawPointer
  *
  * Notably this supports requests which use the URI scheme `mdoc-openid4vp://`.
  */
-public protocol Oid4vp180137Protocol: AnyObject {
+public protocol Oid4vp180137Protocol: AnyObject, Sendable {
     
     func processRequest(url: Url) async throws  -> InProgressRequest180137
     
@@ -4364,6 +4433,9 @@ open class Oid4vp180137: Oid4vp180137Protocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4421,7 +4493,7 @@ open func processRequest(url: Url)async throws  -> InProgressRequest180137  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeInProgressRequest180137_lift,
-            errorHandler: FfiConverterTypeOID4VP180137Error.lift
+            errorHandler: FfiConverterTypeOID4VP180137Error_lift
         )
 }
     
@@ -4483,7 +4555,7 @@ public func FfiConverterTypeOID4VP180137_lower(_ value: Oid4vp180137) -> UnsafeM
 
 
 
-public protocol Oid4vciProtocol: AnyObject {
+public protocol Oid4vciProtocol: AnyObject, Sendable {
     
     func clearContextMap() throws 
     
@@ -4516,6 +4588,9 @@ open class Oid4vci: Oid4vciProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4607,7 +4682,7 @@ open func exchangeCredential(proofsOfPossession: [String], options: Oid4vciExcha
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeCredentialResponse.lift,
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
     
@@ -4624,7 +4699,7 @@ open func exchangeToken()async throws  -> String?  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionString.lift,
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
     
@@ -4648,7 +4723,7 @@ open func initiate(baseUrl: String, clientId: String, redirectUrl: String)async 
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
     
@@ -4671,7 +4746,7 @@ open func initiateWithOffer(credentialOffer: String, clientId: String, redirectU
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
     
@@ -4740,7 +4815,7 @@ public func FfiConverterTypeOid4vci_lower(_ value: Oid4vci) -> UnsafeMutableRawP
 
 
 
-public protocol Oid4vciMetadataProtocol: AnyObject {
+public protocol Oid4vciMetadataProtocol: AnyObject, Sendable {
     
     func authorizationServers()  -> [String]?
     
@@ -4771,6 +4846,9 @@ open class Oid4vciMetadata: Oid4vciMetadataProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4913,7 +4991,7 @@ public func FfiConverterTypeOid4vciMetadata_lower(_ value: Oid4vciMetadata) -> U
 
 
 
-public protocol Oid4vciSessionProtocol: AnyObject {
+public protocol Oid4vciSessionProtocol: AnyObject, Sendable {
     
 }
 open class Oid4vciSession: Oid4vciSessionProtocol, @unchecked Sendable {
@@ -4930,6 +5008,9 @@ open class Oid4vciSession: Oid4vciSessionProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5026,7 +5107,7 @@ public func FfiConverterTypeOid4vciSession_lower(_ value: Oid4vciSession) -> Uns
 /**
  * A credential that has been parsed as a known variant.
  */
-public protocol ParsedCredentialProtocol: AnyObject {
+public protocol ParsedCredentialProtocol: AnyObject, Sendable {
     
     /**
      * Return the credential as an CWT, if it is of that format.
@@ -5096,6 +5177,9 @@ open class ParsedCredential: ParsedCredentialProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5387,7 +5471,7 @@ public func FfiConverterTypeParsedCredential_lower(_ value: ParsedCredential) ->
 
 
 
-public protocol PermissionRequestProtocol: AnyObject {
+public protocol PermissionRequestProtocol: AnyObject, Sendable {
     
     /**
      * Return the client ID for the authorization request.
@@ -5448,6 +5532,9 @@ open class PermissionRequest: PermissionRequestProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5516,7 +5603,7 @@ open func createPermissionResponse(selectedCredentials: [PresentableCredential],
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypePermissionResponse_lift,
-            errorHandler: FfiConverterTypeOID4VPError.lift
+            errorHandler: FfiConverterTypeOID4VPError_lift
         )
 }
     
@@ -5634,7 +5721,7 @@ public func FfiConverterTypePermissionRequest_lower(_ value: PermissionRequest) 
  * The Requested Fields are created by calling the [PermissionRequest::requested_fields] method, and then
  * explicitly setting the permission to true or false, based on the holder's decision.
  */
-public protocol PermissionResponseProtocol: AnyObject {
+public protocol PermissionResponseProtocol: AnyObject, Sendable {
     
     /**
      * Return the selected credentials for the permission response.
@@ -5672,6 +5759,9 @@ open class PermissionResponse: PermissionResponseProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5791,7 +5881,7 @@ public func FfiConverterTypePermissionResponse_lower(_ value: PermissionResponse
 /**
  * A credential that has been parsed as a known variant.
  */
-public protocol PresentableCredentialProtocol: AnyObject {
+public protocol PresentableCredentialProtocol: AnyObject, Sendable {
     
     /**
      * Converts to the primitive ParsedCredential type
@@ -5822,6 +5912,9 @@ open class PresentableCredential: PresentableCredentialProtocol, @unchecked Send
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5939,7 +6032,7 @@ public func FfiConverterTypePresentableCredential_lower(_ value: PresentableCred
 /**
  * A viable match for the credential request.
  */
-public protocol RequestMatch180137Protocol: AnyObject {
+public protocol RequestMatch180137Protocol: AnyObject, Sendable {
     
     func credentialId()  -> Uuid
     
@@ -5963,6 +6056,9 @@ open class RequestMatch180137: RequestMatch180137Protocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6070,7 +6166,7 @@ public func FfiConverterTypeRequestMatch180137_lower(_ value: RequestMatch180137
 
 
 
-public protocol RequestedFieldProtocol: AnyObject {
+public protocol RequestedFieldProtocol: AnyObject, Sendable {
     
     /**
      * Return the unique ID for the request field.
@@ -6127,6 +6223,9 @@ open class RequestedField: RequestedFieldProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6303,7 +6402,7 @@ public func FfiConverterTypeRequestedField_lower(_ value: RequestedField) -> Uns
 /**
  * A cryptographic keypair that can be used for signing.
  */
-public protocol SigningKey: AnyObject {
+public protocol SigningKey: AnyObject, Sendable {
     
     /**
      * Generates a public JWK for this key.
@@ -6333,6 +6432,9 @@ open class SigningKeyImpl: SigningKey, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6529,7 +6631,7 @@ public func FfiConverterTypeSigningKey_lower(_ value: SigningKey) -> UnsafeMutab
  * and the purpose is the purpose of the credential, which is used
  * to interpret the value.
  */
-public protocol StatusProtocol: AnyObject {
+public protocol StatusProtocol: AnyObject, Sendable {
     
     /**
      * Return whether the credential status has a message.
@@ -6578,6 +6680,9 @@ open class Status: StatusProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6728,7 +6833,7 @@ public func FfiConverterTypeStatus_lower(_ value: Status) -> UnsafeMutableRawPoi
  * and the purpose is the purpose of the credential, which is used
  * to interpret the value.
  */
-public protocol Status20240406Protocol: AnyObject {
+public protocol Status20240406Protocol: AnyObject, Sendable {
     
     /**
      * Return whether the credential status has a message.
@@ -6777,6 +6882,9 @@ open class Status20240406: Status20240406Protocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6932,7 +7040,7 @@ public func FfiConverterTypeStatus20240406_lower(_ value: Status20240406) -> Uns
  * We use the older callback_interface to keep the required version level of our Android API
  * low.
  */
-public protocol StorageManagerInterface: AnyObject {
+public protocol StorageManagerInterface: AnyObject, Sendable {
     
     /**
      * Function: add
@@ -6998,6 +7106,9 @@ open class StorageManagerInterfaceImpl: StorageManagerInterface, @unchecked Send
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -7056,7 +7167,7 @@ open func add(key: Key, value: Value)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeStorageManagerError.lift
+            errorHandler: FfiConverterTypeStorageManagerError_lift
         )
 }
     
@@ -7079,7 +7190,7 @@ open func get(key: Key)async throws  -> Value?  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeValue.lift,
-            errorHandler: FfiConverterTypeStorageManagerError.lift
+            errorHandler: FfiConverterTypeStorageManagerError_lift
         )
 }
     
@@ -7101,7 +7212,7 @@ open func list()async throws  -> [Key]  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeKey.lift,
-            errorHandler: FfiConverterTypeStorageManagerError.lift
+            errorHandler: FfiConverterTypeStorageManagerError_lift
         )
 }
     
@@ -7126,7 +7237,7 @@ open func remove(key: Key)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeStorageManagerError.lift
+            errorHandler: FfiConverterTypeStorageManagerError_lift
         )
 }
     
@@ -7383,7 +7494,7 @@ public func FfiConverterTypeStorageManagerInterface_lower(_ value: StorageManage
 
 
 
-public protocol SyncHttpClient: AnyObject {
+public protocol SyncHttpClient: AnyObject, Sendable {
     
     func httpClient(request: HttpRequest) throws  -> HttpResponse
     
@@ -7402,6 +7513,9 @@ open class SyncHttpClientImpl: SyncHttpClient, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -7555,7 +7669,7 @@ public func FfiConverterTypeSyncHttpClient_lower(_ value: SyncHttpClient) -> Uns
 
 
 
-public protocol TokenResponseProtocol: AnyObject {
+public protocol TokenResponseProtocol: AnyObject, Sendable {
     
 }
 open class TokenResponse: TokenResponseProtocol, @unchecked Sendable {
@@ -7572,6 +7686,9 @@ open class TokenResponse: TokenResponseProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -7665,7 +7782,7 @@ public func FfiConverterTypeTokenResponse_lower(_ value: TokenResponse) -> Unsaf
 
 
 
-public protocol Vcdm2SdJwtProtocol: AnyObject {
+public protocol Vcdm2SdJwtProtocol: AnyObject, Sendable {
     
     /**
      * Return the ID for the SdJwt instance.
@@ -7709,6 +7826,9 @@ open class Vcdm2SdJwt: Vcdm2SdJwtProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -7814,7 +7934,7 @@ open func status()async throws  -> [Status20240406]  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeStatus20240406.lift,
-            errorHandler: FfiConverterTypeStatusListError.lift
+            errorHandler: FfiConverterTypeStatusListError_lift
         )
 }
     
@@ -7892,7 +8012,7 @@ public func FfiConverterTypeVCDM2SdJwt_lower(_ value: Vcdm2SdJwt) -> UnsafeMutab
  *
  * This is the main interface to credentials.
  */
-public protocol VdcCollectionProtocol: AnyObject {
+public protocol VdcCollectionProtocol: AnyObject, Sendable {
     
     /**
      * Add a credential to the set.
@@ -7944,6 +8064,9 @@ open class VdcCollection: VdcCollectionProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -8006,7 +8129,7 @@ open func add(credential: Credential)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVdcCollectionError.lift
+            errorHandler: FfiConverterTypeVdcCollectionError_lift
         )
 }
     
@@ -8026,7 +8149,7 @@ open func allEntries()async throws  -> [Uuid]  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeUuid.lift,
-            errorHandler: FfiConverterTypeVdcCollectionError.lift
+            errorHandler: FfiConverterTypeVdcCollectionError_lift
         )
 }
     
@@ -8046,7 +8169,7 @@ open func allEntriesByType(ctype: CredentialType)async throws  -> [Uuid]  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeUuid.lift,
-            errorHandler: FfiConverterTypeVdcCollectionError.lift
+            errorHandler: FfiConverterTypeVdcCollectionError_lift
         )
 }
     
@@ -8066,7 +8189,7 @@ open func delete(id: Uuid)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVdcCollectionError.lift
+            errorHandler: FfiConverterTypeVdcCollectionError_lift
         )
 }
     
@@ -8107,7 +8230,7 @@ open func get(id: Uuid)async throws  -> Credential?  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeCredential.lift,
-            errorHandler: FfiConverterTypeVdcCollectionError.lift
+            errorHandler: FfiConverterTypeVdcCollectionError_lift
         )
 }
     
@@ -8169,7 +8292,7 @@ public func FfiConverterTypeVdcCollection_lower(_ value: VdcCollection) -> Unsaf
 
 
 
-public protocol WalletServiceClientProtocol: AnyObject {
+public protocol WalletServiceClientProtocol: AnyObject, Sendable {
     
     /**
      * Helper method to get an authorization header with the current token
@@ -8213,6 +8336,9 @@ open class WalletServiceClient: WalletServiceClientProtocol, @unchecked Sendable
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -8329,7 +8455,7 @@ open func nonce()async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeWalletServiceError.lift
+            errorHandler: FfiConverterTypeWalletServiceError_lift
         )
 }
     
@@ -10076,7 +10202,7 @@ extension AuthenticationStatus: Equatable, Hashable {}
 
 
 
-public enum CborLdEncodingError {
+public enum CborLdEncodingError: Swift.Error {
 
     
     
@@ -10392,7 +10518,7 @@ extension ClaimValue: Equatable, Hashable {}
 
 
 
-public enum CredentialDecodingError {
+public enum CredentialDecodingError: Swift.Error {
 
     
     
@@ -10535,7 +10661,7 @@ extension CredentialDecodingError: Foundation.LocalizedError {
 
 
 
-public enum CredentialEncodingError {
+public enum CredentialEncodingError: Swift.Error {
 
     
     
@@ -10756,7 +10882,7 @@ extension CredentialFormat: Equatable, Hashable {}
 
 
 
-public enum CredentialPresentationError {
+public enum CredentialPresentationError: Swift.Error {
 
     
     
@@ -10839,7 +10965,7 @@ extension CredentialPresentationError: Foundation.LocalizedError {
 
 
 
-public enum CryptoError {
+public enum CryptoError: Swift.Error {
 
     
     
@@ -10912,7 +11038,7 @@ extension CryptoError: Foundation.LocalizedError {
 
 
 
-public enum CwtError {
+public enum CwtError: Swift.Error {
 
     
     
@@ -11264,7 +11390,7 @@ extension DelegatedVerifierStatus: Equatable, Hashable {}
 
 
 
-public enum DidError {
+public enum DidError: Swift.Error {
 
     
     
@@ -11428,7 +11554,7 @@ extension DidMethod: Equatable, Hashable {}
 
 
 
-public enum HttpClientError {
+public enum HttpClientError: Swift.Error {
 
     
     
@@ -11566,7 +11692,7 @@ extension HttpClientError: Foundation.LocalizedError {
 /**
  * Represents errors that may occur during issuance operations
  */
-public enum IssuanceServiceError {
+public enum IssuanceServiceError: Swift.Error {
 
     
     
@@ -11696,7 +11822,7 @@ extension IssuanceServiceError: Foundation.LocalizedError {
 
 
 
-public enum JsonVcEncodingError {
+public enum JsonVcEncodingError: Swift.Error {
 
     
     
@@ -11765,7 +11891,7 @@ extension JsonVcEncodingError: Foundation.LocalizedError {
 
 
 
-public enum JsonVcInitError {
+public enum JsonVcInitError: Swift.Error {
 
     
     
@@ -11852,7 +11978,7 @@ extension JsonVcInitError: Foundation.LocalizedError {
 
 
 
-public enum JwtVcInitError {
+public enum JwtVcInitError: Swift.Error {
 
     
     
@@ -11963,7 +12089,7 @@ extension JwtVcInitError: Foundation.LocalizedError {
 
 
 
-public enum KeyTransformationError {
+public enum KeyTransformationError: Swift.Error {
 
     
     
@@ -12066,7 +12192,7 @@ extension KeyTransformationError: Foundation.LocalizedError {
 
 
 
-public enum MdlReaderResponseError {
+public enum MdlReaderResponseError: Swift.Error {
 
     
     
@@ -12163,7 +12289,7 @@ extension MdlReaderResponseError: Foundation.LocalizedError {
 
 
 
-public enum MdlReaderResponseSerializeError {
+public enum MdlReaderResponseSerializeError: Swift.Error {
 
     
     
@@ -12236,7 +12362,7 @@ extension MdlReaderResponseSerializeError: Foundation.LocalizedError {
 
 
 
-public enum MdlReaderSessionError {
+public enum MdlReaderSessionError: Swift.Error {
 
     
     
@@ -12412,7 +12538,7 @@ extension MDocItem: Equatable, Hashable {}
 
 
 
-public enum MdlUtilError {
+public enum MdlUtilError: Swift.Error {
 
     
     
@@ -12485,7 +12611,7 @@ extension MdlUtilError: Foundation.LocalizedError {
 
 
 
-public enum MdocEncodingError {
+public enum MdocEncodingError: Swift.Error {
 
     
     
@@ -12554,7 +12680,7 @@ extension MdocEncodingError: Foundation.LocalizedError {
 
 
 
-public enum MdocInitError {
+public enum MdocInitError: Swift.Error {
 
     
     
@@ -12669,7 +12795,7 @@ extension MdocInitError: Foundation.LocalizedError {
 
 
 
-public enum Oid4vp180137Error {
+public enum Oid4vp180137Error: Swift.Error {
 
     
     
@@ -12766,7 +12892,7 @@ extension Oid4vp180137Error: Foundation.LocalizedError {
  * The [OID4VPError] enum represents the errors that can occur
  * when using the oid4vp foreign library.
  */
-public enum Oid4vpError {
+public enum Oid4vpError: Swift.Error {
 
     
     
@@ -13145,7 +13271,7 @@ extension Oid4vpError: Foundation.LocalizedError {
 
 
 
-public enum Oid4vciError {
+public enum Oid4vciError: Swift.Error {
 
     
     
@@ -13306,7 +13432,7 @@ extension Oid4vciError: Foundation.LocalizedError {
 
 
 
-public enum Oid4vpVerifierError {
+public enum Oid4vpVerifierError: Swift.Error {
 
     
     
@@ -13472,7 +13598,7 @@ extension Outcome: Equatable, Hashable {}
 
 
 
-public enum PermissionRequestError {
+public enum PermissionRequestError: Swift.Error {
 
     
     
@@ -13666,7 +13792,7 @@ extension PermissionRequestError: Foundation.LocalizedError {
 
 
 
-public enum PopError {
+public enum PopError: Swift.Error {
 
     
     
@@ -13771,7 +13897,7 @@ extension PopError: Foundation.LocalizedError {
 
 
 
-public enum PresentationBuilderError {
+public enum PresentationBuilderError: Swift.Error {
 
     
     
@@ -13900,7 +14026,7 @@ extension PresentationBuilderError: Foundation.LocalizedError {
 
 
 
-public enum PresentationError {
+public enum PresentationError: Swift.Error {
 
     
     
@@ -14013,7 +14139,7 @@ extension PresentationError: Foundation.LocalizedError {
 
 
 
-public enum RequestError {
+public enum RequestError: Swift.Error {
 
     
     
@@ -14086,7 +14212,7 @@ extension RequestError: Foundation.LocalizedError {
 
 
 
-public enum ResponseError {
+public enum ResponseError: Swift.Error {
 
     
     
@@ -14165,7 +14291,7 @@ extension ResponseError: Foundation.LocalizedError {
 
 
 
-public enum SdJwtError {
+public enum SdJwtError: Swift.Error {
 
     
     
@@ -14284,7 +14410,7 @@ extension SdJwtError: Foundation.LocalizedError {
 
 
 
-public enum SessionError {
+public enum SessionError: Swift.Error {
 
     
     
@@ -14357,7 +14483,7 @@ extension SessionError: Foundation.LocalizedError {
 
 
 
-public enum SignatureError {
+public enum SignatureError: Swift.Error {
 
     
     
@@ -14446,7 +14572,7 @@ extension SignatureError: Foundation.LocalizedError {
 
 
 
-public enum StatusListError {
+public enum StatusListError: Swift.Error {
 
     
     
@@ -14530,7 +14656,7 @@ extension StatusListError: Foundation.LocalizedError {
  *
  * Represents errors that may occur during storage management operations
  */
-public enum StorageManagerError {
+public enum StorageManagerError: Swift.Error {
 
     
     
@@ -14640,7 +14766,7 @@ extension StorageManagerError: Foundation.LocalizedError {
 
 
 
-public enum TerminationError {
+public enum TerminationError: Swift.Error {
 
     
     
@@ -14713,7 +14839,7 @@ extension TerminationError: Foundation.LocalizedError {
 
 
 
-public enum VcbVerificationError {
+public enum VcbVerificationError: Swift.Error {
 
     
     
@@ -14792,7 +14918,7 @@ extension VcbVerificationError: Foundation.LocalizedError {
 
 
 
-public enum VcVerificationError {
+public enum VcVerificationError: Swift.Error {
 
     
     
@@ -14865,7 +14991,7 @@ extension VcVerificationError: Foundation.LocalizedError {
 
 
 
-public enum VpError {
+public enum VpError: Swift.Error {
 
     
     
@@ -15027,7 +15153,7 @@ extension VcdmVersion: Equatable, Hashable {}
 
 
 
-public enum VdcCollectionError {
+public enum VdcCollectionError: Swift.Error {
 
     
     
@@ -15217,7 +15343,7 @@ extension VerificationResult: Equatable, Hashable {}
 
 
 
-public enum WalletServiceError {
+public enum WalletServiceError: Swift.Error {
 
     
     
@@ -15371,7 +15497,7 @@ extension WalletServiceError: Foundation.LocalizedError {
 
 
 
-public protocol Crypto: AnyObject {
+public protocol Crypto: AnyObject, Sendable {
     
     func p256Verify(certificateDer: Data, payload: Data, signature: Data)  -> VerificationResult
     
@@ -15504,7 +15630,7 @@ public func FfiConverterCallbackInterfaceCrypto_lower(_ v: Crypto) -> UInt64 {
  * For example, in the case of `JwtVc` credential format,
  * the signing payload consists of the JWT header and payload (JWS).
  */
-public protocol PresentationSigner: AnyObject {
+public protocol PresentationSigner: AnyObject, Sendable {
     
     /**
      * Sign the payload with the private key and return the signature.
@@ -17617,7 +17743,7 @@ public func cborLdEncodeToBytes(credentialStr: String, loader: [String: String]?
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterData.lift,
-            errorHandler: FfiConverterTypeCborLdEncodingError.lift
+            errorHandler: FfiConverterTypeCborLdEncodingError_lift
         )
 }
 public func decodeRevealSdJwt(input: String)throws  -> String  {
@@ -17666,7 +17792,7 @@ public func generatePopPrepare(audience: String, nonce: String?, didMethod: DidM
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterData.lift,
-            errorHandler: FfiConverterTypePopError.lift
+            errorHandler: FfiConverterTypePopError_lift
         )
 }
 /**
@@ -17727,7 +17853,7 @@ public func initializeMdlPresentation(mdocId: Uuid, uuid: Uuid, storageManager: 
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeMdlPresentationSession_lift,
-            errorHandler: FfiConverterTypeSessionError.lift
+            errorHandler: FfiConverterTypeSessionError_lift
         )
 }
 /**
@@ -17773,7 +17899,7 @@ public func oid4vciExchangeCredential(session: Oid4vciSession, proofsOfPossessio
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeCredentialResponse.lift,
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
 public func oid4vciExchangeToken(session: Oid4vciSession, httpClient: IHttpClient)async throws  -> String?  {
@@ -17787,7 +17913,7 @@ public func oid4vciExchangeToken(session: Oid4vciSession, httpClient: IHttpClien
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionString.lift,
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
 public func oid4vciGetMetadata(session: Oid4vciSession)throws  -> Oid4vciMetadata  {
@@ -17808,7 +17934,7 @@ public func oid4vciInitiate(baseUrl: String, clientId: String, redirectUrl: Stri
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeOid4vciSession_lift,
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
 public func oid4vciInitiateWithOffer(credentialOffer: String, clientId: String, redirectUrl: String, httpClient: IHttpClient)async throws  -> Oid4vciSession  {
@@ -17822,7 +17948,7 @@ public func oid4vciInitiateWithOffer(credentialOffer: String, clientId: String, 
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeOid4vciSession_lift,
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
 public func vcToSignedVp(vc: String, keyStr: String)async throws  -> String  {
@@ -17836,7 +17962,7 @@ public func vcToSignedVp(vc: String, keyStr: String)async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeVPError.lift
+            errorHandler: FfiConverterTypeVPError_lift
         )
 }
 public func verifiedResponseAsJsonString(response: MdlReaderResponseData)throws  -> String  {
@@ -17857,7 +17983,7 @@ public func verifyJsonVcString(json: String)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVCVerificationError.lift
+            errorHandler: FfiConverterTypeVCVerificationError_lift
         )
 }
 public func verifyJwtVp(jwtVp: String)async throws   {
@@ -17871,7 +17997,7 @@ public func verifyJwtVp(jwtVp: String)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVPError.lift
+            errorHandler: FfiConverterTypeVPError_lift
         )
 }
 public func verifyPdf417Barcode(payload: String)async throws   {
@@ -17885,7 +18011,7 @@ public func verifyPdf417Barcode(payload: String)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVCBVerificationError.lift
+            errorHandler: FfiConverterTypeVCBVerificationError_lift
         )
 }
 public func verifyVcbQrcodeAgainstMrz(mrzPayload: String, qrPayload: String)async throws   {
@@ -17899,7 +18025,7 @@ public func verifyVcbQrcodeAgainstMrz(mrzPayload: String, qrPayload: String)asyn
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVCBVerificationError.lift
+            errorHandler: FfiConverterTypeVCBVerificationError_lift
         )
 }
 

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -13917,6 +13917,12 @@ public enum PresentationBuilderError: Swift.Error {
     
     case Context(message: String)
     
+    case SignatureError(message: String)
+    
+    case SigningSuitePickError(message: String)
+    
+    case UnsupportedCredentialFormat(message: String)
+    
 }
 
 
@@ -13965,6 +13971,18 @@ public struct FfiConverterTypePresentationBuilderError: FfiConverterRustBuffer {
             message: try FfiConverterString.read(from: &buf)
         )
         
+        case 9: return .SignatureError(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 10: return .SigningSuitePickError(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 11: return .UnsupportedCredentialFormat(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
 
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -13992,6 +14010,12 @@ public struct FfiConverterTypePresentationBuilderError: FfiConverterRustBuffer {
             writeInt(&buf, Int32(7))
         case .Context(_ /* message is ignored*/):
             writeInt(&buf, Int32(8))
+        case .SignatureError(_ /* message is ignored*/):
+            writeInt(&buf, Int32(9))
+        case .SigningSuitePickError(_ /* message is ignored*/):
+            writeInt(&buf, Int32(10))
+        case .UnsupportedCredentialFormat(_ /* message is ignored*/):
+            writeInt(&buf, Int32(11))
 
         
         }

--- a/rust/src/credential/json_vc.rs
+++ b/rust/src/credential/json_vc.rs
@@ -61,7 +61,7 @@ pub enum JsonVcEncodingError {
 /// A verifiable credential secured as JSON.
 pub struct JsonVc {
     id: Uuid,
-    raw: Json,
+    pub(crate) raw: Json,
     credential_string: String,
     parsed: AnyJsonCredential,
     key_alias: Option<KeyAlias>,

--- a/rust/src/credential/jwt_vc.rs
+++ b/rust/src/credential/jwt_vc.rs
@@ -31,7 +31,7 @@ use uuid::Uuid;
 /// A verifiable credential secured as a JWT.
 pub struct JwtVc {
     id: Uuid,
-    jws: JwsString,
+    pub(crate) jws: JwsString,
     credential: JsonCredential,
     credential_string: String,
     header_json_string: String,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -12,6 +12,7 @@ pub mod logger;
 pub mod mdl;
 pub mod oid4vci;
 pub mod oid4vp;
+pub mod presentation;
 pub mod proof_of_possession;
 pub mod storage_manager;
 #[cfg(test)]

--- a/rust/src/oid4vp/holder.rs
+++ b/rust/src/oid4vp/holder.rs
@@ -462,6 +462,7 @@ pub(crate) mod tests {
             DidMethod::Key
                 .vm_from_jwk(&self.jwk())
                 .await
+                // SAFETY: The JWK should always be well-formed and this method should not panic.
                 .unwrap()
                 .id
                 .to_string()

--- a/rust/src/oid4vp/holder.rs
+++ b/rust/src/oid4vp/holder.rs
@@ -459,11 +459,19 @@ pub(crate) mod tests {
         }
 
         async fn verification_method(&self) -> String {
-            DidMethod::Key.vm_from_jwk(&self.jwk()).await.unwrap()
+            DidMethod::Key
+                .vm_from_jwk(&self.jwk())
+                .await
+                .unwrap()
+                .id
+                .to_string()
         }
 
         fn did(&self) -> String {
-            DidMethod::Key.did_from_jwk(&self.jwk()).unwrap()
+            DidMethod::Key
+                .did_from_jwk(&self.jwk())
+                .unwrap()
+                .to_string()
         }
 
         fn cryptosuite(&self) -> CryptosuiteString {

--- a/rust/src/oid4vp/holder.rs
+++ b/rust/src/oid4vp/holder.rs
@@ -471,6 +471,7 @@ pub(crate) mod tests {
         fn did(&self) -> String {
             DidMethod::Key
                 .did_from_jwk(&self.jwk())
+                // SAFETY: The JWK should always be well-formed and this method should not panic.
                 .unwrap()
                 .to_string()
         }

--- a/rust/src/presentation/error.rs
+++ b/rust/src/presentation/error.rs
@@ -24,4 +24,13 @@ pub enum PresentationBuilderError {
 
     #[error("Context: {_0}")]
     Context(String),
+
+    #[error("SignatureError: {_0}")]
+    SignatureError(#[from] ssi::claims::SignatureError),
+
+    #[error("Unable to pick signing suite for verification method")]
+    SigningSuitePickError,
+
+    #[error("Unsupported credential format for json-ld presentation")]
+    UnsupportedCredentialFormat,
 }

--- a/rust/src/presentation/error.rs
+++ b/rust/src/presentation/error.rs
@@ -1,0 +1,27 @@
+#[derive(thiserror::Error, uniffi::Error, Debug)]
+#[uniffi(flat_error)]
+pub enum PresentationBuilderError {
+    #[error("DidError: {_0}")]
+    DidError(#[from] crate::did::DidError),
+
+    #[error("ParseError: {_0}")]
+    UrlParseError(#[from] url::ParseError),
+
+    #[error("InvalidDIDURL: {_0}")]
+    DidUrlParseError(#[from] ssi::dids::InvalidDIDURL<String>),
+
+    #[error("SerializationError: {_0}")]
+    SerializationError(#[from] serde_json::Error),
+
+    #[error("ConversionError: {_0}")]
+    ConversionError(#[from] oid4vci::proof_of_possession::ConversionError),
+
+    #[error("InvalidIri: {_0}")]
+    IriBufError(#[from] ssi::json_ld::iref::InvalidIri<std::string::String>),
+
+    #[error("InvalidUri: {_0}")]
+    UriBufError(#[from] ssi::json_ld::iref::InvalidUri<std::string::String>),
+
+    #[error("Context: {_0}")]
+    Context(String),
+}

--- a/rust/src/presentation/mod.rs
+++ b/rust/src/presentation/mod.rs
@@ -1,0 +1,188 @@
+use std::{collections::HashMap, str::FromStr, sync::Arc};
+
+use serde::de::{Deserialize, IntoDeserializer};
+use ssi::{
+    claims::{data_integrity::AnyProtocol, MessageSignatureError, SignatureEnvironment},
+    crypto::AlgorithmInstance,
+    dids::{AnyDidMethod, VerificationMethodDIDResolver},
+    json_ld::{iref::UriBuf, ContextLoader, IriBuf},
+    prelude::{AnySuite, CryptographicSuite, ProofOptions},
+    verification_methods::{protocol::WithProtocol, MessageSigner, ProofPurpose},
+};
+
+pub use error::*;
+
+use crate::{
+    credential::{ParsedCredential, ParsedCredentialInner},
+    crypto::CryptoCurveUtils,
+    oid4vp::PresentationSigner,
+};
+
+mod error;
+
+#[derive(Debug, Clone, uniffi::Object)]
+pub struct JsonLdPresentationBuilder {
+    pub(crate) id: String,
+    pub(crate) holder: String,
+
+    pub(crate) proof_purpose: ProofPurpose,
+    pub(crate) challenge: Option<String>,
+    pub(crate) domain: Option<String>,
+
+    pub(crate) signer: Arc<Box<dyn PresentationSigner>>,
+    pub(crate) context_map: Option<HashMap<String, String>>,
+}
+
+#[uniffi::export]
+impl JsonLdPresentationBuilder {
+    #[uniffi::constructor(name = "new")]
+    fn new(
+        id: String,
+        holder: String,
+
+        proof_purpose: String,
+        challenge: Option<String>,
+        domain: Option<String>,
+
+        signer: Box<dyn PresentationSigner>,
+        context_map: Option<HashMap<String, String>>,
+    ) -> Arc<Self> {
+        let proof_purpose: Result<ProofPurpose, serde::de::value::Error> =
+            ProofPurpose::deserialize(proof_purpose.into_deserializer());
+        Self {
+            id,
+            holder,
+            proof_purpose: proof_purpose.unwrap(),
+            challenge,
+            domain,
+            signer: Arc::new(signer),
+            context_map,
+        }
+        .into()
+    }
+
+    pub async fn issue_presentation(
+        &self,
+        credentials: Vec<Arc<ParsedCredential>>,
+    ) -> Result<String, PresentationBuilderError> {
+        let key = serde_json::from_str(&self.signer.jwk())?;
+        let vm = self.signer.verification_method().await;
+
+        let id = UriBuf::from_str(&self.id)?;
+        let holder = UriBuf::from_str(&self.holder)?;
+
+        let vp = ssi::claims::vc::v1::JsonPresentation::new(
+            Some(id),
+            Some(holder),
+            credentials
+                .into_iter()
+                .map(|c| match &c.inner {
+                    ParsedCredentialInner::MsoMdoc(_) => unimplemented!(),
+                    ParsedCredentialInner::JwtVcJson(jwt_vc_json) => {
+                        serde_json::Value::String(jwt_vc_json.jws.clone().into_string())
+                    }
+                    ParsedCredentialInner::JwtVcJsonLd(jwt_vc_json_ld) => {
+                        serde_json::Value::String(jwt_vc_json_ld.jws.clone().into_string())
+                    }
+                    ParsedCredentialInner::VCDM2SdJwt(_) => unimplemented!(),
+                    ParsedCredentialInner::LdpVc(ldp_vc) => ldp_vc.raw.clone(),
+                    ParsedCredentialInner::Cwt(_) => unimplemented!(),
+                })
+                .collect(),
+        );
+
+        let mut params = ProofOptions::from_method(IriBuf::new(vm)?.into());
+
+        params.proof_purpose = self.proof_purpose;
+        params.challenge = self.challenge.to_owned();
+        params.domains = self.domain.to_owned().map(|d| vec![d]).unwrap_or_default();
+
+        let resolver = VerificationMethodDIDResolver::new(AnyDidMethod::default());
+        let suite = AnySuite::pick(&key, params.verification_method.as_ref()).unwrap();
+
+        let context = self
+            .context_map
+            .clone()
+            .map(|map| ContextLoader::default().with_context_map_from(map))
+            .transpose()
+            .map_err(|e| PresentationBuilderError::Context(format!("{e:?}")))?
+            .unwrap_or_default();
+
+        let vp = suite
+            .sign_with(
+                SignatureEnvironment {
+                    json_ld_loader: context,
+                    eip712_loader: (),
+                },
+                vp,
+                &resolver,
+                self,
+                params,
+                Default::default(),
+            )
+            .await
+            .unwrap();
+
+        Ok(serde_json::to_string(&vp)?)
+    }
+}
+
+impl MessageSigner<WithProtocol<ssi::crypto::Algorithm, AnyProtocol>>
+    for JsonLdPresentationBuilder
+{
+    #[allow(async_fn_in_trait)]
+    async fn sign(
+        self,
+        WithProtocol(alg, _protocol): WithProtocol<AlgorithmInstance, AnyProtocol>,
+        message: &[u8],
+    ) -> Result<Vec<u8>, MessageSignatureError> {
+        if !self.signer.algorithm().is_compatible_with(alg.algorithm()) {
+            return Err(MessageSignatureError::UnsupportedAlgorithm(
+                self.signer.algorithm().to_string(),
+            ));
+        }
+
+        let signature_bytes = self
+            .signer
+            .sign(message.to_vec())
+            .await
+            .map_err(|e| MessageSignatureError::signature_failed(format!("{e:?}")))?;
+
+        let curve_utils = match self.signer.algorithm() {
+            ssi::crypto::Algorithm::Es256 => Ok(CryptoCurveUtils::secp256r1()),
+            alg => Err(MessageSignatureError::UnsupportedAlgorithm(format!(
+                "Unsupported curve utils for algorithm: {alg:?}"
+            ))),
+        };
+
+        match self.signer.cryptosuite().as_ref() {
+            "EcdsaSecp256r1Signature2019" | "ecdsa-rdfc-2019" => curve_utils
+                .map(|utils| utils.ensure_raw_fixed_width_signature_encoding(signature_bytes))
+                .map_err(|e| MessageSignatureError::UnsupportedAlgorithm(format!("{e:?}")))?
+                .ok_or(MessageSignatureError::UnsupportedAlgorithm(
+                    "Unsupported signature encoding".into(),
+                )),
+            _ => Err(MessageSignatureError::UnsupportedAlgorithm(
+                self.signer.cryptosuite().to_string(),
+            )),
+        }
+    }
+}
+
+impl<M> ssi::verification_methods::Signer<M> for JsonLdPresentationBuilder
+where
+    M: ssi::verification_methods::VerificationMethod,
+{
+    type MessageSigner = Self;
+
+    #[allow(async_fn_in_trait)]
+    async fn for_method(
+        &self,
+        method: std::borrow::Cow<'_, M>,
+    ) -> Result<Option<Self::MessageSigner>, ssi::claims::SignatureError> {
+        Ok(method
+            .controller()
+            .filter(|ctrl| **ctrl == self.signer.did())
+            .map(|_| self.clone()))
+    }
+}

--- a/rust/src/proof_of_possession/mod.rs
+++ b/rust/src/proof_of_possession/mod.rs
@@ -7,7 +7,7 @@ use oid4vci::{
     },
     types::Nonce,
 };
-use ssi::{dids::DIDURLBuf, jwk::JWK};
+use ssi::jwk::JWK;
 use url::Url;
 
 pub use error::*;
@@ -26,14 +26,14 @@ pub async fn generate_pop_prepare(
     public_jwk: String,
     duration_in_secs: Option<i64>,
 ) -> Result<Vec<u8>, PopError> {
-    let issuer = did_method.did_from_jwk(&public_jwk)?;
-    let vm = did_method.vm_from_jwk(&public_jwk).await?;
+    let issuer = did_method.did_from_jwk(&public_jwk)?.to_string();
+    let vm = did_method.vm_from_jwk(&public_jwk).await?.id;
 
     let pop_params = ProofOfPossessionParams {
         audience: Url::from_str(&audience).map_err(PopError::from)?,
         issuer,
         controller: ProofOfPossessionController {
-            vm: Some(DIDURLBuf::from_string(vm).map_err(PopError::from)?),
+            vm: Some(vm),
             jwk: JWK::from_str(&public_jwk).map_err(PopError::from)?,
         },
         nonce: nonce.map(Nonce::new),


### PR DESCRIPTION
## Description

Adds a function to sign one or more `ParsedCredential`s into a json-ld `VerifiablePresentation`.

Breaking changes to:
- `DidMethod::did_from_jwk`: now returns `DIDBuf`, but `DidMethodUtils::did_from_jwk` is unchanged and still returns a `String`.
- `DidMethod::vm_from_jwk`: now returns `DIDVerificationMethod`, but `DidMethodUtils::vm_from_jwk` is unchanged and still returns a `String`.

## Tested

Tested through app functionality staying the same after replacing `DIDKit` signing by this new presentation signing.
