### PR TITLE
Delete HACIApplications too

### DIFF
--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/walletsettings/WalletSettingsHomeView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/walletsettings/WalletSettingsHomeView.kt
@@ -215,6 +215,7 @@ fun WalletSettingsHomeBody(
                             )
                         }
                     })
+                    hacApplicationsViewModel.deleteAllApplications()
                 }
             },
             shape = RoundedCornerShape(5.dp),

--- a/ios/Showcase/Targets/AppUIKit/Sources/walletSettings/WalletSettingsHomeView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/walletSettings/WalletSettingsHomeView.swift
@@ -102,6 +102,7 @@ struct WalletSettingsHomeBody: View {
                             )
                         }
                     }
+                    let _ = HacApplicationDataStore.shared.deleteAll()
                 } catch {
                     // TODO: display error message
                     print(error)


### PR DESCRIPTION
## Description

Make the "Delete all credentials" button also delete unfinished HACI Applications.

### Other changes

N/A

### Optional section

N/A

## Tested

Tested locally on iOS and Android
