### PR TITLE
revert to using swift tools version 5 instead of 6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:5.3
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             ],
             path: "rust/MobileSdkRs/Sources/MobileSdkRs",
             swiftSettings: [
-                .swiftLanguageMode(.v5)  // required until https://github.com/mozilla/uniffi-rs/issues/2448 is closed
+                //.swiftLanguageMode(.v5)  // required until https://github.com/mozilla/uniffi-rs/issues/2448 is closed
             ]
         ),
         .target(
@@ -40,7 +40,7 @@ let package = Package(
             ],
             path: "./ios/MobileSdk/Sources/MobileSdk",
             swiftSettings: [
-                .swiftLanguageMode(.v5)  // some of our code isn't concurrent-safe (e.g. OID4VCI.swift)
+                //.swiftLanguageMode(.v5)  // some of our code isn't concurrent-safe (e.g. OID4VCI.swift)
             ]
         ),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -1,52 +1,52 @@
-// swift-tools-version: 6.0
+// swift-tools-version:5.0
 
 import PackageDescription
 
 let package = Package(
-  name: "SpruceIDMobileSdk",
-  platforms: [
-    .iOS(.v14)
-  ],
-  products: [
-    .library(
-      name: "SpruceIDMobileSdk",
-      targets: ["SpruceIDMobileSdk"]
-    ),
-    .library(
-      name: "SpruceIDMobileSdkRs",
-      targets: ["SpruceIDMobileSdkRs"]
-    ),
-  ],
-  dependencies: [
-    .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.0")
-  ],
-  targets: [
-    .binaryTarget(name: "RustFramework", path: "rust/MobileSdkRs/RustFramework.xcframework"),
-    .target(
-      name: "SpruceIDMobileSdkRs",
-      dependencies: [
-        .target(name: "RustFramework")
-      ],
-      path: "rust/MobileSdkRs/Sources/MobileSdkRs",
-      swiftSettings: [
-        .swiftLanguageMode(.v5)  // required until https://github.com/mozilla/uniffi-rs/issues/2448 is closed
-      ]
-    ),
-    .target(
-      name: "SpruceIDMobileSdk",
-      dependencies: [
-        .target(name: "SpruceIDMobileSdkRs"),
-        .product(name: "Algorithms", package: "swift-algorithms"),
-      ],
-      path: "./ios/MobileSdk/Sources/MobileSdk",
-      swiftSettings: [
-        .swiftLanguageMode(.v5)  // some of our code isn't concurrent-safe (e.g. OID4VCI.swift)
-      ]
-    ),
-    .testTarget(
-      name: "SpruceIDMobileSdkTests",
-      dependencies: ["SpruceIDMobileSdk"],
-      path: "./ios/MobileSdk/Tests/MobileSdkTests"
-    ),
-  ]
+    name: "SpruceIDMobileSdk",
+    platforms: [
+        .iOS(.v14)
+    ],
+    products: [
+        .library(
+            name: "SpruceIDMobileSdk",
+            targets: ["SpruceIDMobileSdk"]
+        ),
+        .library(
+            name: "SpruceIDMobileSdkRs",
+            targets: ["SpruceIDMobileSdkRs"]
+        ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.0")
+    ],
+    targets: [
+        .binaryTarget(name: "RustFramework", path: "rust/MobileSdkRs/RustFramework.xcframework"),
+        .target(
+            name: "SpruceIDMobileSdkRs",
+            dependencies: [
+                .target(name: "RustFramework")
+            ],
+            path: "rust/MobileSdkRs/Sources/MobileSdkRs",
+            swiftSettings: [
+                .swiftLanguageMode(.v5)  // required until https://github.com/mozilla/uniffi-rs/issues/2448 is closed
+            ]
+        ),
+        .target(
+            name: "SpruceIDMobileSdk",
+            dependencies: [
+                .target(name: "SpruceIDMobileSdkRs"),
+                .product(name: "Algorithms", package: "swift-algorithms"),
+            ],
+            path: "./ios/MobileSdk/Sources/MobileSdk",
+            swiftSettings: [
+                .swiftLanguageMode(.v5)  // some of our code isn't concurrent-safe (e.g. OID4VCI.swift)
+            ]
+        ),
+        .testTarget(
+            name: "SpruceIDMobileSdkTests",
+            dependencies: ["SpruceIDMobileSdk"],
+            path: "./ios/MobileSdk/Tests/MobileSdkTests"
+        ),
+    ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:6.0
 
 import PackageDescription
 

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -8289,7 +8289,7 @@ open func login(appAttestation: String)async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeWalletServiceError.lift
+            errorHandler: FfiConverterTypeWalletServiceError_lift
         )
 }
     


### PR DESCRIPTION
## Description

Reverts the use of swift tools version to 5 instead of 6 to pass GH CI checks.
