### PR TITLE
Present mDL issued through HACI

### DIFF
--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/dcapi/Activity.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/dcapi/Activity.kt
@@ -184,13 +184,13 @@ open class Activity(val allowedAuthenticators: Int = BIOMETRIC_STRONG or DEVICE_
         Log.d(TAG, "origin: $origin")
 
         return request.credentialOptions.mapNotNull { option ->
-                if (option is GetDigitalCredentialOption) {
-                    option
-                } else {
-                    Log.d(TAG, "unsupported option: $option")
-                    null
-                }
-            }.map { option -> option.requestJson }
+            if (option is GetDigitalCredentialOption) {
+                option
+            } else {
+                Log.d(TAG, "unsupported option: $option")
+                null
+            }
+        }.map { option -> option.requestJson }
             .flatMap { requestJson -> parseOid4vpRequestJson(requestJson) }
             .map { openid4vp_request ->
                 Log.d(TAG, "openid4vp request: ${JSONObject(openid4vp_request)}")
@@ -289,9 +289,11 @@ open class Activity(val allowedAuthenticators: Int = BIOMETRIC_STRONG or DEVICE_
             resultData,
             com.google.android.gms.identitycredentials.GetCredentialResponse(
                 Credential(
-                DigitalCredential.TYPE_DIGITAL_CREDENTIAL, Bundle().apply {
-                    putByteArray("identityToken", data.toString().toByteArray())
-                })))
+                    DigitalCredential.TYPE_DIGITAL_CREDENTIAL, Bundle().apply {
+                        putByteArray("identityToken", data.toString().toByteArray())
+                    })
+            )
+        )
         PendingIntentHandler.setGetCredentialResponse(
             resultData, GetCredentialResponse(DigitalCredential(response))
         )
@@ -349,24 +351,24 @@ open class Activity(val allowedAuthenticators: Int = BIOMETRIC_STRONG or DEVICE_
 
                 if (providers != null) {
                     return List(providers.length()) { providers[it] as JSONObject }.mapNotNull {
-                            if (it.getString("protocol") == "openid4vp") {
-                                it.getString("request")
-                            } else {
-                                null
-                            }
+                        if (it.getString("protocol") == "openid4vp") {
+                            it.getString("request")
+                        } else {
+                            null
                         }
+                    }
                 }
 
                 val requests = request.optJSONArray("requests")
 
                 if (requests != null) {
                     return List(requests.length()) { requests[it] as JSONObject }.mapNotNull {
-                            if (it.getString("protocol") == "openid4vp") {
-                                it.getString("data")
-                            } else {
-                                null
-                            }
+                        if (it.getString("protocol") == "openid4vp") {
+                            it.getString("data")
+                        } else {
+                            null
                         }
+                    }
                 }
 
                 Log.d(TAG, "failed to match request to an expected format")

--- a/android/Showcase/build.gradle.kts
+++ b/android/Showcase/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.spruceid.mobilesdkexample"
         minSdk = 26
         targetSdk = 34
-        versionCode = 41
-        versionName = "1.10.4"
+        versionCode = 47
+        versionName = "1.11.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/ErrorView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/ErrorView.kt
@@ -9,9 +9,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -31,6 +31,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
@@ -129,16 +130,14 @@ fun ErrorView(
                 onDismissRequest = {
                     showSheet = false
                 },
-                modifier =
-                Modifier
-                    .fillMaxHeight(0.8f),
                 sheetState = sheetState,
                 dragHandle = null,
                 containerColor = Color.Transparent,
             ) {
                 Box(
                     Modifier
-                        .fillMaxSize()
+                        .fillMaxWidth()
+                        .height((LocalConfiguration.current.screenHeightDp * .8f).dp)
                         .background(Color.White),
                 ) {
                     Column(

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/MainActivity.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/MainActivity.kt
@@ -44,6 +44,8 @@ import com.spruceid.mobilesdkexample.viewmodels.WalletActivityLogsViewModel
 import com.spruceid.mobilesdkexample.viewmodels.WalletActivityLogsViewModelFactory
 import com.spruceid.mobilesdkexample.wallet.ApplySpruceMdlConfirmation
 
+const val DEFAULT_SIGNING_KEY_ID = "reference-app/default-signing"
+
 class MainActivity : ComponentActivity() {
     private lateinit var navController: NavHostController
     private lateinit var connectionLiveData: ConnectionLiveData

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/AddToWalletView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/AddToWalletView.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.spruceid.mobile.sdk.CredentialPack
+import com.spruceid.mobilesdkexample.DEFAULT_SIGNING_KEY_ID
 import com.spruceid.mobilesdkexample.ErrorView
 import com.spruceid.mobilesdkexample.LoadingView
 import com.spruceid.mobilesdkexample.db.WalletActivityLogs
@@ -68,9 +69,9 @@ fun AddToWalletView(
             this.async(Dispatchers.Default) {
                 try {
                     val credentialPack = CredentialPack()
-                    
+
                     // Try add credential in any supported format
-                    credentialPack.tryAddAnyFormat(rawCredential, "mdl")
+                    credentialPack.tryAddAnyFormat(rawCredential, DEFAULT_SIGNING_KEY_ID)
 
                     credentialPacksViewModel.saveCredentialPack(credentialPack)
                     val credentialInfo = getCredentialIdTitleAndIssuer(credentialPack)

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/AddToWalletView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/AddToWalletView.kt
@@ -68,7 +68,10 @@ fun AddToWalletView(
             this.async(Dispatchers.Default) {
                 try {
                     val credentialPack = CredentialPack()
-                    credentialPack.tryAddRawCredential(rawCredential)
+                    
+                    // Try add credential in any supported format
+                    credentialPack.tryAddAnyFormat(rawCredential, "mdl")
+
                     credentialPacksViewModel.saveCredentialPack(credentialPack)
                     val credentialInfo = getCredentialIdTitleAndIssuer(credentialPack)
                     walletActivityLogsViewModel.saveWalletActivityLog(

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/viewmodels/HacApplicationsViewModel.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/viewmodels/HacApplicationsViewModel.kt
@@ -44,7 +44,9 @@ class HacApplicationsViewModel(
 
     fun getSigningJwk(): String? {
         val keyId = signingKeyAlias
-        keyManager.generateSigningKey(keyId)
+        if (!keyManager.keyExists(keyId)) {
+            keyManager.generateSigningKey(keyId)
+        }
         return keyManager.getJwk(keyId)
     }
 

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/viewmodels/HacApplicationsViewModel.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/viewmodels/HacApplicationsViewModel.kt
@@ -9,6 +9,7 @@ import com.spruceid.mobile.sdk.AppAttestation
 import com.spruceid.mobile.sdk.KeyManager
 import com.spruceid.mobile.sdk.rs.IssuanceServiceClient
 import com.spruceid.mobile.sdk.rs.WalletServiceClient
+import com.spruceid.mobilesdkexample.DEFAULT_SIGNING_KEY_ID
 import com.spruceid.mobilesdkexample.db.HacApplications
 import com.spruceid.mobilesdkexample.db.HacApplicationsRepository
 import com.spruceid.mobilesdkexample.utils.Toast
@@ -34,7 +35,6 @@ class HacApplicationsViewModel(
     val issuanceClient = IssuanceServiceClient(SPRUCEID_HAC_ISSUANCE_SERVICE)
     private val keyManager = KeyManager()
     private val context = application as Context
-    private val signingKeyAlias = "reference-app/default-signing"
 
     init {
         viewModelScope.launch {
@@ -43,7 +43,7 @@ class HacApplicationsViewModel(
     }
 
     fun getSigningJwk(): String? {
-        val keyId = signingKeyAlias
+        val keyId = DEFAULT_SIGNING_KEY_ID
         if (!keyManager.keyExists(keyId)) {
             keyManager.generateSigningKey(keyId)
         }
@@ -70,7 +70,7 @@ class HacApplicationsViewModel(
                 getSigningJwk()
 
                 suspendCancellableCoroutine { continuation ->
-                    attestation.appAttest(nonce, signingKeyAlias) { result ->
+                    attestation.appAttest(nonce, DEFAULT_SIGNING_KEY_ID) { result ->
                         result.fold(
                             onSuccess = { payload ->
                                 viewModelScope.launch {

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleOID4VCIView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleOID4VCIView.kt
@@ -19,6 +19,7 @@ import com.spruceid.mobile.sdk.rs.Oid4vci
 import com.spruceid.mobile.sdk.rs.Oid4vciExchangeOptions
 import com.spruceid.mobile.sdk.rs.generatePopComplete
 import com.spruceid.mobile.sdk.rs.generatePopPrepare
+import com.spruceid.mobilesdkexample.DEFAULT_SIGNING_KEY_ID
 import com.spruceid.mobilesdkexample.ErrorView
 import com.spruceid.mobilesdkexample.LoadingView
 import com.spruceid.mobilesdkexample.R
@@ -96,13 +97,12 @@ fun HandleOID4VCIView(
             val metadata = oid4vciSession.getMetadata()
 
             val keyManager = KeyManager()
-            val signingKeyId = "reference-app/default-signing"
 
-            if (!keyManager.keyExists(signingKeyId)) {
-                keyManager.generateSigningKey(signingKeyId)
+            if (!keyManager.keyExists(DEFAULT_SIGNING_KEY_ID)) {
+                keyManager.generateSigningKey(DEFAULT_SIGNING_KEY_ID)
             }
-            
-            val jwk = keyManager.getJwk(id = signingKeyId)
+
+            val jwk = keyManager.getJwk(id = DEFAULT_SIGNING_KEY_ID)
 
             val signingInput =
                 jwk?.let {
@@ -118,7 +118,7 @@ fun HandleOID4VCIView(
             val signature =
                 signingInput?.let {
                     keyManager.signPayload(
-                        id = signingKeyId,
+                        id = DEFAULT_SIGNING_KEY_ID,
                         payload = signingInput
                     )
                 }

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleOID4VPView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleOID4VPView.kt
@@ -85,7 +85,9 @@ class Signer(keyId: String?) : PresentationSigner {
     private val didJwk = DidMethodUtils(DidMethod.JWK)
 
     init {
-        keyManager.generateSigningKey(id = this.keyId)
+        if (!keyManager.keyExists(this.keyId)) {
+            keyManager.generateSigningKey(id = this.keyId)
+        }
         this.jwk = keyManager.getJwk(this.keyId) ?: throw IllegalArgumentException("Invalid kid")
     }
 
@@ -243,7 +245,7 @@ fun HandleOID4VPView(
 
         OID4VPState.SelectiveDisclosure -> DataFieldSelector(
             requestedFields =
-            permissionRequest!!.requestedFields(selectedCredential!!),
+                permissionRequest!!.requestedFields(selectedCredential!!),
             onContinue = {
                 scope.launch {
                     try {
@@ -326,10 +328,10 @@ fun DataFieldSelector(
 
         Column(
             modifier =
-            Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .weight(weight = 1f, fill = false)
+                Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .weight(weight = 1f, fill = false)
         ) {
             requestedFields.forEach {
                 Row(verticalAlignment = Alignment.CenterVertically) {
@@ -358,29 +360,29 @@ fun DataFieldSelector(
 
         Row(
             modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(vertical = 12.dp)
-                .navigationBarsPadding(),
+                Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 12.dp)
+                    .navigationBarsPadding(),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Button(
                 onClick = { onCancel() },
                 shape = RoundedCornerShape(6.dp),
                 colors =
-                ButtonDefaults.buttonColors(
-                    containerColor = Color.Transparent,
-                    contentColor = ColorStone950,
-                ),
+                    ButtonDefaults.buttonColors(
+                        containerColor = Color.Transparent,
+                        contentColor = ColorStone950,
+                    ),
                 modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .border(
-                        width = 1.dp,
-                        color = ColorStone300,
-                        shape = RoundedCornerShape(6.dp)
-                    )
-                    .weight(1f)
+                    Modifier
+                        .fillMaxWidth()
+                        .border(
+                            width = 1.dp,
+                            color = ColorStone300,
+                            shape = RoundedCornerShape(6.dp)
+                        )
+                        .weight(1f)
             ) {
                 Text(
                     text = "Cancel",
@@ -395,13 +397,13 @@ fun DataFieldSelector(
                 shape = RoundedCornerShape(6.dp),
                 colors = ButtonDefaults.buttonColors(containerColor = ColorEmerald900),
                 modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .background(
-                        color = ColorEmerald900,
-                        shape = RoundedCornerShape(6.dp),
-                    )
-                    .weight(1f)
+                    Modifier
+                        .fillMaxWidth()
+                        .background(
+                            color = ColorEmerald900,
+                            shape = RoundedCornerShape(6.dp),
+                        )
+                        .weight(1f)
             ) {
                 Text(
                     text = "Approve",
@@ -486,18 +488,18 @@ fun CredentialSelector(
                 fontSize = 15.sp,
                 color = ColorBlue600,
                 modifier =
-                Modifier.clickable {
-                    // TODO: implement select all
-                }
+                    Modifier.clickable {
+                        // TODO: implement select all
+                    }
             )
         }
 
         Column(
             modifier =
-            Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .weight(weight = 1f, fill = false)
+                Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .weight(weight = 1f, fill = false)
         ) {
             credentials.forEach { credential ->
                 CredentialSelectorItem(
@@ -513,29 +515,29 @@ fun CredentialSelector(
 
         Row(
             modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(vertical = 12.dp)
-                .navigationBarsPadding(),
+                Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 12.dp)
+                    .navigationBarsPadding(),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Button(
                 onClick = { onCancel() },
                 shape = RoundedCornerShape(6.dp),
                 colors =
-                ButtonDefaults.buttonColors(
-                    containerColor = Color.Transparent,
-                    contentColor = ColorStone950,
-                ),
+                    ButtonDefaults.buttonColors(
+                        containerColor = Color.Transparent,
+                        contentColor = ColorStone950,
+                    ),
                 modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .border(
-                        width = 1.dp,
-                        color = ColorStone300,
-                        shape = RoundedCornerShape(6.dp)
-                    )
-                    .weight(1f)
+                    Modifier
+                        .fillMaxWidth()
+                        .border(
+                            width = 1.dp,
+                            color = ColorStone300,
+                            shape = RoundedCornerShape(6.dp)
+                        )
+                        .weight(1f)
             ) {
                 Text(
                     text = "Cancel",
@@ -553,27 +555,27 @@ fun CredentialSelector(
                 },
                 shape = RoundedCornerShape(6.dp),
                 colors =
-                ButtonDefaults.buttonColors(
-                    containerColor =
-                    if (selectedCredentials.isNotEmpty()) {
-                        ColorStone600
-                    } else {
-                        Color.Gray
-                    }
-                ),
+                    ButtonDefaults.buttonColors(
+                        containerColor =
+                            if (selectedCredentials.isNotEmpty()) {
+                                ColorStone600
+                            } else {
+                                Color.Gray
+                            }
+                    ),
                 modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .background(
-                        color =
-                        if (selectedCredentials.isNotEmpty()) {
-                            ColorStone600
-                        } else {
-                            Color.Gray
-                        },
-                        shape = RoundedCornerShape(6.dp),
-                    )
-                    .weight(1f)
+                    Modifier
+                        .fillMaxWidth()
+                        .background(
+                            color =
+                                if (selectedCredentials.isNotEmpty()) {
+                                    ColorStone600
+                                } else {
+                                    Color.Gray
+                                },
+                            shape = RoundedCornerShape(6.dp),
+                        )
+                        .weight(1f)
             ) {
                 Text(
                     text = "Continue",
@@ -604,14 +606,14 @@ fun CredentialSelectorItem(
 
     Column(
         modifier =
-        Modifier
-            .fillMaxWidth()
-            .padding(vertical = 8.dp)
-            .border(
-                width = 1.dp,
-                color = ColorBase300,
-                shape = RoundedCornerShape(8.dp)
-            )
+            Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp)
+                .border(
+                    width = 1.dp,
+                    color = ColorBase300,
+                    shape = RoundedCornerShape(8.dp)
+                )
     ) {
         Row(
             modifier = Modifier
@@ -630,10 +632,10 @@ fun CredentialSelectorItem(
                     }
                 },
                 colors =
-                CheckboxDefaults.colors(
-                    checkedColor = ColorBlue600,
-                    uncheckedColor = ColorStone300
-                )
+                    CheckboxDefaults.colors(
+                        checkedColor = ColorBlue600,
+                        uncheckedColor = ColorStone300
+                    )
             )
             Text(
                 text = getCredentialTitle(credential),

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleOID4VPView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleOID4VPView.kt
@@ -54,6 +54,7 @@ import com.spruceid.mobile.sdk.rs.PresentableCredential
 import com.spruceid.mobile.sdk.rs.PresentationSigner
 import com.spruceid.mobile.sdk.rs.RequestedField
 import com.spruceid.mobile.sdk.rs.ResponseOptions
+import com.spruceid.mobilesdkexample.DEFAULT_SIGNING_KEY_ID
 import com.spruceid.mobilesdkexample.ErrorView
 import com.spruceid.mobilesdkexample.LoadingView
 import com.spruceid.mobilesdkexample.R
@@ -79,7 +80,7 @@ import kotlinx.coroutines.withContext
 import org.json.JSONObject
 
 class Signer(keyId: String?) : PresentationSigner {
-    private val keyId = keyId ?: "reference-app/default-signing"
+    private val keyId = keyId ?: DEFAULT_SIGNING_KEY_ID
     private val keyManager = KeyManager()
     private var jwk: String
     private val didJwk = DidMethodUtils(DidMethod.JWK)
@@ -179,7 +180,7 @@ fun HandleOID4VPView(
                 }
 
                 withContext(Dispatchers.IO) {
-                    val signer = Signer("reference-app/default-signing")
+                    val signer = Signer(DEFAULT_SIGNING_KEY_ID)
                     holder =
                         Holder.newWithCredentials(
                             credentials,

--- a/ios/MobileSdk/Sources/MobileSdk/CredentialPack.swift
+++ b/ios/MobileSdk/Sources/MobileSdk/CredentialPack.swift
@@ -35,8 +35,7 @@ public class CredentialPack {
      * Try to add a credential and throws a ParsingException if not possible
      */
     public func tryAddRawCredential(rawCredential: String) throws
-        -> [ParsedCredential]
-    {
+        -> [ParsedCredential] {
         if let credentials = try? addJwtVc(
             jwtVc: JwtVc.newFromCompactJws(jws: rawCredential)
         ) {
@@ -64,8 +63,7 @@ public class CredentialPack {
      * Try to add a raw mDoc with specified keyAlias
      */
     public func tryAddRawMdoc(rawCredential: String, keyAlias: String) throws
-        -> [ParsedCredential]
-    {
+        -> [ParsedCredential] {
         if let credentials = try? addMDoc(
             mdoc: Mdoc.fromStringifiedDocument(
                 stringifiedDocument: rawCredential,
@@ -98,8 +96,7 @@ public class CredentialPack {
      * @throws CredentialPackError if the credential cannot be parsed in any supported format
      */
     public func tryAddAnyFormat(rawCredential: String, mdocKeyAlias: String)
-        throws -> [ParsedCredential]
-    {
+        throws -> [ParsedCredential] {
         // First try our standard formats (which already include mdoc but with random keyAlias)
         do {
             return try tryAddRawCredential(rawCredential: rawCredential)
@@ -145,8 +142,7 @@ public class CredentialPack {
 
     /// Get all status from all credentials async
     public func getStatusListsAsync(hasConnection: Bool) async -> [Uuid:
-        CredentialStatusList]
-    {
+        CredentialStatusList] {
         var res = [Uuid: CredentialStatusList]()
         for credential in credentials {
             let credentialId = credential.id()
@@ -195,8 +191,7 @@ public class CredentialPack {
 
     /// Find credential claims from all credentials in this CredentialPack.
     public func findCredentialClaims(claimNames: [String]) -> [Uuid: [String:
-        GenericJSON]]
-    {
+        GenericJSON]] {
         Dictionary(
             uniqueKeysWithValues: list()
                 .map { credential in
@@ -305,8 +300,7 @@ public class CredentialPack {
 
     /// Loads all CredentialPacks from the StorageManager.
     public static func loadAll(storageManager: StorageManagerInterface)
-        async throws -> [CredentialPack]
-    {
+        async throws -> [CredentialPack] {
         try await CredentialPackContents.list(storageManager: storageManager)
             .asyncMap { contents in
                 try await contents.load(
@@ -383,8 +377,7 @@ public struct CredentialPackContents {
 
     /// Loads all of the credentials from the VdcCollection for this CredentialPack.
     public func load(vdcCollection: VdcCollection) async throws
-        -> CredentialPack
-    {
+        -> CredentialPack {
         let credentials = try await credentials.asyncMap { credentialId in
             do {
                 guard
@@ -409,8 +402,7 @@ public struct CredentialPackContents {
 
     /// Clears all CredentialPacks.
     public static func clear(storageManager: StorageManagerInterface)
-        async throws
-    {
+        async throws {
         do {
             try await storageManager.list()
                 .filter { file in
@@ -428,8 +420,7 @@ public struct CredentialPackContents {
     ///
     /// These can then be individually loaded. For eager loading of all packs, see `CredentialPack.loadAll`.
     public static func list(storageManager: StorageManagerInterface)
-        async throws -> [CredentialPackContents]
-    {
+        async throws -> [CredentialPackContents] {
         do {
             return try await storageManager.list()
                 .filter { file in
@@ -464,7 +455,7 @@ public struct CredentialPackContents {
                     self.credentials.map { id in
                         GenericJSON.string(id)
                     }
-                ),
+                )
             ]
 
             return try JSONEncoder().encode(json)

--- a/ios/MobileSdk/Sources/MobileSdk/CredentialPack.swift
+++ b/ios/MobileSdk/Sources/MobileSdk/CredentialPack.swift
@@ -34,27 +34,88 @@ public class CredentialPack {
     /**
      * Try to add a credential and throws a ParsingException if not possible
      */
-    public func tryAddRawCredential(rawCredential: String) throws -> [ParsedCredential] {
-        if let credentials = try? addJwtVc(jwtVc: JwtVc.newFromCompactJws(jws: rawCredential)) {
-            return credentials
-        } else if let credentials = try? addJsonVc(jsonVc: JsonVc.newFromJson(utf8JsonString: rawCredential)) {
-            return credentials
-        } else if let credentials = try? addSdJwt(sdJwt: Vcdm2SdJwt.newFromCompactSdJwt(input: rawCredential)) {
-            return credentials
-        } else if let credentials = try? addCwt(cwt: Cwt.newFromBase10(payload: rawCredential)) {
-            return credentials
-        } else if let credentials = try? addMDoc(mdoc: Mdoc.fromStringifiedDocument(
-            stringifiedDocument: rawCredential,
-            keyAlias: UUID().uuidString)
+    public func tryAddRawCredential(rawCredential: String) throws
+        -> [ParsedCredential]
+    {
+        if let credentials = try? addJwtVc(
+            jwtVc: JwtVc.newFromCompactJws(jws: rawCredential)
         ) {
             return credentials
-        } else if let credentials = try? addMDoc(mdoc: Mdoc.newFromBase64urlEncodedIssuerSigned(
-            base64urlEncodedIssuerSigned: rawCredential,
-            keyAlias: UUID().uuidString)
+        } else if let credentials = try? addJsonVc(
+            jsonVc: JsonVc.newFromJson(utf8JsonString: rawCredential)
+        ) {
+            return credentials
+        } else if let credentials = try? addSdJwt(
+            sdJwt: Vcdm2SdJwt.newFromCompactSdJwt(input: rawCredential)
+        ) {
+            return credentials
+        } else if let credentials = try? addCwt(
+            cwt: Cwt.newFromBase10(payload: rawCredential)
         ) {
             return credentials
         } else {
-            throw CredentialPackError.credentialParsing(reason: "Couldn't parse credential: \(rawCredential)")
+            throw CredentialPackError.credentialParsing(
+                reason: "Couldn't parse credential: \(rawCredential)"
+            )
+        }
+    }
+
+    /**
+     * Try to add a raw mDoc with specified keyAlias
+     */
+    public func tryAddRawMdoc(rawCredential: String, keyAlias: String) throws
+        -> [ParsedCredential]
+    {
+        if let credentials = try? addMDoc(
+            mdoc: Mdoc.fromStringifiedDocument(
+                stringifiedDocument: rawCredential,
+                keyAlias: keyAlias
+            )
+        ) {
+            return credentials
+        } else if let credentials = try? addMDoc(
+            mdoc: Mdoc.newFromBase64urlEncodedIssuerSigned(
+                base64urlEncodedIssuerSigned: rawCredential,
+                keyAlias: keyAlias
+            )
+        ) {
+            return credentials
+        } else {
+            throw CredentialPackError.credentialParsing(
+                reason:
+                    "The mdoc format is not supported. Credential = \(rawCredential)"
+            )
+        }
+    }
+
+    /**
+     * Try to add a credential in any supported format (standard credential or mdoc).
+     * Attempts to parse as standard credential first, then as mdoc with specified keyAlias if that fails.
+     *
+     * @param rawCredential The raw credential data as a string
+     * @param mdocKeyAlias The key alias to use if parsing as mdoc is needed
+     * @return List of parsed credentials
+     * @throws CredentialPackError if the credential cannot be parsed in any supported format
+     */
+    public func tryAddAnyFormat(rawCredential: String, mdocKeyAlias: String)
+        throws -> [ParsedCredential]
+    {
+        // First try our standard formats (which already include mdoc but with random keyAlias)
+        do {
+            return try tryAddRawCredential(rawCredential: rawCredential)
+        } catch {
+            // If that fails, try specifically with the provided keyAlias
+            do {
+                return try tryAddRawMdoc(
+                    rawCredential: rawCredential,
+                    keyAlias: mdocKeyAlias
+                )
+            } catch {
+                throw CredentialPackError.credentialParsing(
+                    reason:
+                        "The credential format is not supported in any format. Credential = \(rawCredential)"
+                )
+            }
         }
     }
 
@@ -83,7 +144,9 @@ public class CredentialPack {
     }
 
     /// Get all status from all credentials async
-    public func getStatusListsAsync(hasConnection: Bool) async -> [Uuid: CredentialStatusList] {
+    public func getStatusListsAsync(hasConnection: Bool) async -> [Uuid:
+        CredentialStatusList]
+    {
         var res = [Uuid: CredentialStatusList]()
         for credential in credentials {
             let credentialId = credential.id()
@@ -99,7 +162,8 @@ public class CredentialPack {
                             res[credentialId] = CredentialStatusList.valid
                         }
                     } catch {
-                        res[credentialId] = CredentialStatusList.undefined}
+                        res[credentialId] = CredentialStatusList.undefined
+                    }
                 } else {
                     res[credentialId] = CredentialStatusList.unknown
                 }
@@ -113,7 +177,8 @@ public class CredentialPack {
                                 res[credentialId] = CredentialStatusList.revoked
                                 break
                             } else if credentialStatus.isSuspended() {
-                                res[credentialId] = CredentialStatusList.suspended
+                                res[credentialId] =
+                                    CredentialStatusList.suspended
                             }
                         }
                     } catch {
@@ -129,7 +194,9 @@ public class CredentialPack {
     }
 
     /// Find credential claims from all credentials in this CredentialPack.
-    public func findCredentialClaims(claimNames: [String]) -> [Uuid: [String: GenericJSON]] {
+    public func findCredentialClaims(claimNames: [String]) -> [Uuid: [String:
+        GenericJSON]]
+    {
         Dictionary(
             uniqueKeysWithValues: list()
                 .map { credential in
@@ -138,31 +205,41 @@ public class CredentialPack {
                         if claimNames.isEmpty {
                             claims = mdoc.jsonEncodedDetails()
                         } else {
-                            claims = mdoc.jsonEncodedDetails(containing: claimNames)
+                            claims = mdoc.jsonEncodedDetails(
+                                containing: claimNames
+                            )
                         }
                     } else if let jwtVc = credential.asJwtVc() {
                         if claimNames.isEmpty {
                             claims = jwtVc.credentialClaims()
                         } else {
-                            claims = jwtVc.credentialClaims(containing: claimNames)
+                            claims = jwtVc.credentialClaims(
+                                containing: claimNames
+                            )
                         }
                     } else if let cwt = credential.asCwt() {
                         if claimNames.isEmpty {
                             claims = cwt.credentialClaims()
                         } else {
-                            claims = cwt.credentialClaims(containing: claimNames)
+                            claims = cwt.credentialClaims(
+                                containing: claimNames
+                            )
                         }
                     } else if let jsonVc = credential.asJsonVc() {
                         if claimNames.isEmpty {
                             claims = jsonVc.credentialClaims()
                         } else {
-                            claims = jsonVc.credentialClaims(containing: claimNames)
+                            claims = jsonVc.credentialClaims(
+                                containing: claimNames
+                            )
                         }
                     } else if let sdJwt = credential.asSdJwt() {
                         if claimNames.isEmpty {
                             claims = sdJwt.credentialClaims()
                         } else {
-                            claims = sdJwt.credentialClaims(containing: claimNames)
+                            claims = sdJwt.credentialClaims(
+                                containing: claimNames
+                            )
                         }
                     } else {
                         var type: String
@@ -175,7 +252,8 @@ public class CredentialPack {
                         claims = [:]
                     }
                     return (credential.id(), claims)
-                })
+                }
+        )
     }
 
     /// Get credentials by id.
@@ -203,10 +281,15 @@ public class CredentialPack {
         for credential in list() {
             do {
                 if (try await vdcCollection.get(id: credential.id())) == nil {
-                    try await vdcCollection.add(credential: try credential.intoGenericForm())
+                    try await vdcCollection.add(
+                        credential: try credential.intoGenericForm()
+                    )
                 }
             } catch {
-                throw CredentialPackError.credentialStorage(id: credential.id(), reason: error)
+                throw CredentialPackError.credentialStorage(
+                    id: credential.id(),
+                    reason: error
+                )
             }
         }
 
@@ -221,16 +304,24 @@ public class CredentialPack {
     }
 
     /// Loads all CredentialPacks from the StorageManager.
-    public static func loadAll(storageManager: StorageManagerInterface) async throws -> [CredentialPack] {
-        try await CredentialPackContents.list(storageManager: storageManager).asyncMap { contents in
-            try await contents.load(vdcCollection: VdcCollection(engine: storageManager))
-        }
+    public static func loadAll(storageManager: StorageManagerInterface)
+        async throws -> [CredentialPack]
+    {
+        try await CredentialPackContents.list(storageManager: storageManager)
+            .asyncMap { contents in
+                try await contents.load(
+                    vdcCollection: VdcCollection(engine: storageManager)
+                )
+            }
     }
 
     private func intoContents() -> CredentialPackContents {
-        CredentialPackContents(id: self.id, credentials: self.credentials.map { credential in
-            credential.id()
-        })
+        CredentialPackContents(
+            id: self.id,
+            credentials: self.credentials.map { credential in
+                credential.id()
+            }
+        )
     }
 }
 
@@ -250,7 +341,10 @@ public struct CredentialPackContents {
     public init(fromBytes data: Data) throws {
         let json: [String: GenericJSON]
         do {
-            json = try JSONDecoder().decode([String: GenericJSON].self, from: data)
+            json = try JSONDecoder().decode(
+                [String: GenericJSON].self,
+                from: data
+            )
         } catch {
             throw CredentialPackError.contentsNotJSON(reason: error)
         }
@@ -281,18 +375,30 @@ public struct CredentialPackContents {
         case nil:
             throw CredentialPackError.credentialIdsMissingFromContents
         default:
-            throw CredentialPackError.credentialIdsNotArray(value: json[credentialsKey]!)
+            throw CredentialPackError.credentialIdsNotArray(
+                value: json[credentialsKey]!
+            )
         }
     }
 
     /// Loads all of the credentials from the VdcCollection for this CredentialPack.
-    public func load(vdcCollection: VdcCollection) async throws -> CredentialPack {
+    public func load(vdcCollection: VdcCollection) async throws
+        -> CredentialPack
+    {
         let credentials = try await credentials.asyncMap { credentialId in
             do {
-                guard let credential = try await vdcCollection.get(id: credentialId) else {
-                    throw CredentialPackError.credentialNotFound(id: credentialId)
+                guard
+                    let credential = try await vdcCollection.get(
+                        id: credentialId
+                    )
+                else {
+                    throw CredentialPackError.credentialNotFound(
+                        id: credentialId
+                    )
                 }
-                return try ParsedCredential.parseFromCredential(credential: credential)
+                return try ParsedCredential.parseFromCredential(
+                    credential: credential
+                )
             } catch {
                 throw CredentialPackError.credentialLoading(reason: error)
             }
@@ -302,7 +408,9 @@ public struct CredentialPackContents {
     }
 
     /// Clears all CredentialPacks.
-    public static func clear(storageManager: StorageManagerInterface) async throws {
+    public static func clear(storageManager: StorageManagerInterface)
+        async throws
+    {
         do {
             try await storageManager.list()
                 .filter { file in
@@ -319,14 +427,17 @@ public struct CredentialPackContents {
     /// Lists all CredentialPacks.
     ///
     /// These can then be individually loaded. For eager loading of all packs, see `CredentialPack.loadAll`.
-    public static func list(storageManager: StorageManagerInterface) async throws -> [CredentialPackContents] {
+    public static func list(storageManager: StorageManagerInterface)
+        async throws -> [CredentialPackContents]
+    {
         do {
             return try await storageManager.list()
                 .filter { file in
                     file.hasPrefix(Self.storagePrefix)
                 }
                 .asyncMap { file in
-                    guard let contents = try await storageManager.get(key: file) else {
+                    guard let contents = try await storageManager.get(key: file)
+                    else {
                         throw CredentialPackError.missing(file: file)
                     }
                     return try CredentialPackContents(fromBytes: contents)
@@ -353,7 +464,7 @@ public struct CredentialPackContents {
                     self.credentials.map { id in
                         GenericJSON.string(id)
                     }
-                )
+                ),
             ]
 
             return try JSONEncoder().encode(json)
@@ -371,7 +482,9 @@ public struct CredentialPackContents {
             do {
                 try await vdcCollection.delete(id: credential)
             } catch {
-                print("failed to remove Credential '\(credential)' from the VdcCollection")
+                print(
+                    "failed to remove Credential '\(credential)' from the VdcCollection"
+                )
             }
         }
 

--- a/ios/Showcase/Targets/AppUIKit/Sources/ContentView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/ContentView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 
+let DEFAULT_SIGNING_KEY_ID = "reference-app/default-signing"
+
 public struct ContentView: View {
     @State var path: NavigationPath = .init()
     @State var sheetOpen: Bool = false

--- a/ios/Showcase/Targets/AppUIKit/Sources/credentials/AddToWalletView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/credentials/AddToWalletView.swift
@@ -24,7 +24,8 @@ struct AddToWalletView: View {
 
         do {
             credentialItem = try credentialDisplayerSelector(
-                rawCredential: rawCredential)
+                rawCredential: rawCredential
+            )
             errorDetails = ""
             presentError = false
         } catch {
@@ -45,12 +46,16 @@ struct AddToWalletView: View {
         storing = true
         do {
             let credentialPack = CredentialPack()
-            _ = try credentialPack.tryAddRawCredential(
-                rawCredential: rawCredential)
+            _ = try credentialPack.tryAddAnyFormat(
+                rawCredential: rawCredential,
+                mdocKeyAlias: "mdl"
+            )
             try await credentialPackObservable.add(
-                credentialPack: credentialPack)
+                credentialPack: credentialPack
+            )
             let credentialInfo = getCredentialIdTitleAndIssuer(
-                credentialPack: credentialPack)
+                credentialPack: credentialPack
+            )
             _ = WalletActivityLogDataStore.shared.insert(
                 credentialPackId: credentialPack.id.uuidString,
                 credentialId: credentialInfo.0,
@@ -97,7 +102,11 @@ struct AddToWalletView: View {
                             .padding(.horizontal, -20)
                             .font(
                                 .customFont(
-                                    font: .inter, style: .medium, size: .h4))
+                                    font: .inter,
+                                    style: .medium,
+                                    size: .h4
+                                )
+                            )
                     }
                     .foregroundColor(.white)
                     .padding(.vertical, 13)
@@ -111,7 +120,11 @@ struct AddToWalletView: View {
                             .padding(.horizontal, -20)
                             .font(
                                 .customFont(
-                                    font: .inter, style: .medium, size: .h4))
+                                    font: .inter,
+                                    style: .medium,
+                                    size: .h4
+                                )
+                            )
                     }
                     .foregroundColor(Color("ColorRose600"))
                     .padding(.vertical, 13)

--- a/ios/Showcase/Targets/AppUIKit/Sources/credentials/AddToWalletView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/credentials/AddToWalletView.swift
@@ -48,7 +48,7 @@ struct AddToWalletView: View {
             let credentialPack = CredentialPack()
             _ = try credentialPack.tryAddAnyFormat(
                 rawCredential: rawCredential,
-                mdocKeyAlias: "mdl"
+                mdocKeyAlias: DEFAULT_SIGNING_KEY_ID
             )
             try await credentialPackObservable.add(
                 credentialPack: credentialPack

--- a/ios/Showcase/Targets/AppUIKit/Sources/dataStores/HacApplicationObservable.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/dataStores/HacApplicationObservable.swift
@@ -27,11 +27,10 @@ class HacApplicationObservable: ObservableObject {
     }
 
     func getSigningJwk() -> String? {
-        let keyId = "reference-app/default-signing"
-        if !KeyManager.keyExists(id: keyId) {
-            _ = KeyManager.generateSigningKey(id: keyId)
+        if !KeyManager.keyExists(id: DEFAULT_SIGNING_KEY_ID) {
+            _ = KeyManager.generateSigningKey(id: DEFAULT_SIGNING_KEY_ID)
         }
-        return KeyManager.getJwk(id: keyId)
+        return KeyManager.getJwk(id: DEFAULT_SIGNING_KEY_ID)
     }
 
     @MainActor func getNonce() async -> String? {

--- a/ios/Showcase/Targets/AppUIKit/Sources/dataStores/HacApplicationObservable.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/dataStores/HacApplicationObservable.swift
@@ -28,7 +28,9 @@ class HacApplicationObservable: ObservableObject {
 
     func getSigningJwk() -> String? {
         let keyId = "reference-app/default-signing"
-        _ = KeyManager.generateSigningKey(id: keyId)
+        if !KeyManager.keyExists(id: keyId) {
+            _ = KeyManager.generateSigningKey(id: keyId)
+        }
         return KeyManager.getJwk(id: keyId)
     }
 

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleOID4VCIView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleOID4VCIView.swift
@@ -40,14 +40,13 @@ struct HandleOID4VCIView: View {
 
                 let metadata = try oid4vciSession.getMetadata()
 
-                let keyId = "reference-app/default-signing"
-                if !KeyManager.keyExists(id: keyId) {
+                if !KeyManager.keyExists(id: DEFAULT_SIGNING_KEY_ID) {
                     _ = KeyManager.generateSigningKey(
-                        id: keyId
+                        id: DEFAULT_SIGNING_KEY_ID
                     )
                 }
 
-                let jwk = KeyManager.getJwk(id: keyId)
+                let jwk = KeyManager.getJwk(id: DEFAULT_SIGNING_KEY_ID)
 
                 let signingInput =
                     try await SpruceIDMobileSdkRs.generatePopPrepare(
@@ -59,7 +58,7 @@ struct HandleOID4VCIView: View {
                     )
 
                 let signature = KeyManager.signPayload(
-                    id: keyId,
+                    id: DEFAULT_SIGNING_KEY_ID,
                     payload: [UInt8](signingInput)
                 )
 

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleOID4VCIView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleOID4VCIView.swift
@@ -40,9 +40,14 @@ struct HandleOID4VCIView: View {
 
                 let metadata = try oid4vciSession.getMetadata()
 
-                _ = KeyManager.generateSigningKey(
-                    id: "reference-app/default-signing")
-                let jwk = KeyManager.getJwk(id: "reference-app/default-signing")
+                let keyId = "reference-app/default-signing"
+                if !KeyManager.keyExists(id: keyId) {
+                    _ = KeyManager.generateSigningKey(
+                        id: keyId
+                    )
+                }
+
+                let jwk = KeyManager.getJwk(id: keyId)
 
                 let signingInput =
                     try await SpruceIDMobileSdkRs.generatePopPrepare(
@@ -54,8 +59,9 @@ struct HandleOID4VCIView: View {
                     )
 
                 let signature = KeyManager.signPayload(
-                    id: "reference-app/default-signing",
-                    payload: [UInt8](signingInput))
+                    id: keyId,
+                    payload: [UInt8](signingInput)
+                )
 
                 let pop = try SpruceIDMobileSdkRs.generatePopComplete(
                     signingInput: signingInput,
@@ -63,7 +69,8 @@ struct HandleOID4VCIView: View {
                 )
 
                 try oid4vciSession.setContextMap(
-                    values: getVCPlaygroundOID4VCIContext())
+                    values: getVCPlaygroundOID4VCIContext()
+                )
 
                 self.credentialPack = CredentialPack()
                 let credentials = try await oid4vciSession.exchangeCredential(
@@ -71,10 +78,8 @@ struct HandleOID4VCIView: View {
                     options: Oid4vciExchangeOptions(verifyAfterExchange: false)
                 )
 
-                try credentials.forEach {
+                credentials.forEach {
                     let cred = String(decoding: Data($0.payload), as: UTF8.self)
-                    _ = try self.credentialPack?.tryAddRawCredential(
-                        rawCredential: cred)
                     self.credential = cred
                 }
 
@@ -119,40 +124,62 @@ func getVCPlaygroundOID4VCIContext() throws -> [String: String] {
     var context: [String: String] = [:]
 
     var path = Bundle.main.path(
-        forResource: "w3id.org_first-responder_v1", ofType: "json")
+        forResource: "w3id.org_first-responder_v1",
+        ofType: "json"
+    )
     context["https://w3id.org/first-responder/v1"] = try String(
-        contentsOfFile: path!, encoding: String.Encoding.utf8)
+        contentsOfFile: path!,
+        encoding: String.Encoding.utf8
+    )
 
     path = Bundle.main.path(
-        forResource: "w3id.org_vdl_aamva_v1", ofType: "json")
+        forResource: "w3id.org_vdl_aamva_v1",
+        ofType: "json"
+    )
     context["https://w3id.org/vdl/aamva/v1"] = try String(
-        contentsOfFile: path!, encoding: String.Encoding.utf8)
+        contentsOfFile: path!,
+        encoding: String.Encoding.utf8
+    )
 
     path = Bundle.main.path(
-        forResource: "w3id.org_citizenship_v3", ofType: "json")
+        forResource: "w3id.org_citizenship_v3",
+        ofType: "json"
+    )
     context["https://w3id.org/citizenship/v3"] = try String(
-        contentsOfFile: path!, encoding: String.Encoding.utf8)
+        contentsOfFile: path!,
+        encoding: String.Encoding.utf8
+    )
 
     path = Bundle.main.path(
         forResource: "purl.imsglobal.org_spec_ob_v3p0_context-3.0.2",
-        ofType: "json")
+        ofType: "json"
+    )
     context["https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.2.json"] =
         try String(contentsOfFile: path!, encoding: String.Encoding.utf8)
 
     path = Bundle.main.path(
-        forResource: "w3id.org_citizenship_v4rc1", ofType: "json")
+        forResource: "w3id.org_citizenship_v4rc1",
+        ofType: "json"
+    )
     context["https://w3id.org/citizenship/v4rc1"] = try String(
-        contentsOfFile: path!, encoding: String.Encoding.utf8)
+        contentsOfFile: path!,
+        encoding: String.Encoding.utf8
+    )
 
     path = Bundle.main.path(
-        forResource: "w3id.org_vc_render-method_v2rc1", ofType: "json")
+        forResource: "w3id.org_vc_render-method_v2rc1",
+        ofType: "json"
+    )
     context["https://w3id.org/vc/render-method/v2rc1"] = try String(
-        contentsOfFile: path!, encoding: String.Encoding.utf8)
+        contentsOfFile: path!,
+        encoding: String.Encoding.utf8
+    )
 
     path = Bundle.main.path(
         forResource:
             "examples.vcplayground.org_contexts_alumni_v2",
-        ofType: "json")
+        ofType: "json"
+    )
     context[
         "https://examples.vcplayground.org/contexts/alumni/v2.json"
     ] = try String(contentsOfFile: path!, encoding: String.Encoding.utf8)
@@ -160,7 +187,8 @@ func getVCPlaygroundOID4VCIContext() throws -> [String: String] {
     path = Bundle.main.path(
         forResource:
             "examples.vcplayground.org_contexts_first-responder_v1",
-        ofType: "json")
+        ofType: "json"
+    )
     context[
         "https://examples.vcplayground.org/contexts/first-responder/v1.json"
     ] = try String(contentsOfFile: path!, encoding: String.Encoding.utf8)
@@ -168,7 +196,8 @@ func getVCPlaygroundOID4VCIContext() throws -> [String: String] {
     path = Bundle.main.path(
         forResource:
             "examples.vcplayground.org_contexts_shim-render-method-term_v1",
-        ofType: "json")
+        ofType: "json"
+    )
     context[
         "https://examples.vcplayground.org/contexts/shim-render-method-term/v1.json"
     ] = try String(contentsOfFile: path!, encoding: String.Encoding.utf8)
@@ -176,7 +205,8 @@ func getVCPlaygroundOID4VCIContext() throws -> [String: String] {
     path = Bundle.main.path(
         forResource:
             "examples.vcplayground.org_contexts_shim-VCv1.1-common-example-terms_v1",
-        ofType: "json")
+        ofType: "json"
+    )
     context[
         "https://examples.vcplayground.org/contexts/shim-VCv1.1-common-example-terms/v1.json"
     ] = try String(contentsOfFile: path!, encoding: String.Encoding.utf8)
@@ -184,7 +214,8 @@ func getVCPlaygroundOID4VCIContext() throws -> [String: String] {
     path = Bundle.main.path(
         forResource:
             "examples.vcplayground.org_contexts_utopia-natcert_v1",
-        ofType: "json")
+        ofType: "json"
+    )
     context[
         "https://examples.vcplayground.org/contexts/utopia-natcert/v1.json"
     ] = try String(contentsOfFile: path!, encoding: String.Encoding.utf8)
@@ -192,7 +223,8 @@ func getVCPlaygroundOID4VCIContext() throws -> [String: String] {
     path = Bundle.main.path(
         forResource:
             "w3.org_ns_controller_v1",
-        ofType: "json")
+        ofType: "json"
+    )
     context[
         "https://www.w3.org/ns/controller/v1"
     ] = try String(contentsOfFile: path!, encoding: String.Encoding.utf8)
@@ -200,7 +232,8 @@ func getVCPlaygroundOID4VCIContext() throws -> [String: String] {
     path = Bundle.main.path(
         forResource:
             "examples.vcplayground.org_contexts_movie-ticket_v2",
-        ofType: "json")
+        ofType: "json"
+    )
     context[
         "https://examples.vcplayground.org/contexts/movie-ticket/v2.json"
     ] = try String(contentsOfFile: path!, encoding: String.Encoding.utf8)
@@ -208,7 +241,8 @@ func getVCPlaygroundOID4VCIContext() throws -> [String: String] {
     path = Bundle.main.path(
         forResource:
             "examples.vcplayground.org_contexts_food-safety-certification_v1",
-        ofType: "json")
+        ofType: "json"
+    )
     context[
         "https://examples.vcplayground.org/contexts/food-safety-certification/v1.json"
     ] = try String(contentsOfFile: path!, encoding: String.Encoding.utf8)
@@ -216,7 +250,8 @@ func getVCPlaygroundOID4VCIContext() throws -> [String: String] {
     path = Bundle.main.path(
         forResource:
             "examples.vcplayground.org_contexts_academic-course-credential_v1",
-        ofType: "json")
+        ofType: "json"
+    )
     context[
         "https://examples.vcplayground.org/contexts/academic-course-credential/v1.json"
     ] = try String(contentsOfFile: path!, encoding: String.Encoding.utf8)
@@ -224,7 +259,8 @@ func getVCPlaygroundOID4VCIContext() throws -> [String: String] {
     path = Bundle.main.path(
         forResource:
             "examples.vcplayground.org_contexts_gs1-8110-coupon_v2",
-        ofType: "json")
+        ofType: "json"
+    )
     context[
         "https://examples.vcplayground.org/contexts/gs1-8110-coupon/v2.json"
     ] = try String(contentsOfFile: path!, encoding: String.Encoding.utf8)
@@ -232,7 +268,8 @@ func getVCPlaygroundOID4VCIContext() throws -> [String: String] {
     path = Bundle.main.path(
         forResource:
             "examples.vcplayground.org_contexts_customer-loyalty_v1",
-        ofType: "json")
+        ofType: "json"
+    )
     context[
         "https://examples.vcplayground.org/contexts/customer-loyalty/v1.json"
     ] = try String(contentsOfFile: path!, encoding: String.Encoding.utf8)
@@ -240,7 +277,8 @@ func getVCPlaygroundOID4VCIContext() throws -> [String: String] {
     path = Bundle.main.path(
         forResource:
             "examples.vcplayground.org_contexts_movie-ticket-vcdm-v2_v1",
-        ofType: "json")
+        ofType: "json"
+    )
     context[
         "https://examples.vcplayground.org/contexts/movie-ticket-vcdm-v2/v1.json"
     ] = try String(contentsOfFile: path!, encoding: String.Encoding.utf8)

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleOID4VPView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleOID4VPView.swift
@@ -18,7 +18,7 @@ class Signer: PresentationSigner {
 
     init(keyId: String?) throws {
         self.keyId =
-            if keyId == nil { "reference-app/default-signing" } else { keyId! }
+            if keyId == nil { DEFAULT_SIGNING_KEY_ID } else { keyId! }
         if !KeyManager.keyExists(id: self.keyId) {
             _ = KeyManager.generateSigningKey(id: self.keyId)
         }
@@ -110,7 +110,7 @@ struct HandleOID4VPView: View {
                 ) { (_, new) in new }
             }
 
-            let signer = try Signer(keyId: "reference-app/default-signing")
+            let signer = try Signer(keyId: DEFAULT_SIGNING_KEY_ID)
 
             holder = try await Holder.newWithCredentials(
                 providedCredentials: credentials,

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleOID4VPView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleOID4VPView.swift
@@ -19,7 +19,9 @@ class Signer: PresentationSigner {
     init(keyId: String?) throws {
         self.keyId =
             if keyId == nil { "reference-app/default-signing" } else { keyId! }
-        _ = KeyManager.generateSigningKey(id: self.keyId)
+        if !KeyManager.keyExists(id: self.keyId) {
+            _ = KeyManager.generateSigningKey(id: self.keyId)
+        }
         let jwk = KeyManager.getJwk(id: self.keyId)
         if jwk == nil {
             throw Oid4vpSignerError.illegalArgumentException(

--- a/ios/Showcase/project.yml
+++ b/ios/Showcase/project.yml
@@ -44,8 +44,8 @@ targets:
     info:
       path: Info.plist
       properties:
-        CFBundleVersion: "1.10.4"
-        CFBundleShortVersionString: "1.10.4"
+        CFBundleVersion: "1.11.3"
+        CFBundleShortVersionString: "1.11.3"
         CFBundleDisplayName: "SpruceKit"
         CFBundleIconName: "AppIcon"
         CFBundlePackageType: "APPL"


### PR DESCRIPTION
## Description

> **This PR contains a breaking change!**

This updates the way the CredentialPack stores mDocs. In the old implementation, it wasn't correctly setting the keyAlias. The new implementation split the `.tryAddRawCredential` into `.tryAddRawCredential` and `.tryAddRawMdoc`, and created a new method called `.tryAddAnyFormat`, which calls both to try all options.

### Other changes

This also includes a minor change in the Android app to fix the error modal bottom sheet, and creates a `DEFAULT_SIGNING_KEY_ID` variable to make it easier to use the same `key_id` in different flows.
