### PR TITLE
Add support for new High Assurance requisition states

### DIFF
--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/ApplicationStatus.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/ApplicationStatus.kt
@@ -1,0 +1,285 @@
+package com.spruceid.mobilesdkexample.credentials
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.spruceid.mobile.sdk.rs.FlowState
+import com.spruceid.mobilesdkexample.R
+import com.spruceid.mobilesdkexample.ui.theme.ColorBase50
+import com.spruceid.mobilesdkexample.ui.theme.ColorBlue600
+import com.spruceid.mobilesdkexample.ui.theme.ColorEmerald600
+import com.spruceid.mobilesdkexample.ui.theme.ColorRose700
+import com.spruceid.mobilesdkexample.ui.theme.ColorStone100
+import com.spruceid.mobilesdkexample.ui.theme.ColorStone300
+import com.spruceid.mobilesdkexample.ui.theme.ColorStone500
+import com.spruceid.mobilesdkexample.ui.theme.ColorStone950
+import com.spruceid.mobilesdkexample.ui.theme.Inter
+
+@Composable
+fun ApplicationStatusSmall(status: FlowState) {
+    when (status) {
+        is FlowState.ProofingRequired -> Row(verticalAlignment = Alignment.CenterVertically) {
+            Image(
+                painter = painterResource(id = R.drawable.unknown),
+                contentDescription = stringResource(id = R.string.application_proofing_required),
+                colorFilter = ColorFilter.tint(ColorStone950),
+                modifier = Modifier
+                    .width(14.dp)
+                    .height(14.dp)
+                    .padding(end = 3.dp)
+            )
+            Text(
+                text = "Proofing Required",
+                fontFamily = Inter,
+                fontWeight = FontWeight.Normal,
+                fontSize = 11.sp,
+                color = ColorStone950
+            )
+        }
+
+        FlowState.AwaitingManualReview -> Row(verticalAlignment = Alignment.CenterVertically) {
+            Image(
+                painter = painterResource(id = R.drawable.pending_check),
+                contentDescription = stringResource(id = R.string.application_awaiting_manual_review),
+                colorFilter = ColorFilter.tint(ColorBlue600),
+                modifier = Modifier
+                    .width(14.dp)
+                    .height(14.dp)
+                    .padding(end = 3.dp)
+            )
+            Text(
+                text = "Awaiting Manual Review",
+                fontFamily = Inter,
+                fontWeight = FontWeight.Normal,
+                fontSize = 11.sp,
+                color = ColorBlue600
+            )
+        }
+
+        is FlowState.ReadyToProvision -> Row(verticalAlignment = Alignment.CenterVertically) {
+            Image(
+                painter = painterResource(id = R.drawable.valid),
+                contentDescription = stringResource(id = R.string.application_ready_to_provision),
+                colorFilter = ColorFilter.tint(ColorEmerald600),
+                modifier = Modifier
+                    .width(14.dp)
+                    .height(14.dp)
+                    .padding(end = 3.dp)
+            )
+            Text(
+                text = "Ready to Provision",
+                fontFamily = Inter,
+                fontWeight = FontWeight.Normal,
+                fontSize = 11.sp,
+                color = ColorEmerald600
+            )
+        }
+
+        FlowState.ApplicationDenied -> Row(verticalAlignment = Alignment.CenterVertically) {
+            Image(
+                painter = painterResource(id = R.drawable.invalid),
+                contentDescription = stringResource(id = R.string.application_denied),
+                colorFilter = ColorFilter.tint(ColorRose700),
+                modifier = Modifier
+                    .width(14.dp)
+                    .height(14.dp)
+                    .padding(end = 3.dp)
+            )
+            Text(
+                text = "Application Denied",
+                fontFamily = Inter,
+                fontWeight = FontWeight.Normal,
+                fontSize = 11.sp,
+                color = ColorRose700
+            )
+        }
+    }
+}
+
+@Composable
+fun ApplicationStatus(status: FlowState) {
+    when (status) {
+        is FlowState.ProofingRequired -> Column {
+            Text(
+                "Status",
+                fontFamily = Inter,
+                fontWeight = FontWeight.Normal,
+                fontSize = 16.sp,
+                color = ColorStone500,
+            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(40.dp)
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(ColorStone100)
+                    .border(
+                        width = 1.dp,
+                        color = ColorStone300,
+                        shape = RoundedCornerShape(6.dp)
+                    )
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.unknown),
+                    contentDescription = stringResource(id = R.string.application_proofing_required),
+                    colorFilter = ColorFilter.tint(ColorStone950),
+                    modifier = Modifier
+                        .width(24.dp)
+                        .height(24.dp)
+                        .padding(end = 3.dp)
+                )
+                Text(
+                    text = "PROOFING REQUIRED",
+                    fontFamily = Inter,
+                    fontWeight = FontWeight.Normal,
+                    fontSize = 18.sp,
+                    color = ColorStone950
+                )
+            }
+        }
+
+        FlowState.AwaitingManualReview -> Column {
+            Text(
+                "Status",
+                fontFamily = Inter,
+                fontWeight = FontWeight.Normal,
+                fontSize = 16.sp,
+                color = ColorStone500,
+            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(40.dp)
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(ColorBlue600)
+                    .border(
+                        width = 1.dp,
+                        color = ColorBlue600,
+                        shape = RoundedCornerShape(6.dp)
+                    )
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.pending_check),
+                    contentDescription = stringResource(id = R.string.application_awaiting_manual_review),
+                    colorFilter = ColorFilter.tint(ColorBase50),
+                    modifier = Modifier
+                        .width(24.dp)
+                        .height(24.dp)
+                        .padding(end = 3.dp)
+                )
+                Text(
+                    text = "AWAITING MANUAL REVIEW",
+                    fontFamily = Inter,
+                    fontWeight = FontWeight.Normal,
+                    fontSize = 18.sp,
+                    color = ColorBase50
+                )
+            }
+        }
+
+        is FlowState.ReadyToProvision -> Column {
+            Text(
+                "Status",
+                fontFamily = Inter,
+                fontWeight = FontWeight.Normal,
+                fontSize = 16.sp,
+                color = ColorStone500,
+            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(40.dp)
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(ColorEmerald600)
+                    .border(
+                        width = 1.dp,
+                        color = ColorEmerald600,
+                        shape = RoundedCornerShape(6.dp)
+                    )
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.valid),
+                    contentDescription = stringResource(id = R.string.application_ready_to_provision),
+                    colorFilter = ColorFilter.tint(ColorBase50),
+                    modifier = Modifier
+                        .width(24.dp)
+                        .height(24.dp)
+                        .padding(end = 3.dp)
+                )
+                Text(
+                    text = "READY TO PROVISION",
+                    fontFamily = Inter,
+                    fontWeight = FontWeight.Normal,
+                    fontSize = 18.sp,
+                    color = ColorBase50
+                )
+            }
+        }
+
+        FlowState.ApplicationDenied -> Column {
+            Text(
+                "Status",
+                fontFamily = Inter,
+                fontWeight = FontWeight.Normal,
+                fontSize = 16.sp,
+                color = ColorStone500,
+            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(40.dp)
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(ColorRose700)
+                    .border(
+                        width = 1.dp,
+                        color = ColorRose700,
+                        shape = RoundedCornerShape(6.dp)
+                    )
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.invalid),
+                    contentDescription = stringResource(id = R.string.application_denied),
+                    colorFilter = ColorFilter.tint(ColorBase50),
+                    modifier = Modifier
+                        .width(24.dp)
+                        .height(24.dp)
+                        .padding(end = 3.dp)
+                )
+                Text(
+                    text = "APPLICATION DENIED",
+                    fontFamily = Inter,
+                    fontWeight = FontWeight.Normal,
+                    fontSize = 18.sp,
+                    color = ColorBase50
+                )
+            }
+        }
+    }
+}

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/utils/ControlledSimpleDeleteAlertDialog.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/utils/ControlledSimpleDeleteAlertDialog.kt
@@ -1,0 +1,55 @@
+package com.spruceid.mobilesdkexample.utils
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import com.spruceid.mobilesdkexample.ui.theme.ColorBlue600
+import com.spruceid.mobilesdkexample.ui.theme.ColorRose600
+import com.spruceid.mobilesdkexample.ui.theme.Inter
+
+@Composable
+fun ControlledSimpleDeleteAlertDialog(
+    showDialog: Boolean,
+    message: String,
+    onConfirm: () -> Unit,
+    onClose: () -> Unit,
+    confirmButtonText: String = "Confirm",
+    dismissButtonText: String = "Cancel"
+) {
+    if (showDialog) {
+        AlertDialog(
+            onDismissRequest = { onClose() },
+            confirmButton = {
+                TextButton(onClick = { onConfirm() }) {
+                    Text(
+                        text = confirmButtonText,
+                        fontFamily = Inter,
+                        fontWeight = FontWeight.Normal,
+                        color = ColorRose600,
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { onClose() }) {
+                    Text(
+                        text = dismissButtonText,
+                        fontFamily = Inter,
+                        fontWeight = FontWeight.Bold,
+                        color = ColorBlue600,
+                    )
+                }
+            },
+            text = {
+                Column(Modifier.verticalScroll(rememberScrollState())) {
+                    Text(message)
+                }
+            }
+        )
+    }
+}

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HacApplicationListItem.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HacApplicationListItem.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
 import com.spruceid.mobile.sdk.rs.FlowState
-import com.spruceid.mobilesdkexample.config.EnvironmentConfig
 import com.spruceid.mobilesdkexample.credentials.ApplicationStatusSmall
 import com.spruceid.mobilesdkexample.db.HacApplications
 import com.spruceid.mobilesdkexample.ui.theme.ColorBase300
@@ -75,7 +74,7 @@ fun HacApplicationListItem(
                             is FlowState.ProofingRequired -> {
                                 val intent = Intent(
                                     Intent.ACTION_VIEW,
-                                    "${EnvironmentConfig.proofingClientUrl}/proofing?id=${application?.id}&redirect=spruceid".toUri()
+                                    it.proofingUrl.toUri()
                                 )
                                 context.startActivity(intent)
                             }

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HacApplicationListItem.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HacApplicationListItem.kt
@@ -1,5 +1,6 @@
 package com.spruceid.mobilesdkexample.wallet
 
+import android.content.Intent
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -13,18 +14,24 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.spruceid.mobile.sdk.CredentialStatusList
-import com.spruceid.mobilesdkexample.credentials.CredentialStatusSmall
+import androidx.core.net.toUri
+import com.spruceid.mobile.sdk.rs.FlowState
+import com.spruceid.mobilesdkexample.config.EnvironmentConfig
+import com.spruceid.mobilesdkexample.credentials.ApplicationStatusSmall
 import com.spruceid.mobilesdkexample.db.HacApplications
 import com.spruceid.mobilesdkexample.ui.theme.ColorBase300
 import com.spruceid.mobilesdkexample.ui.theme.ColorStone950
 import com.spruceid.mobilesdkexample.ui.theme.Inter
+import com.spruceid.mobilesdkexample.utils.ControlledSimpleDeleteAlertDialog
 import com.spruceid.mobilesdkexample.viewmodels.HacApplicationsViewModel
+import kotlinx.coroutines.launch
 
 @Composable
 fun HacApplicationListItem(
@@ -32,25 +39,21 @@ fun HacApplicationListItem(
     startIssuance: (String, suspend () -> Unit) -> Unit,
     hacApplicationsViewModel: HacApplicationsViewModel?
 ) {
-    var credentialOfferUrl by remember { mutableStateOf<String?>(null) }
-    var credentialStatus by remember { mutableStateOf(CredentialStatusList.UNDEFINED) }
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var issuanceStatus by remember { mutableStateOf<FlowState?>(null) }
+    var showDeleteDialog by remember { mutableStateOf(false) }
 
     LaunchedEffect(application) {
         if (application != null) {
             try {
-                val status = hacApplicationsViewModel?.issuanceClient?.checkStatus(
+                issuanceStatus = hacApplicationsViewModel?.issuanceClient?.checkStatus(
                     issuanceId = application.issuanceId,
                     walletAttestation = hacApplicationsViewModel.getWalletAttestation()!!
                 )
-                if (status?.state == "ReadyToProvision") {
-                    credentialStatus = CredentialStatusList.READY
-                }
-                credentialOfferUrl = status?.openidCredentialOffer
             } catch (e: Exception) {
                 println(e.message)
             }
-        } else {
-            credentialStatus = CredentialStatusList.PENDING
         }
     }
 
@@ -65,13 +68,31 @@ fun HacApplicationListItem(
             )
             .padding(12.dp)
             .clickable(
-                enabled = credentialOfferUrl != null,
+                enabled = issuanceStatus != FlowState.AwaitingManualReview,
                 onClick = {
-                    credentialOfferUrl?.let { url ->
-                        startIssuance(url) {
-                            application?.let {
-                                hacApplicationsViewModel?.deleteApplication(application.id)
+                    issuanceStatus?.let {
+                        when (it) {
+                            is FlowState.ProofingRequired -> {
+                                val intent = Intent(
+                                    Intent.ACTION_VIEW,
+                                    "${EnvironmentConfig.proofingClientUrl}/proofing?id=${application?.id}&redirect=spruceid".toUri()
+                                )
+                                context.startActivity(intent)
                             }
+
+                            is FlowState.ReadyToProvision -> {
+                                startIssuance(it.openidCredentialOffer) {
+                                    application?.let {
+                                        hacApplicationsViewModel?.deleteApplication(application.id)
+                                    }
+                                }
+                            }
+
+                            FlowState.ApplicationDenied -> {
+                                showDeleteDialog = true
+                            }
+
+                            else -> {}
                         }
                     }
                 }
@@ -86,9 +107,28 @@ fun HacApplicationListItem(
                 color = ColorStone950,
                 modifier = Modifier.padding(bottom = 8.dp)
             )
-            CredentialStatusSmall(status = credentialStatus)
+            issuanceStatus?.let {
+                ApplicationStatusSmall(status = it)
+            }
         }
         Spacer(modifier = Modifier.weight(1f))
     }
+
+    ControlledSimpleDeleteAlertDialog(
+        showDialog = showDeleteDialog,
+        message = "Are you sure you want to delete this application? This action cannot be undone.",
+        onConfirm = {
+            scope.launch {
+                application?.let {
+                    hacApplicationsViewModel?.deleteApplication(application.id)
+                    showDeleteDialog = false
+                }
+            }
+        },
+        onClose = {
+            showDeleteDialog = false
+        },
+        confirmButtonText = "Delete"
+    )
 }
 

--- a/android/Showcase/src/main/res/values/strings.xml
+++ b/android/Showcase/src/main/res/values/strings.xml
@@ -16,6 +16,10 @@
     <string name="revoked_check">Revoked credential</string>
     <string name="pending_check">Credential pending approval</string>
     <string name="ready_check">Credential ready to be claimed</string>
+    <string name="application_proofing_required">Proofing required</string>
+    <string name="application_awaiting_manual_review">Awaiting manual review</string>
+    <string name="application_ready_to_provision">Ready to provision</string>
+    <string name="application_denied">Application denied</string>
     <string name="verification_activity_log">Verification Activity Log</string>
     <string name="chevron">Start action</string>
     <string name="empty_wallet">No credentials added yet</string>

--- a/ios/Showcase/Targets/AppUIKit/Sources/credentials/ApplicationStatus.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/credentials/ApplicationStatus.swift
@@ -1,0 +1,251 @@
+import SpruceIDMobileSdkRs
+import SwiftUI
+
+struct ApplicationStatusSmall: View {
+    var status: FlowState?
+
+    var body: some View {
+        if status != nil {
+            switch status! {
+            case .proofingRequired:
+                HStack {
+                    Image("Unknown")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 14, height: 14)
+                        .foregroundColor(Color("ColorStone950"))
+                    Text("Proofing Required")
+                        .font(
+                            .customFont(
+                                font: .inter,
+                                style: .regular,
+                                size: .small
+                            )
+                        )
+                        .foregroundStyle(Color("ColorStone950"))
+                }
+            case .awaitingManualReview:
+                HStack {
+                    Image("Pending")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 14, height: 14)
+                        .foregroundColor(Color("ColorBlue600"))
+                    Text("Awaiting Manual Review")
+                        .font(
+                            .customFont(
+                                font: .inter,
+                                style: .regular,
+                                size: .small
+                            )
+                        )
+                        .foregroundStyle(Color("ColorBlue600"))
+                }
+
+            case .readyToProvision:
+                HStack {
+                    Image("Valid")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 14, height: 14)
+                        .foregroundColor(Color("ColorEmerald600"))
+                    Text("Ready to Provision")
+                        .font(
+                            .customFont(
+                                font: .inter,
+                                style: .regular,
+                                size: .small
+                            )
+                        )
+                        .foregroundStyle(Color("ColorEmerald600"))
+                }
+
+            case .applicationDenied:
+                HStack {
+                    Image("Invalid")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 14, height: 14)
+                        .foregroundColor(Color("ColorRose700"))
+                    Text("Application Denied")
+                        .font(
+                            .customFont(
+                                font: .inter,
+                                style: .regular,
+                                size: .small
+                            )
+                        )
+                        .foregroundStyle(Color("ColorRose700"))
+                }
+            }
+        } else {
+            EmptyView()
+        }
+
+    }
+}
+
+struct ApplicationStatus: View {
+    var status: FlowState?
+
+    var body: some View {
+        if status != nil {
+            switch status! {
+            case .proofingRequired:
+                VStack {
+                    HStack(alignment: .center) {
+                        Text("Status")
+                            .font(
+                                .customFont(
+                                    font: .inter,
+                                    style: .regular,
+                                    size: .h4
+                                )
+                            )
+                            .foregroundStyle(Color("ColorStone600"))
+                        Spacer()
+                    }
+                    HStack {
+                        Image("Unknown")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(Color("ColorStone950"))
+                        Text("PROOFING REQUIRED")
+                            .font(
+                                .customFont(
+                                    font: .inter,
+                                    style: .regular,
+                                    size: .h3
+                                )
+                            )
+                            .foregroundStyle(Color("ColorStone950"))
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 40)
+                    .background(Color("ColorStone100"))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(Color("ColorStone300"), lineWidth: 1)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+                .padding(.leading, CGFloat(4))
+
+            case .awaitingManualReview:
+                VStack {
+                    HStack(alignment: .center) {
+                        Text("Status")
+                            .font(
+                                .customFont(
+                                    font: .inter,
+                                    style: .regular,
+                                    size: .h4
+                                )
+                            )
+                            .foregroundStyle(Color("ColorBlue600"))
+                        Spacer()
+                    }
+                    HStack {
+                        Image("Pending")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(Color("ColorBase50"))
+                        Text("AWAITING MANUAL REVIEW")
+                            .font(
+                                .customFont(
+                                    font: .inter,
+                                    style: .regular,
+                                    size: .h3
+                                )
+                            )
+                            .foregroundStyle(Color("ColorBase50"))
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 40)
+                    .background(Color("ColorBlue600"))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+                .padding(.leading, CGFloat(4))
+
+            case .readyToProvision:
+                VStack {
+                    HStack(alignment: .center) {
+                        Text("Status")
+                            .font(
+                                .customFont(
+                                    font: .inter,
+                                    style: .regular,
+                                    size: .h4
+                                )
+                            )
+                            .foregroundStyle(Color("ColorStone600"))
+                        Spacer()
+                    }
+                    HStack {
+                        Image("Valid")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(Color("ColorBase50"))
+                        Text("READY TO PROVISION")
+                            .font(
+                                .customFont(
+                                    font: .inter,
+                                    style: .regular,
+                                    size: .h3
+                                )
+                            )
+                            .foregroundStyle(Color("ColorBase50"))
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 40)
+                    .background(Color("ColorEmerald600"))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+                .padding(.leading, CGFloat(4))
+
+            case .applicationDenied:
+                VStack {
+                    HStack(alignment: .center) {
+                        Text("Status")
+                            .font(
+                                .customFont(
+                                    font: .inter,
+                                    style: .regular,
+                                    size: .h4
+                                )
+                            )
+                            .foregroundStyle(Color("ColorStone600"))
+                        Spacer()
+                    }
+                    HStack {
+                        Image("Invalid")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(Color("ColorBase50"))
+                        Text("APPLICATION DENIED")
+                            .font(
+                                .customFont(
+                                    font: .inter,
+                                    style: .regular,
+                                    size: .h3
+                                )
+                            )
+                            .foregroundStyle(Color("ColorBase50"))
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 40)
+                    .background(Color("ColorRose700"))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+                .padding(.leading, CGFloat(4))
+            }
+        } else {
+            EmptyView()
+        }
+
+    }
+}

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/ApplySpruceMdlConfirmation.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/ApplySpruceMdlConfirmation.swift
@@ -15,8 +15,7 @@ struct ApplySpruceMdlConfirmation: View {
                     .padding(.top, 24)
 
                 HacApplicationListItem(
-                    application: nil,
-                    startIssuance: { _ in }
+                    hacApplication: nil
                 )
 
                 Text(

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/HacApplicationListItem.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/HacApplicationListItem.swift
@@ -3,12 +3,29 @@ import SpruceIDMobileSdkRs
 import SwiftUI
 
 struct HacApplicationListItem: View {
+    @Binding var path: NavigationPath?
     @EnvironmentObject var hacApplicationObservable: HacApplicationObservable
 
-    let application: HacApplication?
-    let startIssuance: (String) -> Void
-    @State var credentialOfferUrl: String?
-    @State var credentialStatus: CredentialStatusList = .undefined
+    let hacApplication: HacApplication?
+    @State var issuanceStatus: FlowState?
+    @State var showDeleteDialog: Bool = false
+
+    init(
+        path: Binding<NavigationPath?> = .constant(nil),
+        hacApplication: HacApplication?
+    ) {
+        self._path = path
+        self.hacApplication = hacApplication
+    }
+
+    func deleteApplication() {
+        if let application = hacApplication {
+            _ = HacApplicationDataStore
+                .shared.delete(
+                    id: application.id
+                )
+        }
+    }
 
     var body: some View {
         HStack {
@@ -23,8 +40,8 @@ struct HacApplicationListItem: View {
                             )
                         )
                         .foregroundStyle(Color("ColorStone950"))
-                    CredentialStatusSmall(
-                        status: credentialStatus
+                    ApplicationStatusSmall(
+                        status: issuanceStatus
                     )
                 }
                 .padding(.leading, 12)
@@ -42,13 +59,48 @@ struct HacApplicationListItem: View {
                 .stroke(Color("ColorBase300"), lineWidth: 1)
         )
         .padding(12)
+        .alert("Delete Application", isPresented: $showDeleteDialog) {
+            Button("Cancel", role: .cancel) {}
+            Button("Delete", role: .destructive) {
+                deleteApplication()
+            }
+        } message: {
+            Text(
+                "Are you sure you want to delete this application? This action cannot be undone."
+            )
+        }
         .onTapGesture {
-            if let credentialOfferUrl = credentialOfferUrl {
-                startIssuance(credentialOfferUrl)
+            if let status = issuanceStatus {
+                switch status {
+                case .proofingRequired(let proofingUrl):
+                    if let url = URL(
+                        string:
+                            proofingUrl
+                    ) {
+                        UIApplication.shared.open(
+                            url,
+                            options: [:],
+                            completionHandler: nil
+                        )
+                    }
+                case .awaitingManualReview:
+                    return
+                case .readyToProvision(let openidCredentialOffer):
+                    path?.append(
+                        HandleOID4VCI(
+                            url: openidCredentialOffer,
+                            onSuccess: {
+                                deleteApplication()
+                            }
+                        )
+                    )
+                case .applicationDenied:
+                    showDeleteDialog = true
+                }
             }
         }
         .onAppear {
-            if let application = application {
+            if let application = hacApplication {
                 Task {
                     do {
                         let walletAttestation =
@@ -56,22 +108,16 @@ struct HacApplicationListItem: View {
                             .getWalletAttestation()
                             .unwrap()
 
-                        let status =
+                        issuanceStatus =
                             try await hacApplicationObservable.issuanceClient
                             .checkStatus(
                                 issuanceId: application.issuanceId,
                                 walletAttestation: walletAttestation
                             )
-                        if status.state == "ReadyToProvision" {
-                            credentialStatus = .ready
-                        }
-                        credentialOfferUrl = status.openidCredentialOffer
                     } catch {
                         print(error.localizedDescription)
                     }
                 }
-            } else {
-                credentialStatus = .pending
             }
         }
     }

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/WalletHomeView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/WalletHomeView.swift
@@ -124,20 +124,8 @@ struct WalletHomeBody: View {
                                 id: \.self.id
                             ) { hacApplication in
                                 HacApplicationListItem(
-                                    application: hacApplication,
-                                    startIssuance: { credentialOfferUrl in
-                                        path.append(
-                                            HandleOID4VCI(
-                                                url: credentialOfferUrl,
-                                                onSuccess: {
-                                                    _ = HacApplicationDataStore
-                                                        .shared.delete(
-                                                            id: hacApplication
-                                                                .id)
-                                                }
-                                            )
-                                        )
-                                    }
+                                    path: Binding<NavigationPath?>($path),
+                                    hacApplication: hacApplication
                                 )
                             }
                             ForEach(

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -563,7 +563,7 @@ fileprivate struct FfiConverterData: FfiConverterRustBuffer {
 
 
 
-public protocol AsyncHttpClient: AnyObject {
+public protocol AsyncHttpClient: AnyObject, Sendable {
     
     func httpClient(request: HttpRequest) async throws  -> HttpResponse
     
@@ -582,6 +582,9 @@ open class AsyncHttpClientImpl: AsyncHttpClient, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -630,7 +633,7 @@ open func httpClient(request: HttpRequest)async throws  -> HttpResponse  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeHttpResponse_lift,
-            errorHandler: FfiConverterTypeHttpClientError.lift
+            errorHandler: FfiConverterTypeHttpClientError_lift
         )
 }
     
@@ -768,7 +771,7 @@ public func FfiConverterTypeAsyncHttpClient_lower(_ value: AsyncHttpClient) -> U
 
 
 
-public protocol CborIntegerProtocol: AnyObject {
+public protocol CborIntegerProtocol: AnyObject, Sendable {
     
     func lowerBytes()  -> UInt64
     
@@ -791,6 +794,9 @@ open class CborInteger: CborIntegerProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -905,7 +911,7 @@ public func FfiConverterTypeCborInteger_lower(_ value: CborInteger) -> UnsafeMut
 
 
 
-public protocol CborTagProtocol: AnyObject {
+public protocol CborTagProtocol: AnyObject, Sendable {
     
     func id()  -> UInt64
     
@@ -926,6 +932,9 @@ open class CborTag: CborTagProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1033,7 +1042,7 @@ public func FfiConverterTypeCborTag_lower(_ value: CborTag) -> UnsafeMutableRawP
 
 
 
-public protocol ClientProtocol: AnyObject {
+public protocol ClientProtocol: AnyObject, Sendable {
     
 }
 open class Client: ClientProtocol, @unchecked Sendable {
@@ -1050,6 +1059,9 @@ open class Client: ClientProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1143,7 +1155,7 @@ public func FfiConverterTypeClient_lower(_ value: Client) -> UnsafeMutableRawPoi
 
 
 
-public protocol CredentialIssuerMetadataProtocol: AnyObject {
+public protocol CredentialIssuerMetadataProtocol: AnyObject, Sendable {
     
 }
 open class CredentialIssuerMetadata: CredentialIssuerMetadataProtocol, @unchecked Sendable {
@@ -1160,6 +1172,9 @@ open class CredentialIssuerMetadata: CredentialIssuerMetadataProtocol, @unchecke
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1253,7 +1268,7 @@ public func FfiConverterTypeCredentialIssuerMetadata_lower(_ value: CredentialIs
 
 
 
-public protocol CredentialRequestProtocol: AnyObject {
+public protocol CredentialRequestProtocol: AnyObject, Sendable {
     
 }
 open class CredentialRequest: CredentialRequestProtocol, @unchecked Sendable {
@@ -1270,6 +1285,9 @@ open class CredentialRequest: CredentialRequestProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1363,7 +1381,7 @@ public func FfiConverterTypeCredentialRequest_lower(_ value: CredentialRequest) 
 
 
 
-public protocol Crypto: AnyObject {
+public protocol Crypto: AnyObject, Sendable {
     
     func p256Verify(certificateDer: Data, payload: Data, signature: Data)  -> VerificationResult
     
@@ -1382,6 +1400,9 @@ open class CryptoImpl: Crypto, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1543,7 +1564,7 @@ public func FfiConverterTypeCrypto_lower(_ value: Crypto) -> UnsafeMutableRawPoi
 /**
  * Utility functions for cryptographic curves
  */
-public protocol CryptoCurveUtilsProtocol: AnyObject {
+public protocol CryptoCurveUtilsProtocol: AnyObject, Sendable {
     
     /**
      * Returns null if the original signature encoding is not recognized.
@@ -1568,6 +1589,9 @@ open class CryptoCurveUtils: CryptoCurveUtilsProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1682,7 +1706,7 @@ public func FfiConverterTypeCryptoCurveUtils_lower(_ value: CryptoCurveUtils) ->
 
 
 
-public protocol CwtProtocol: AnyObject {
+public protocol CwtProtocol: AnyObject, Sendable {
     
     /**
      * The version of the Verifiable Credential Data Model that this credential conforms to.
@@ -1718,6 +1742,9 @@ open class Cwt: CwtProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1811,7 +1838,7 @@ open func verify(crypto: Crypto)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeCwtError.lift
+            errorHandler: FfiConverterTypeCwtError_lift
         )
 }
     
@@ -1873,7 +1900,7 @@ public func FfiConverterTypeCwt_lower(_ value: Cwt) -> UnsafeMutableRawPointer {
 
 
 
-public protocol DelegatedVerifierProtocol: AnyObject {
+public protocol DelegatedVerifierProtocol: AnyObject, Sendable {
     
     func pollVerificationStatus(url: String) async throws  -> DelegatedVerifierStatusResponse
     
@@ -1904,6 +1931,9 @@ open class DelegatedVerifier: DelegatedVerifierProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1948,7 +1978,7 @@ public static func newClient(baseUrl: Url)async throws  -> DelegatedVerifier  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeDelegatedVerifier_lift,
-            errorHandler: FfiConverterTypeOid4vpVerifierError.lift
+            errorHandler: FfiConverterTypeOid4vpVerifierError_lift
         )
 }
     
@@ -1967,7 +1997,7 @@ open func pollVerificationStatus(url: String)async throws  -> DelegatedVerifierS
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeDelegatedVerifierStatusResponse_lift,
-            errorHandler: FfiConverterTypeOid4vpVerifierError.lift
+            errorHandler: FfiConverterTypeOid4vpVerifierError_lift
         )
 }
     
@@ -1994,7 +2024,7 @@ open func requestDelegatedVerification(url: String)async throws  -> DelegateInit
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeDelegateInitializationResponse_lift,
-            errorHandler: FfiConverterTypeOid4vpVerifierError.lift
+            errorHandler: FfiConverterTypeOid4vpVerifierError_lift
         )
 }
     
@@ -2056,7 +2086,7 @@ public func FfiConverterTypeDelegatedVerifier_lower(_ value: DelegatedVerifier) 
 
 
 
-public protocol DidMethodUtilsProtocol: AnyObject {
+public protocol DidMethodUtilsProtocol: AnyObject, Sendable {
     
     func didFromJwk(jwk: String) throws  -> String
     
@@ -2077,6 +2107,9 @@ open class DidMethodUtils: DidMethodUtilsProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2141,7 +2174,7 @@ open func vmFromJwk(jwk: String)async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeDidError.lift
+            errorHandler: FfiConverterTypeDidError_lift
         )
 }
     
@@ -2203,7 +2236,7 @@ public func FfiConverterTypeDidMethodUtils_lower(_ value: DidMethodUtils) -> Uns
 
 
 
-public protocol GrantsProtocol: AnyObject {
+public protocol GrantsProtocol: AnyObject, Sendable {
     
 }
 open class Grants: GrantsProtocol, @unchecked Sendable {
@@ -2220,6 +2253,9 @@ open class Grants: GrantsProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2319,7 +2355,7 @@ public func FfiConverterTypeGrants_lower(_ value: Grants) -> UnsafeMutableRawPoi
  * The Holder has the ability to generate Verifiable Presentations from
  * these credentials and share them with Verifiers.
  */
-public protocol HolderProtocol: AnyObject {
+public protocol HolderProtocol: AnyObject, Sendable {
     
     /**
      * Given an authorization request URL, return a permission request,
@@ -2353,6 +2389,9 @@ open class Holder: HolderProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2389,7 +2428,7 @@ public convenience init(vdcCollection: VdcCollection, trustedDids: [String], sig
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeHolder_lift,
-            errorHandler: FfiConverterTypeOID4VPError.lift
+            errorHandler: FfiConverterTypeOID4VPError_lift
         )
         
         .uniffiClonePointer()
@@ -2423,7 +2462,7 @@ public static func newWithCredentials(providedCredentials: [ParsedCredential], t
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeHolder_lift,
-            errorHandler: FfiConverterTypeOID4VPError.lift
+            errorHandler: FfiConverterTypeOID4VPError_lift
         )
 }
     
@@ -2449,7 +2488,7 @@ open func authorizationRequest(req: AuthRequest)async throws  -> PermissionReque
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypePermissionRequest_lift,
-            errorHandler: FfiConverterTypeOID4VPError.lift
+            errorHandler: FfiConverterTypeOID4VPError_lift
         )
 }
     
@@ -2466,7 +2505,7 @@ open func submitPermissionResponse(response: PermissionResponse)async throws  ->
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeUrl.lift,
-            errorHandler: FfiConverterTypeOID4VPError.lift
+            errorHandler: FfiConverterTypeOID4VPError_lift
         )
 }
     
@@ -2536,7 +2575,7 @@ public func FfiConverterTypeHolder_lower(_ value: Holder) -> UnsafeMutableRawPoi
  * `Arc` is wrapped with `IArc` to facilitate trait implementation from
  * `openidconnect` library used by request builders and client on `oid4vci-rs`.
  */
-public protocol IHttpClientProtocol: AnyObject {
+public protocol IHttpClientProtocol: AnyObject, Sendable {
     
 }
 /**
@@ -2561,6 +2600,9 @@ open class IHttpClient: IHttpClientProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2670,7 +2712,7 @@ public func FfiConverterTypeIHttpClient_lower(_ value: IHttpClient) -> UnsafeMut
 
 
 
-public protocol InProcessRecordProtocol: AnyObject {
+public protocol InProcessRecordProtocol: AnyObject, Sendable {
     
 }
 open class InProcessRecord: InProcessRecordProtocol, @unchecked Sendable {
@@ -2687,6 +2729,9 @@ open class InProcessRecord: InProcessRecordProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2780,7 +2825,7 @@ public func FfiConverterTypeInProcessRecord_lower(_ value: InProcessRecord) -> U
 
 
 
-public protocol InProgressRequest180137Protocol: AnyObject {
+public protocol InProgressRequest180137Protocol: AnyObject, Sendable {
     
     func matches()  -> [RequestMatch180137]
     
@@ -2801,6 +2846,9 @@ open class InProgressRequest180137: InProgressRequest180137Protocol, @unchecked 
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2856,7 +2904,7 @@ open func respond(approvedResponse: ApprovedResponse180137)async throws  -> Url?
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeUrl.lift,
-            errorHandler: FfiConverterTypeOID4VP180137Error.lift
+            errorHandler: FfiConverterTypeOID4VP180137Error_lift
         )
 }
     
@@ -2918,7 +2966,7 @@ public func FfiConverterTypeInProgressRequest180137_lower(_ value: InProgressReq
 
 
 
-public protocol InProgressRequestDcApiProtocol: AnyObject {
+public protocol InProgressRequestDcApiProtocol: AnyObject, Sendable {
     
     func getMatch()  -> RequestMatch180137
     
@@ -2946,6 +2994,9 @@ open class InProgressRequestDcApi: InProgressRequestDcApiProtocol, @unchecked Se
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3013,7 +3064,7 @@ open func respond(keystore: KeyStore, approvedFields: [FieldId180137])async thro
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeDcApiError.lift
+            errorHandler: FfiConverterTypeDcApiError_lift
         )
 }
     
@@ -3075,7 +3126,7 @@ public func FfiConverterTypeInProgressRequestDcApi_lower(_ value: InProgressRequ
 
 
 
-public protocol IssuanceServiceClientProtocol: AnyObject {
+public protocol IssuanceServiceClientProtocol: AnyObject, Sendable {
     
     /**
      * Checks the status of an issuance request
@@ -3117,6 +3168,9 @@ open class IssuanceServiceClient: IssuanceServiceClientProtocol, @unchecked Send
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3190,7 +3244,7 @@ open func checkStatus(issuanceId: String, walletAttestation: String)async throws
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeFlowState_lift,
-            errorHandler: FfiConverterTypeIssuanceServiceError.lift
+            errorHandler: FfiConverterTypeIssuanceServiceError_lift
         )
 }
     
@@ -3217,7 +3271,7 @@ open func newIssuance(walletAttestation: String)async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeIssuanceServiceError.lift
+            errorHandler: FfiConverterTypeIssuanceServiceError_lift
         )
 }
     
@@ -3279,7 +3333,7 @@ public func FfiConverterTypeIssuanceServiceClient_lower(_ value: IssuanceService
 
 
 
-public protocol JsonLdPresentationBuilderProtocol: AnyObject {
+public protocol JsonLdPresentationBuilderProtocol: AnyObject, Sendable {
     
     func issuePresentation(credentials: [ParsedCredential]) async throws  -> String
     
@@ -3298,6 +3352,9 @@ open class JsonLdPresentationBuilder: JsonLdPresentationBuilderProtocol, @unchec
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3360,7 +3417,7 @@ open func issuePresentation(credentials: [ParsedCredential])async throws  -> Str
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypePresentationBuilderError.lift
+            errorHandler: FfiConverterTypePresentationBuilderError_lift
         )
 }
     
@@ -3425,7 +3482,7 @@ public func FfiConverterTypeJsonLdPresentationBuilder_lower(_ value: JsonLdPrese
 /**
  * A verifiable credential secured as JSON.
  */
-public protocol JsonVcProtocol: AnyObject {
+public protocol JsonVcProtocol: AnyObject, Sendable {
     
     /**
      * Access the W3C VCDM credential as a JSON encoded UTF-8 string.
@@ -3482,6 +3539,9 @@ open class JsonVc: JsonVcProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3587,7 +3647,7 @@ open func status()async throws  -> Status  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeStatus_lift,
-            errorHandler: FfiConverterTypeStatusListError.lift
+            errorHandler: FfiConverterTypeStatusListError_lift
         )
 }
     
@@ -3683,7 +3743,7 @@ public func FfiConverterTypeJsonVc_lower(_ value: JsonVc) -> UnsafeMutableRawPoi
 /**
  * A verifiable credential secured as a JWT.
  */
-public protocol JwtVcProtocol: AnyObject {
+public protocol JwtVcProtocol: AnyObject, Sendable {
     
     /**
      * Access the W3C VCDM credential as a JSON encoded UTF-8 string.
@@ -3744,6 +3804,9 @@ open class JwtVc: JwtVcProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3948,7 +4011,7 @@ public func FfiConverterTypeJwtVc_lower(_ value: JwtVc) -> UnsafeMutableRawPoint
 /**
  * An interface that can provide access to cryptographic keypairs from the native crypto API.
  */
-public protocol KeyStore: AnyObject {
+public protocol KeyStore: AnyObject, Sendable {
     
     /**
      * Retrieve a cryptographic keypair by alias. The cryptographic key must be usable for
@@ -3974,6 +4037,9 @@ open class KeyStoreImpl: KeyStore, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4131,7 +4197,7 @@ public func FfiConverterTypeKeyStore_lower(_ value: KeyStore) -> UnsafeMutableRa
 
 
 
-public protocol LogWriter: AnyObject {
+public protocol LogWriter: AnyObject, Sendable {
     
     func writeToBuffer(message: Data) 
     
@@ -4152,6 +4218,9 @@ open class LogWriterImpl: LogWriter, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4331,7 +4400,7 @@ public func FfiConverterTypeLogWriter_lower(_ value: LogWriter) -> UnsafeMutable
 
 
 
-public protocol MdlSessionManagerProtocol: AnyObject {
+public protocol MdlSessionManagerProtocol: AnyObject, Sendable {
     
 }
 open class MdlSessionManager: MdlSessionManagerProtocol, @unchecked Sendable {
@@ -4348,6 +4417,9 @@ open class MdlSessionManager: MdlSessionManagerProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4441,7 +4513,7 @@ public func FfiConverterTypeMDLSessionManager_lower(_ value: MdlSessionManager) 
 
 
 
-public protocol MdlPresentationSessionProtocol: AnyObject {
+public protocol MdlPresentationSessionProtocol: AnyObject, Sendable {
     
     /**
      * Constructs the response to be sent from the holder to the reader containing
@@ -4497,6 +4569,9 @@ open class MdlPresentationSession: MdlPresentationSessionProtocol, @unchecked Se
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4662,7 +4737,7 @@ public func FfiConverterTypeMdlPresentationSession_lower(_ value: MdlPresentatio
 
 
 
-public protocol MdocProtocol: AnyObject {
+public protocol MdocProtocol: AnyObject, Sendable {
     
     /**
      * Simple representation of mdoc namespace and data elements for display in the UI.
@@ -4696,6 +4771,9 @@ open class Mdoc: MdocProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4869,7 +4947,7 @@ public func FfiConverterTypeMdoc_lower(_ value: Mdoc) -> UnsafeMutableRawPointer
  *
  * Notably this supports requests which use the URI scheme `mdoc-openid4vp://`.
  */
-public protocol Oid4vp180137Protocol: AnyObject {
+public protocol Oid4vp180137Protocol: AnyObject, Sendable {
     
     func processRequest(url: Url) async throws  -> InProgressRequest180137
     
@@ -4893,6 +4971,9 @@ open class Oid4vp180137: Oid4vp180137Protocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4950,7 +5031,7 @@ open func processRequest(url: Url)async throws  -> InProgressRequest180137  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeInProgressRequest180137_lift,
-            errorHandler: FfiConverterTypeOID4VP180137Error.lift
+            errorHandler: FfiConverterTypeOID4VP180137Error_lift
         )
 }
     
@@ -5012,7 +5093,7 @@ public func FfiConverterTypeOID4VP180137_lower(_ value: Oid4vp180137) -> UnsafeM
 
 
 
-public protocol Oid4vciProtocol: AnyObject {
+public protocol Oid4vciProtocol: AnyObject, Sendable {
     
     func clearContextMap() throws 
     
@@ -5043,6 +5124,9 @@ open class Oid4vci: Oid4vciProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5134,7 +5218,7 @@ open func exchangeCredential(proofsOfPossession: [String], options: Oid4vciExcha
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeCredentialResponse.lift,
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
     
@@ -5151,7 +5235,7 @@ open func exchangeToken()async throws  -> String?  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionString.lift,
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
     
@@ -5175,7 +5259,7 @@ open func initiate(baseUrl: String, clientId: String, redirectUrl: String)async 
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
     
@@ -5192,7 +5276,7 @@ open func initiateWithOffer(credentialOffer: String, clientId: String, redirectU
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
     
@@ -5261,7 +5345,7 @@ public func FfiConverterTypeOid4vci_lower(_ value: Oid4vci) -> UnsafeMutableRawP
 
 
 
-public protocol Oid4vciMetadataProtocol: AnyObject {
+public protocol Oid4vciMetadataProtocol: AnyObject, Sendable {
     
     func authorizationServers()  -> [String]?
     
@@ -5292,6 +5376,9 @@ open class Oid4vciMetadata: Oid4vciMetadataProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5434,7 +5521,7 @@ public func FfiConverterTypeOid4vciMetadata_lower(_ value: Oid4vciMetadata) -> U
 
 
 
-public protocol Oid4vciSessionProtocol: AnyObject {
+public protocol Oid4vciSessionProtocol: AnyObject, Sendable {
     
 }
 open class Oid4vciSession: Oid4vciSessionProtocol, @unchecked Sendable {
@@ -5451,6 +5538,9 @@ open class Oid4vciSession: Oid4vciSessionProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5547,7 +5637,7 @@ public func FfiConverterTypeOid4vciSession_lower(_ value: Oid4vciSession) -> Uns
 /**
  * A credential that has been parsed as a known variant.
  */
-public protocol ParsedCredentialProtocol: AnyObject {
+public protocol ParsedCredentialProtocol: AnyObject, Sendable {
     
     /**
      * Return the credential as an CWT, if it is of that format.
@@ -5617,6 +5707,9 @@ open class ParsedCredential: ParsedCredentialProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5908,7 +6001,7 @@ public func FfiConverterTypeParsedCredential_lower(_ value: ParsedCredential) ->
 
 
 
-public protocol PermissionRequestProtocol: AnyObject {
+public protocol PermissionRequestProtocol: AnyObject, Sendable {
     
     /**
      * Return the client ID for the authorization request.
@@ -5969,6 +6062,9 @@ open class PermissionRequest: PermissionRequestProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6037,7 +6133,7 @@ open func createPermissionResponse(selectedCredentials: [PresentableCredential],
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypePermissionResponse_lift,
-            errorHandler: FfiConverterTypeOID4VPError.lift
+            errorHandler: FfiConverterTypeOID4VPError_lift
         )
 }
     
@@ -6155,7 +6251,7 @@ public func FfiConverterTypePermissionRequest_lower(_ value: PermissionRequest) 
  * The Requested Fields are created by calling the [PermissionRequest::requested_fields] method, and then
  * explicitly setting the permission to true or false, based on the holder's decision.
  */
-public protocol PermissionResponseProtocol: AnyObject {
+public protocol PermissionResponseProtocol: AnyObject, Sendable {
     
     /**
      * Return the selected credentials for the permission response.
@@ -6193,6 +6289,9 @@ open class PermissionResponse: PermissionResponseProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6312,7 +6411,7 @@ public func FfiConverterTypePermissionResponse_lower(_ value: PermissionResponse
 /**
  * A credential that has been parsed as a known variant.
  */
-public protocol PresentableCredentialProtocol: AnyObject {
+public protocol PresentableCredentialProtocol: AnyObject, Sendable {
     
     /**
      * Converts to the primitive ParsedCredential type
@@ -6343,6 +6442,9 @@ open class PresentableCredential: PresentableCredentialProtocol, @unchecked Send
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6460,7 +6562,7 @@ public func FfiConverterTypePresentableCredential_lower(_ value: PresentableCred
 /**
  * A viable match for the credential request.
  */
-public protocol RequestMatch180137Protocol: AnyObject {
+public protocol RequestMatch180137Protocol: AnyObject, Sendable {
     
     func credentialId()  -> Uuid
     
@@ -6484,6 +6586,9 @@ open class RequestMatch180137: RequestMatch180137Protocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6591,7 +6696,7 @@ public func FfiConverterTypeRequestMatch180137_lower(_ value: RequestMatch180137
 
 
 
-public protocol RequestedFieldProtocol: AnyObject {
+public protocol RequestedFieldProtocol: AnyObject, Sendable {
     
     /**
      * Return the unique ID for the request field.
@@ -6648,6 +6753,9 @@ open class RequestedField: RequestedFieldProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6824,7 +6932,7 @@ public func FfiConverterTypeRequestedField_lower(_ value: RequestedField) -> Uns
 /**
  * A cryptographic keypair that can be used for signing.
  */
-public protocol SigningKey: AnyObject {
+public protocol SigningKey: AnyObject, Sendable {
     
     /**
      * Generates a public JWK for this key.
@@ -6854,6 +6962,9 @@ open class SigningKeyImpl: SigningKey, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -7050,7 +7161,7 @@ public func FfiConverterTypeSigningKey_lower(_ value: SigningKey) -> UnsafeMutab
  * and the purpose is the purpose of the credential, which is used
  * to interpret the value.
  */
-public protocol StatusProtocol: AnyObject {
+public protocol StatusProtocol: AnyObject, Sendable {
     
     /**
      * Return whether the credential status has a message.
@@ -7099,6 +7210,9 @@ open class Status: StatusProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -7249,7 +7363,7 @@ public func FfiConverterTypeStatus_lower(_ value: Status) -> UnsafeMutableRawPoi
  * and the purpose is the purpose of the credential, which is used
  * to interpret the value.
  */
-public protocol Status20240406Protocol: AnyObject {
+public protocol Status20240406Protocol: AnyObject, Sendable {
     
     /**
      * Return whether the credential status has a message.
@@ -7298,6 +7412,9 @@ open class Status20240406: Status20240406Protocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -7453,7 +7570,7 @@ public func FfiConverterTypeStatus20240406_lower(_ value: Status20240406) -> Uns
  * We use the older callback_interface to keep the required version level of our Android API
  * low.
  */
-public protocol StorageManagerInterface: AnyObject {
+public protocol StorageManagerInterface: AnyObject, Sendable {
     
     /**
      * Function: add
@@ -7519,6 +7636,9 @@ open class StorageManagerInterfaceImpl: StorageManagerInterface, @unchecked Send
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -7577,7 +7697,7 @@ open func add(key: Key, value: Value)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeStorageManagerError.lift
+            errorHandler: FfiConverterTypeStorageManagerError_lift
         )
 }
     
@@ -7600,7 +7720,7 @@ open func get(key: Key)async throws  -> Value?  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeValue.lift,
-            errorHandler: FfiConverterTypeStorageManagerError.lift
+            errorHandler: FfiConverterTypeStorageManagerError_lift
         )
 }
     
@@ -7622,7 +7742,7 @@ open func list()async throws  -> [Key]  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeKey.lift,
-            errorHandler: FfiConverterTypeStorageManagerError.lift
+            errorHandler: FfiConverterTypeStorageManagerError_lift
         )
 }
     
@@ -7647,7 +7767,7 @@ open func remove(key: Key)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeStorageManagerError.lift
+            errorHandler: FfiConverterTypeStorageManagerError_lift
         )
 }
     
@@ -7904,7 +8024,7 @@ public func FfiConverterTypeStorageManagerInterface_lower(_ value: StorageManage
 
 
 
-public protocol SyncHttpClient: AnyObject {
+public protocol SyncHttpClient: AnyObject, Sendable {
     
     func httpClient(request: HttpRequest) throws  -> HttpResponse
     
@@ -7923,6 +8043,9 @@ open class SyncHttpClientImpl: SyncHttpClient, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -8076,7 +8199,7 @@ public func FfiConverterTypeSyncHttpClient_lower(_ value: SyncHttpClient) -> Uns
 
 
 
-public protocol TokenResponseProtocol: AnyObject {
+public protocol TokenResponseProtocol: AnyObject, Sendable {
     
 }
 open class TokenResponse: TokenResponseProtocol, @unchecked Sendable {
@@ -8093,6 +8216,9 @@ open class TokenResponse: TokenResponseProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -8186,7 +8312,7 @@ public func FfiConverterTypeTokenResponse_lower(_ value: TokenResponse) -> Unsaf
 
 
 
-public protocol Vcdm2SdJwtProtocol: AnyObject {
+public protocol Vcdm2SdJwtProtocol: AnyObject, Sendable {
     
     /**
      * Return the ID for the SdJwt instance.
@@ -8230,6 +8356,9 @@ open class Vcdm2SdJwt: Vcdm2SdJwtProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -8335,7 +8464,7 @@ open func status()async throws  -> [Status20240406]  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeStatus20240406.lift,
-            errorHandler: FfiConverterTypeStatusListError.lift
+            errorHandler: FfiConverterTypeStatusListError_lift
         )
 }
     
@@ -8413,7 +8542,7 @@ public func FfiConverterTypeVCDM2SdJwt_lower(_ value: Vcdm2SdJwt) -> UnsafeMutab
  *
  * This is the main interface to credentials.
  */
-public protocol VdcCollectionProtocol: AnyObject {
+public protocol VdcCollectionProtocol: AnyObject, Sendable {
     
     /**
      * Add a credential to the set.
@@ -8465,6 +8594,9 @@ open class VdcCollection: VdcCollectionProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -8527,7 +8659,7 @@ open func add(credential: Credential)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVdcCollectionError.lift
+            errorHandler: FfiConverterTypeVdcCollectionError_lift
         )
 }
     
@@ -8547,7 +8679,7 @@ open func allEntries()async throws  -> [Uuid]  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeUuid.lift,
-            errorHandler: FfiConverterTypeVdcCollectionError.lift
+            errorHandler: FfiConverterTypeVdcCollectionError_lift
         )
 }
     
@@ -8567,7 +8699,7 @@ open func allEntriesByType(ctype: CredentialType)async throws  -> [Uuid]  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeUuid.lift,
-            errorHandler: FfiConverterTypeVdcCollectionError.lift
+            errorHandler: FfiConverterTypeVdcCollectionError_lift
         )
 }
     
@@ -8587,7 +8719,7 @@ open func delete(id: Uuid)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVdcCollectionError.lift
+            errorHandler: FfiConverterTypeVdcCollectionError_lift
         )
 }
     
@@ -8628,7 +8760,7 @@ open func get(id: Uuid)async throws  -> Credential?  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeCredential.lift,
-            errorHandler: FfiConverterTypeVdcCollectionError.lift
+            errorHandler: FfiConverterTypeVdcCollectionError_lift
         )
 }
     
@@ -8690,7 +8822,7 @@ public func FfiConverterTypeVdcCollection_lower(_ value: VdcCollection) -> Unsaf
 
 
 
-public protocol WalletServiceClientProtocol: AnyObject {
+public protocol WalletServiceClientProtocol: AnyObject, Sendable {
     
     /**
      * Helper method to get an authorization header with the current token
@@ -8734,6 +8866,9 @@ open class WalletServiceClient: WalletServiceClientProtocol, @unchecked Sendable
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -8830,7 +8965,7 @@ open func login(appAttestation: String)async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeWalletServiceError.lift
+            errorHandler: FfiConverterTypeWalletServiceError_lift
         )
 }
     
@@ -8850,7 +8985,7 @@ open func nonce()async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeWalletServiceError.lift
+            errorHandler: FfiConverterTypeWalletServiceError_lift
         )
 }
     
@@ -10527,7 +10662,7 @@ extension AuthenticationStatus: Equatable, Hashable {}
 
 
 
-public enum CborLdEncodingError {
+public enum CborLdEncodingError: Swift.Error {
 
     
     
@@ -10843,7 +10978,7 @@ extension ClaimValue: Equatable, Hashable {}
 
 
 
-public enum CredentialDecodingError {
+public enum CredentialDecodingError: Swift.Error {
 
     
     
@@ -10986,7 +11121,7 @@ extension CredentialDecodingError: Foundation.LocalizedError {
 
 
 
-public enum CredentialEncodingError {
+public enum CredentialEncodingError: Swift.Error {
 
     
     
@@ -11207,7 +11342,7 @@ extension CredentialFormat: Equatable, Hashable {}
 
 
 
-public enum CredentialPresentationError {
+public enum CredentialPresentationError: Swift.Error {
 
     
     
@@ -11290,7 +11425,7 @@ extension CredentialPresentationError: Foundation.LocalizedError {
 
 
 
-public enum CryptoError {
+public enum CryptoError: Swift.Error {
 
     
     
@@ -11363,7 +11498,7 @@ extension CryptoError: Foundation.LocalizedError {
 
 
 
-public enum CwtError {
+public enum CwtError: Swift.Error {
 
     
     
@@ -11634,7 +11769,7 @@ extension CwtError: Foundation.LocalizedError {
 
 
 
-public enum DcApiError {
+public enum DcApiError: Swift.Error {
 
     
     
@@ -11798,7 +11933,7 @@ extension DelegatedVerifierStatus: Equatable, Hashable {}
 
 
 
-public enum DidError {
+public enum DidError: Swift.Error {
 
     
     
@@ -12066,7 +12201,7 @@ extension FlowState: Equatable, Hashable {}
 
 
 
-public enum HttpClientError {
+public enum HttpClientError: Swift.Error {
 
     
     
@@ -12204,7 +12339,7 @@ extension HttpClientError: Foundation.LocalizedError {
 /**
  * Represents errors that may occur during issuance operations
  */
-public enum IssuanceServiceError {
+public enum IssuanceServiceError: Swift.Error {
 
     
     
@@ -12334,7 +12469,7 @@ extension IssuanceServiceError: Foundation.LocalizedError {
 
 
 
-public enum JsonVcEncodingError {
+public enum JsonVcEncodingError: Swift.Error {
 
     
     
@@ -12403,7 +12538,7 @@ extension JsonVcEncodingError: Foundation.LocalizedError {
 
 
 
-public enum JsonVcInitError {
+public enum JsonVcInitError: Swift.Error {
 
     
     
@@ -12490,7 +12625,7 @@ extension JsonVcInitError: Foundation.LocalizedError {
 
 
 
-public enum JwtVcInitError {
+public enum JwtVcInitError: Swift.Error {
 
     
     
@@ -12601,7 +12736,7 @@ extension JwtVcInitError: Foundation.LocalizedError {
 
 
 
-public enum KeyTransformationError {
+public enum KeyTransformationError: Swift.Error {
 
     
     
@@ -12704,7 +12839,7 @@ extension KeyTransformationError: Foundation.LocalizedError {
 
 
 
-public enum MdlReaderResponseError {
+public enum MdlReaderResponseError: Swift.Error {
 
     
     
@@ -12801,7 +12936,7 @@ extension MdlReaderResponseError: Foundation.LocalizedError {
 
 
 
-public enum MdlReaderResponseSerializeError {
+public enum MdlReaderResponseSerializeError: Swift.Error {
 
     
     
@@ -12874,7 +13009,7 @@ extension MdlReaderResponseSerializeError: Foundation.LocalizedError {
 
 
 
-public enum MdlReaderSessionError {
+public enum MdlReaderSessionError: Swift.Error {
 
     
     
@@ -13050,7 +13185,7 @@ extension MDocItem: Equatable, Hashable {}
 
 
 
-public enum MdlUtilError {
+public enum MdlUtilError: Swift.Error {
 
     
     
@@ -13123,7 +13258,7 @@ extension MdlUtilError: Foundation.LocalizedError {
 
 
 
-public enum MdocEncodingError {
+public enum MdocEncodingError: Swift.Error {
 
     
     
@@ -13192,7 +13327,7 @@ extension MdocEncodingError: Foundation.LocalizedError {
 
 
 
-public enum MdocInitError {
+public enum MdocInitError: Swift.Error {
 
     
     
@@ -13307,7 +13442,7 @@ extension MdocInitError: Foundation.LocalizedError {
 
 
 
-public enum Oid4vp180137Error {
+public enum Oid4vp180137Error: Swift.Error {
 
     
     
@@ -13404,7 +13539,7 @@ extension Oid4vp180137Error: Foundation.LocalizedError {
  * The [OID4VPError] enum represents the errors that can occur
  * when using the oid4vp foreign library.
  */
-public enum Oid4vpError {
+public enum Oid4vpError: Swift.Error {
 
     
     
@@ -13783,7 +13918,7 @@ extension Oid4vpError: Foundation.LocalizedError {
 
 
 
-public enum Oid4vciError {
+public enum Oid4vciError: Swift.Error {
 
     
     
@@ -13944,7 +14079,7 @@ extension Oid4vciError: Foundation.LocalizedError {
 
 
 
-public enum Oid4vpVerifierError {
+public enum Oid4vpVerifierError: Swift.Error {
 
     
     
@@ -14110,7 +14245,7 @@ extension Outcome: Equatable, Hashable {}
 
 
 
-public enum PermissionRequestError {
+public enum PermissionRequestError: Swift.Error {
 
     
     
@@ -14304,7 +14439,7 @@ extension PermissionRequestError: Foundation.LocalizedError {
 
 
 
-public enum PopError {
+public enum PopError: Swift.Error {
 
     
     
@@ -14409,7 +14544,7 @@ extension PopError: Foundation.LocalizedError {
 
 
 
-public enum PresentationBuilderError {
+public enum PresentationBuilderError: Swift.Error {
 
     
     
@@ -14562,7 +14697,7 @@ extension PresentationBuilderError: Foundation.LocalizedError {
 
 
 
-public enum PresentationError {
+public enum PresentationError: Swift.Error {
 
     
     
@@ -14675,7 +14810,7 @@ extension PresentationError: Foundation.LocalizedError {
 
 
 
-public enum RequestError {
+public enum RequestError: Swift.Error {
 
     
     
@@ -14748,7 +14883,7 @@ extension RequestError: Foundation.LocalizedError {
 
 
 
-public enum ResponseError {
+public enum ResponseError: Swift.Error {
 
     
     
@@ -14827,7 +14962,7 @@ extension ResponseError: Foundation.LocalizedError {
 
 
 
-public enum SdJwtError {
+public enum SdJwtError: Swift.Error {
 
     
     
@@ -14946,7 +15081,7 @@ extension SdJwtError: Foundation.LocalizedError {
 
 
 
-public enum SessionError {
+public enum SessionError: Swift.Error {
 
     
     
@@ -15019,7 +15154,7 @@ extension SessionError: Foundation.LocalizedError {
 
 
 
-public enum SignatureError {
+public enum SignatureError: Swift.Error {
 
     
     
@@ -15108,7 +15243,7 @@ extension SignatureError: Foundation.LocalizedError {
 
 
 
-public enum StatusListError {
+public enum StatusListError: Swift.Error {
 
     
     
@@ -15192,7 +15327,7 @@ extension StatusListError: Foundation.LocalizedError {
  *
  * Represents errors that may occur during storage management operations
  */
-public enum StorageManagerError {
+public enum StorageManagerError: Swift.Error {
 
     
     
@@ -15302,7 +15437,7 @@ extension StorageManagerError: Foundation.LocalizedError {
 
 
 
-public enum TerminationError {
+public enum TerminationError: Swift.Error {
 
     
     
@@ -15375,7 +15510,7 @@ extension TerminationError: Foundation.LocalizedError {
 
 
 
-public enum VcbVerificationError {
+public enum VcbVerificationError: Swift.Error {
 
     
     
@@ -15454,7 +15589,7 @@ extension VcbVerificationError: Foundation.LocalizedError {
 
 
 
-public enum VcVerificationError {
+public enum VcVerificationError: Swift.Error {
 
     
     
@@ -15527,7 +15662,7 @@ extension VcVerificationError: Foundation.LocalizedError {
 
 
 
-public enum VpError {
+public enum VpError: Swift.Error {
 
     
     
@@ -15689,7 +15824,7 @@ extension VcdmVersion: Equatable, Hashable {}
 
 
 
-public enum VdcCollectionError {
+public enum VdcCollectionError: Swift.Error {
 
     
     
@@ -15879,7 +16014,7 @@ extension VerificationResult: Equatable, Hashable {}
 
 
 
-public enum WalletServiceError {
+public enum WalletServiceError: Swift.Error {
 
     
     
@@ -16046,7 +16181,7 @@ extension WalletServiceError: Foundation.LocalizedError {
  * For example, in the case of `JwtVc` credential format,
  * the signing payload consists of the JWT header and payload (JWS).
  */
-public protocol PresentationSigner: AnyObject {
+public protocol PresentationSigner: AnyObject, Sendable {
     
     /**
      * Sign the payload with the private key and return the signature.
@@ -18159,7 +18294,7 @@ public func cborLdEncodeToBytes(credentialStr: String, loader: [String: String]?
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterData.lift,
-            errorHandler: FfiConverterTypeCborLdEncodingError.lift
+            errorHandler: FfiConverterTypeCborLdEncodingError_lift
         )
 }
 /**
@@ -18219,7 +18354,7 @@ public func generatePopPrepare(audience: String, nonce: String?, didMethod: DidM
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterData.lift,
-            errorHandler: FfiConverterTypePopError.lift
+            errorHandler: FfiConverterTypePopError_lift
         )
 }
 /**
@@ -18249,7 +18384,7 @@ public func handleDcApiRequest(dcqlCredentialId: String, mdoc: Mdoc, origin: Str
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeInProgressRequestDcApi_lift,
-            errorHandler: FfiConverterTypeDcApiError.lift
+            errorHandler: FfiConverterTypeDcApiError_lift
         )
 }
 public func handleResponse(state: MdlSessionManager, response: Data)throws  -> MdlReaderResponseData  {
@@ -18289,7 +18424,7 @@ public func initializeMdlPresentation(mdocId: Uuid, uuid: Uuid, storageManager: 
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeMdlPresentationSession_lift,
-            errorHandler: FfiConverterTypeSessionError.lift
+            errorHandler: FfiConverterTypeSessionError_lift
         )
 }
 /**
@@ -18335,7 +18470,7 @@ public func oid4vciExchangeCredential(session: Oid4vciSession, proofsOfPossessio
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeCredentialResponse.lift,
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
 public func oid4vciExchangeToken(session: Oid4vciSession, httpClient: IHttpClient)async throws  -> String?  {
@@ -18349,7 +18484,7 @@ public func oid4vciExchangeToken(session: Oid4vciSession, httpClient: IHttpClien
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionString.lift,
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
 public func oid4vciGetMetadata(session: Oid4vciSession)throws  -> Oid4vciMetadata  {
@@ -18370,7 +18505,7 @@ public func oid4vciInitiate(baseUrl: String, clientId: String, redirectUrl: Stri
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeOid4vciSession_lift,
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
 public func oid4vciInitiateWithOffer(credentialOffer: String, clientId: String, redirectUrl: String, httpClient: IHttpClient)async throws  -> Oid4vciSession  {
@@ -18384,7 +18519,7 @@ public func oid4vciInitiateWithOffer(credentialOffer: String, clientId: String, 
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeOid4vciSession_lift,
-            errorHandler: FfiConverterTypeOid4vciError.lift
+            errorHandler: FfiConverterTypeOid4vciError_lift
         )
 }
 public func vcToSignedVp(vc: String, keyStr: String)async throws  -> String  {
@@ -18398,7 +18533,7 @@ public func vcToSignedVp(vc: String, keyStr: String)async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeVPError.lift
+            errorHandler: FfiConverterTypeVPError_lift
         )
 }
 public func verifiedResponseAsJsonString(response: MdlReaderResponseData)throws  -> String  {
@@ -18419,7 +18554,7 @@ public func verifyJsonVcString(json: String)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVCVerificationError.lift
+            errorHandler: FfiConverterTypeVCVerificationError_lift
         )
 }
 public func verifyJwtVp(jwtVp: String)async throws   {
@@ -18433,7 +18568,7 @@ public func verifyJwtVp(jwtVp: String)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVPError.lift
+            errorHandler: FfiConverterTypeVPError_lift
         )
 }
 public func verifyPdf417Barcode(payload: String)async throws   {
@@ -18447,7 +18582,7 @@ public func verifyPdf417Barcode(payload: String)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVCBVerificationError.lift
+            errorHandler: FfiConverterTypeVCBVerificationError_lift
         )
 }
 public func verifyVcbQrcodeAgainstMrz(mrzPayload: String, qrPayload: String)async throws   {
@@ -18461,7 +18596,7 @@ public func verifyVcbQrcodeAgainstMrz(mrzPayload: String, qrPayload: String)asyn
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVCBVerificationError.lift
+            errorHandler: FfiConverterTypeVCBVerificationError_lift
         )
 }
 

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -395,7 +395,13 @@ fileprivate final class UniffiHandleMap<T>: @unchecked Sendable {
 
 
 // Public interface members begin here.
-
+// Magic number for the Rust proxy to call using the same mechanism as every other method,
+// to free the callback once it's dropped by Rust.
+private let IDX_CALLBACK_FREE: Int32 = 0
+// Callback return codes
+private let UNIFFI_CALLBACK_SUCCESS: Int32 = 0
+private let UNIFFI_CALLBACK_ERROR: Int32 = 1
+private let UNIFFI_CALLBACK_UNEXPECTED_ERROR: Int32 = 2
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -639,13 +645,7 @@ open func httpClient(request: HttpRequest)async throws  -> HttpResponse  {
     
 
 }
-// Magic number for the Rust proxy to call using the same mechanism as every other method,
-// to free the callback once it's dropped by Rust.
-private let IDX_CALLBACK_FREE: Int32 = 0
-// Callback return codes
-private let UNIFFI_CALLBACK_SUCCESS: Int32 = 0
-private let UNIFFI_CALLBACK_ERROR: Int32 = 1
-private let UNIFFI_CALLBACK_UNEXPECTED_ERROR: Int32 = 2
+
 
 // Put the implementation in a struct so we don't pollute the top-level namespace
 fileprivate struct UniffiCallbackInterfaceAsyncHttpClient {
@@ -10662,6 +10662,9 @@ extension AuthenticationStatus: Equatable, Hashable {}
 
 
 
+
+
+
 public enum CborLdEncodingError: Swift.Error {
 
     
@@ -10737,11 +10740,14 @@ extension CborLdEncodingError: Equatable, Hashable {}
 
 
 
+
 extension CborLdEncodingError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 // Note that we don't yet support `indirect` for enums.
@@ -10882,6 +10888,8 @@ public func FfiConverterTypeCborValue_lower(_ value: CborValue) -> RustBuffer {
 
 
 
+
+
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 /**
@@ -10974,6 +10982,9 @@ public func FfiConverterTypeClaimValue_lower(_ value: ClaimValue) -> RustBuffer 
 
 
 extension ClaimValue: Equatable, Hashable {}
+
+
+
 
 
 
@@ -11113,11 +11124,14 @@ extension CredentialDecodingError: Equatable, Hashable {}
 
 
 
+
 extension CredentialDecodingError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -11226,11 +11240,14 @@ extension CredentialEncodingError: Equatable, Hashable {}
 
 
 
+
 extension CredentialEncodingError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 // Note that we don't yet support `indirect` for enums.
@@ -11342,6 +11359,9 @@ extension CredentialFormat: Equatable, Hashable {}
 
 
 
+
+
+
 public enum CredentialPresentationError: Swift.Error {
 
     
@@ -11417,11 +11437,14 @@ extension CredentialPresentationError: Equatable, Hashable {}
 
 
 
+
 extension CredentialPresentationError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -11490,11 +11513,14 @@ extension CryptoError: Equatable, Hashable {}
 
 
 
+
 extension CryptoError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -11761,11 +11787,14 @@ extension CwtError: Equatable, Hashable {}
 
 
 
+
 extension CwtError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -11844,11 +11873,14 @@ extension DcApiError: Equatable, Hashable {}
 
 
 
+
 extension DcApiError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 // Note that we don't yet support `indirect` for enums.
@@ -11929,6 +11961,9 @@ public func FfiConverterTypeDelegatedVerifierStatus_lower(_ value: DelegatedVeri
 
 
 extension DelegatedVerifierStatus: Equatable, Hashable {}
+
+
+
 
 
 
@@ -12022,11 +12057,14 @@ extension DidError: Equatable, Hashable {}
 
 
 
+
 extension DidError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 // Note that we don't yet support `indirect` for enums.
@@ -12093,6 +12131,9 @@ public func FfiConverterTypeDidMethod_lower(_ value: DidMethod) -> RustBuffer {
 
 
 extension DidMethod: Equatable, Hashable {}
+
+
+
 
 
 
@@ -12197,6 +12238,9 @@ public func FfiConverterTypeFlowState_lower(_ value: FlowState) -> RustBuffer {
 
 
 extension FlowState: Equatable, Hashable {}
+
+
+
 
 
 
@@ -12328,11 +12372,14 @@ extension HttpClientError: Equatable, Hashable {}
 
 
 
+
 extension HttpClientError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -12461,11 +12508,14 @@ extension IssuanceServiceError: Equatable, Hashable {}
 
 
 
+
 extension IssuanceServiceError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -12530,11 +12580,14 @@ extension JsonVcEncodingError: Equatable, Hashable {}
 
 
 
+
 extension JsonVcEncodingError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -12617,11 +12670,14 @@ extension JsonVcInitError: Equatable, Hashable {}
 
 
 
+
 extension JsonVcInitError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -12728,11 +12784,14 @@ extension JwtVcInitError: Equatable, Hashable {}
 
 
 
+
 extension JwtVcInitError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -12831,11 +12890,14 @@ extension KeyTransformationError: Equatable, Hashable {}
 
 
 
+
 extension KeyTransformationError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -12928,11 +12990,14 @@ extension MdlReaderResponseError: Equatable, Hashable {}
 
 
 
+
 extension MdlReaderResponseError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -13001,11 +13066,14 @@ extension MdlReaderResponseSerializeError: Equatable, Hashable {}
 
 
 
+
 extension MdlReaderResponseSerializeError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -13074,11 +13142,14 @@ extension MdlReaderSessionError: Equatable, Hashable {}
 
 
 
+
 extension MdlReaderSessionError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 // Note that we don't yet support `indirect` for enums.
@@ -13185,6 +13256,9 @@ extension MDocItem: Equatable, Hashable {}
 
 
 
+
+
+
 public enum MdlUtilError: Swift.Error {
 
     
@@ -13250,11 +13324,14 @@ extension MdlUtilError: Equatable, Hashable {}
 
 
 
+
 extension MdlUtilError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -13319,11 +13396,14 @@ extension MdocEncodingError: Equatable, Hashable {}
 
 
 
+
 extension MdocEncodingError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -13434,11 +13514,14 @@ extension MdocInitError: Equatable, Hashable {}
 
 
 
+
 extension MdocInitError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -13527,11 +13610,14 @@ extension Oid4vp180137Error: Equatable, Hashable {}
 
 
 
+
 extension Oid4vp180137Error: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -13910,11 +13996,14 @@ extension Oid4vpError: Equatable, Hashable {}
 
 
 
+
 extension Oid4vpError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -14071,11 +14160,14 @@ extension Oid4vciError: Equatable, Hashable {}
 
 
 
+
 extension Oid4vciError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -14154,11 +14246,14 @@ extension Oid4vpVerifierError: Equatable, Hashable {}
 
 
 
+
 extension Oid4vpVerifierError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 // Note that we don't yet support `indirect` for enums.
@@ -14241,6 +14336,9 @@ public func FfiConverterTypeOutcome_lower(_ value: Outcome) -> RustBuffer {
 
 
 extension Outcome: Equatable, Hashable {}
+
+
+
 
 
 
@@ -14431,11 +14529,14 @@ extension PermissionRequestError: Equatable, Hashable {}
 
 
 
+
 extension PermissionRequestError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -14536,11 +14637,14 @@ extension PopError: Equatable, Hashable {}
 
 
 
+
 extension PopError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -14689,11 +14793,14 @@ extension PresentationBuilderError: Equatable, Hashable {}
 
 
 
+
 extension PresentationBuilderError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -14802,11 +14909,14 @@ extension PresentationError: Equatable, Hashable {}
 
 
 
+
 extension PresentationError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -14875,11 +14985,14 @@ extension RequestError: Equatable, Hashable {}
 
 
 
+
 extension RequestError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -14954,11 +15067,14 @@ extension ResponseError: Equatable, Hashable {}
 
 
 
+
 extension ResponseError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -15073,11 +15189,14 @@ extension SdJwtError: Equatable, Hashable {}
 
 
 
+
 extension SdJwtError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -15146,11 +15265,14 @@ extension SessionError: Equatable, Hashable {}
 
 
 
+
 extension SessionError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -15235,11 +15357,14 @@ extension SignatureError: Equatable, Hashable {}
 
 
 
+
 extension SignatureError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -15314,11 +15439,14 @@ extension StatusListError: Equatable, Hashable {}
 
 
 
+
 extension StatusListError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -15429,11 +15557,14 @@ extension StorageManagerError: Equatable, Hashable {}
 
 
 
+
 extension StorageManagerError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -15502,11 +15633,14 @@ extension TerminationError: Equatable, Hashable {}
 
 
 
+
 extension TerminationError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -15581,11 +15715,14 @@ extension VcbVerificationError: Equatable, Hashable {}
 
 
 
+
 extension VcbVerificationError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -15654,11 +15791,14 @@ extension VcVerificationError: Equatable, Hashable {}
 
 
 
+
 extension VcVerificationError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 
@@ -15749,11 +15889,14 @@ extension VpError: Equatable, Hashable {}
 
 
 
+
 extension VpError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 // Note that we don't yet support `indirect` for enums.
@@ -15820,6 +15963,9 @@ public func FfiConverterTypeVcdmVersion_lower(_ value: VcdmVersion) -> RustBuffe
 
 
 extension VcdmVersion: Equatable, Hashable {}
+
+
+
 
 
 
@@ -15936,11 +16082,14 @@ extension VdcCollectionError: Equatable, Hashable {}
 
 
 
+
 extension VdcCollectionError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 // Note that we don't yet support `indirect` for enums.
@@ -16010,6 +16159,9 @@ public func FfiConverterTypeVerificationResult_lower(_ value: VerificationResult
 
 
 extension VerificationResult: Equatable, Hashable {}
+
+
+
 
 
 
@@ -16158,11 +16310,14 @@ extension WalletServiceError: Equatable, Hashable {}
 
 
 
+
 extension WalletServiceError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+
+
 
 
 

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -395,13 +395,7 @@ fileprivate final class UniffiHandleMap<T>: @unchecked Sendable {
 
 
 // Public interface members begin here.
-// Magic number for the Rust proxy to call using the same mechanism as every other method,
-// to free the callback once it's dropped by Rust.
-private let IDX_CALLBACK_FREE: Int32 = 0
-// Callback return codes
-private let UNIFFI_CALLBACK_SUCCESS: Int32 = 0
-private let UNIFFI_CALLBACK_ERROR: Int32 = 1
-private let UNIFFI_CALLBACK_UNEXPECTED_ERROR: Int32 = 2
+
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -569,7 +563,7 @@ fileprivate struct FfiConverterData: FfiConverterRustBuffer {
 
 
 
-public protocol AsyncHttpClient: AnyObject, Sendable {
+public protocol AsyncHttpClient: AnyObject {
     
     func httpClient(request: HttpRequest) async throws  -> HttpResponse
     
@@ -588,9 +582,6 @@ open class AsyncHttpClientImpl: AsyncHttpClient, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -639,13 +630,19 @@ open func httpClient(request: HttpRequest)async throws  -> HttpResponse  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeHttpResponse_lift,
-            errorHandler: FfiConverterTypeHttpClientError_lift
+            errorHandler: FfiConverterTypeHttpClientError.lift
         )
 }
     
 
 }
-
+// Magic number for the Rust proxy to call using the same mechanism as every other method,
+// to free the callback once it's dropped by Rust.
+private let IDX_CALLBACK_FREE: Int32 = 0
+// Callback return codes
+private let UNIFFI_CALLBACK_SUCCESS: Int32 = 0
+private let UNIFFI_CALLBACK_ERROR: Int32 = 1
+private let UNIFFI_CALLBACK_UNEXPECTED_ERROR: Int32 = 2
 
 // Put the implementation in a struct so we don't pollute the top-level namespace
 fileprivate struct UniffiCallbackInterfaceAsyncHttpClient {
@@ -771,7 +768,7 @@ public func FfiConverterTypeAsyncHttpClient_lower(_ value: AsyncHttpClient) -> U
 
 
 
-public protocol CborIntegerProtocol: AnyObject, Sendable {
+public protocol CborIntegerProtocol: AnyObject {
     
     func lowerBytes()  -> UInt64
     
@@ -794,9 +791,6 @@ open class CborInteger: CborIntegerProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -911,7 +905,7 @@ public func FfiConverterTypeCborInteger_lower(_ value: CborInteger) -> UnsafeMut
 
 
 
-public protocol CborTagProtocol: AnyObject, Sendable {
+public protocol CborTagProtocol: AnyObject {
     
     func id()  -> UInt64
     
@@ -932,9 +926,6 @@ open class CborTag: CborTagProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1042,7 +1033,7 @@ public func FfiConverterTypeCborTag_lower(_ value: CborTag) -> UnsafeMutableRawP
 
 
 
-public protocol ClientProtocol: AnyObject, Sendable {
+public protocol ClientProtocol: AnyObject {
     
 }
 open class Client: ClientProtocol, @unchecked Sendable {
@@ -1059,9 +1050,6 @@ open class Client: ClientProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1155,7 +1143,7 @@ public func FfiConverterTypeClient_lower(_ value: Client) -> UnsafeMutableRawPoi
 
 
 
-public protocol CredentialIssuerMetadataProtocol: AnyObject, Sendable {
+public protocol CredentialIssuerMetadataProtocol: AnyObject {
     
 }
 open class CredentialIssuerMetadata: CredentialIssuerMetadataProtocol, @unchecked Sendable {
@@ -1172,9 +1160,6 @@ open class CredentialIssuerMetadata: CredentialIssuerMetadataProtocol, @unchecke
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1268,7 +1253,7 @@ public func FfiConverterTypeCredentialIssuerMetadata_lower(_ value: CredentialIs
 
 
 
-public protocol CredentialRequestProtocol: AnyObject, Sendable {
+public protocol CredentialRequestProtocol: AnyObject {
     
 }
 open class CredentialRequest: CredentialRequestProtocol, @unchecked Sendable {
@@ -1285,9 +1270,6 @@ open class CredentialRequest: CredentialRequestProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1381,7 +1363,7 @@ public func FfiConverterTypeCredentialRequest_lower(_ value: CredentialRequest) 
 
 
 
-public protocol Crypto: AnyObject, Sendable {
+public protocol Crypto: AnyObject {
     
     func p256Verify(certificateDer: Data, payload: Data, signature: Data)  -> VerificationResult
     
@@ -1400,9 +1382,6 @@ open class CryptoImpl: Crypto, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1564,7 +1543,7 @@ public func FfiConverterTypeCrypto_lower(_ value: Crypto) -> UnsafeMutableRawPoi
 /**
  * Utility functions for cryptographic curves
  */
-public protocol CryptoCurveUtilsProtocol: AnyObject, Sendable {
+public protocol CryptoCurveUtilsProtocol: AnyObject {
     
     /**
      * Returns null if the original signature encoding is not recognized.
@@ -1589,9 +1568,6 @@ open class CryptoCurveUtils: CryptoCurveUtilsProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1706,7 +1682,7 @@ public func FfiConverterTypeCryptoCurveUtils_lower(_ value: CryptoCurveUtils) ->
 
 
 
-public protocol CwtProtocol: AnyObject, Sendable {
+public protocol CwtProtocol: AnyObject {
     
     /**
      * The version of the Verifiable Credential Data Model that this credential conforms to.
@@ -1742,9 +1718,6 @@ open class Cwt: CwtProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1838,7 +1811,7 @@ open func verify(crypto: Crypto)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeCwtError_lift
+            errorHandler: FfiConverterTypeCwtError.lift
         )
 }
     
@@ -1900,7 +1873,7 @@ public func FfiConverterTypeCwt_lower(_ value: Cwt) -> UnsafeMutableRawPointer {
 
 
 
-public protocol DelegatedVerifierProtocol: AnyObject, Sendable {
+public protocol DelegatedVerifierProtocol: AnyObject {
     
     func pollVerificationStatus(url: String) async throws  -> DelegatedVerifierStatusResponse
     
@@ -1931,9 +1904,6 @@ open class DelegatedVerifier: DelegatedVerifierProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -1978,7 +1948,7 @@ public static func newClient(baseUrl: Url)async throws  -> DelegatedVerifier  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeDelegatedVerifier_lift,
-            errorHandler: FfiConverterTypeOid4vpVerifierError_lift
+            errorHandler: FfiConverterTypeOid4vpVerifierError.lift
         )
 }
     
@@ -1997,7 +1967,7 @@ open func pollVerificationStatus(url: String)async throws  -> DelegatedVerifierS
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeDelegatedVerifierStatusResponse_lift,
-            errorHandler: FfiConverterTypeOid4vpVerifierError_lift
+            errorHandler: FfiConverterTypeOid4vpVerifierError.lift
         )
 }
     
@@ -2024,7 +1994,7 @@ open func requestDelegatedVerification(url: String)async throws  -> DelegateInit
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeDelegateInitializationResponse_lift,
-            errorHandler: FfiConverterTypeOid4vpVerifierError_lift
+            errorHandler: FfiConverterTypeOid4vpVerifierError.lift
         )
 }
     
@@ -2086,7 +2056,7 @@ public func FfiConverterTypeDelegatedVerifier_lower(_ value: DelegatedVerifier) 
 
 
 
-public protocol DidMethodUtilsProtocol: AnyObject, Sendable {
+public protocol DidMethodUtilsProtocol: AnyObject {
     
     func didFromJwk(jwk: String) throws  -> String
     
@@ -2107,9 +2077,6 @@ open class DidMethodUtils: DidMethodUtilsProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2174,7 +2141,7 @@ open func vmFromJwk(jwk: String)async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeDidError_lift
+            errorHandler: FfiConverterTypeDidError.lift
         )
 }
     
@@ -2236,7 +2203,7 @@ public func FfiConverterTypeDidMethodUtils_lower(_ value: DidMethodUtils) -> Uns
 
 
 
-public protocol GrantsProtocol: AnyObject, Sendable {
+public protocol GrantsProtocol: AnyObject {
     
 }
 open class Grants: GrantsProtocol, @unchecked Sendable {
@@ -2253,9 +2220,6 @@ open class Grants: GrantsProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2355,7 +2319,7 @@ public func FfiConverterTypeGrants_lower(_ value: Grants) -> UnsafeMutableRawPoi
  * The Holder has the ability to generate Verifiable Presentations from
  * these credentials and share them with Verifiers.
  */
-public protocol HolderProtocol: AnyObject, Sendable {
+public protocol HolderProtocol: AnyObject {
     
     /**
      * Given an authorization request URL, return a permission request,
@@ -2389,9 +2353,6 @@ open class Holder: HolderProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2428,7 +2389,7 @@ public convenience init(vdcCollection: VdcCollection, trustedDids: [String], sig
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeHolder_lift,
-            errorHandler: FfiConverterTypeOID4VPError_lift
+            errorHandler: FfiConverterTypeOID4VPError.lift
         )
         
         .uniffiClonePointer()
@@ -2462,7 +2423,7 @@ public static func newWithCredentials(providedCredentials: [ParsedCredential], t
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeHolder_lift,
-            errorHandler: FfiConverterTypeOID4VPError_lift
+            errorHandler: FfiConverterTypeOID4VPError.lift
         )
 }
     
@@ -2488,7 +2449,7 @@ open func authorizationRequest(req: AuthRequest)async throws  -> PermissionReque
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypePermissionRequest_lift,
-            errorHandler: FfiConverterTypeOID4VPError_lift
+            errorHandler: FfiConverterTypeOID4VPError.lift
         )
 }
     
@@ -2505,7 +2466,7 @@ open func submitPermissionResponse(response: PermissionResponse)async throws  ->
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeUrl.lift,
-            errorHandler: FfiConverterTypeOID4VPError_lift
+            errorHandler: FfiConverterTypeOID4VPError.lift
         )
 }
     
@@ -2575,7 +2536,7 @@ public func FfiConverterTypeHolder_lower(_ value: Holder) -> UnsafeMutableRawPoi
  * `Arc` is wrapped with `IArc` to facilitate trait implementation from
  * `openidconnect` library used by request builders and client on `oid4vci-rs`.
  */
-public protocol IHttpClientProtocol: AnyObject, Sendable {
+public protocol IHttpClientProtocol: AnyObject {
     
 }
 /**
@@ -2600,9 +2561,6 @@ open class IHttpClient: IHttpClientProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2712,7 +2670,7 @@ public func FfiConverterTypeIHttpClient_lower(_ value: IHttpClient) -> UnsafeMut
 
 
 
-public protocol InProcessRecordProtocol: AnyObject, Sendable {
+public protocol InProcessRecordProtocol: AnyObject {
     
 }
 open class InProcessRecord: InProcessRecordProtocol, @unchecked Sendable {
@@ -2729,9 +2687,6 @@ open class InProcessRecord: InProcessRecordProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2825,7 +2780,7 @@ public func FfiConverterTypeInProcessRecord_lower(_ value: InProcessRecord) -> U
 
 
 
-public protocol InProgressRequest180137Protocol: AnyObject, Sendable {
+public protocol InProgressRequest180137Protocol: AnyObject {
     
     func matches()  -> [RequestMatch180137]
     
@@ -2846,9 +2801,6 @@ open class InProgressRequest180137: InProgressRequest180137Protocol, @unchecked 
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -2904,7 +2856,7 @@ open func respond(approvedResponse: ApprovedResponse180137)async throws  -> Url?
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeUrl.lift,
-            errorHandler: FfiConverterTypeOID4VP180137Error_lift
+            errorHandler: FfiConverterTypeOID4VP180137Error.lift
         )
 }
     
@@ -2966,7 +2918,7 @@ public func FfiConverterTypeInProgressRequest180137_lower(_ value: InProgressReq
 
 
 
-public protocol InProgressRequestDcApiProtocol: AnyObject, Sendable {
+public protocol InProgressRequestDcApiProtocol: AnyObject {
     
     func getMatch()  -> RequestMatch180137
     
@@ -2994,9 +2946,6 @@ open class InProgressRequestDcApi: InProgressRequestDcApiProtocol, @unchecked Se
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3064,7 +3013,7 @@ open func respond(keystore: KeyStore, approvedFields: [FieldId180137])async thro
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeDcApiError_lift
+            errorHandler: FfiConverterTypeDcApiError.lift
         )
 }
     
@@ -3126,7 +3075,7 @@ public func FfiConverterTypeInProgressRequestDcApi_lower(_ value: InProgressRequ
 
 
 
-public protocol IssuanceServiceClientProtocol: AnyObject, Sendable {
+public protocol IssuanceServiceClientProtocol: AnyObject {
     
     /**
      * Checks the status of an issuance request
@@ -3139,7 +3088,7 @@ public protocol IssuanceServiceClientProtocol: AnyObject, Sendable {
      * * The status response containing state and openid_credential_offer if successful
      * * An error if the request fails
      */
-    func checkStatus(issuanceId: String, walletAttestation: String) async throws  -> CheckStatusResponse
+    func checkStatus(issuanceId: String, walletAttestation: String) async throws  -> FlowState
     
     /**
      * Creates a new issuance request
@@ -3168,9 +3117,6 @@ open class IssuanceServiceClient: IssuanceServiceClientProtocol, @unchecked Send
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3231,7 +3177,7 @@ public convenience init(baseUrl: String) {
      * * The status response containing state and openid_credential_offer if successful
      * * An error if the request fails
      */
-open func checkStatus(issuanceId: String, walletAttestation: String)async throws  -> CheckStatusResponse  {
+open func checkStatus(issuanceId: String, walletAttestation: String)async throws  -> FlowState  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
@@ -3243,8 +3189,8 @@ open func checkStatus(issuanceId: String, walletAttestation: String)async throws
             pollFunc: ffi_mobile_sdk_rs_rust_future_poll_rust_buffer,
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterTypeCheckStatusResponse_lift,
-            errorHandler: FfiConverterTypeIssuanceServiceError_lift
+            liftFunc: FfiConverterTypeFlowState_lift,
+            errorHandler: FfiConverterTypeIssuanceServiceError.lift
         )
 }
     
@@ -3271,7 +3217,7 @@ open func newIssuance(walletAttestation: String)async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeIssuanceServiceError_lift
+            errorHandler: FfiConverterTypeIssuanceServiceError.lift
         )
 }
     
@@ -3333,7 +3279,7 @@ public func FfiConverterTypeIssuanceServiceClient_lower(_ value: IssuanceService
 
 
 
-public protocol JsonLdPresentationBuilderProtocol: AnyObject, Sendable {
+public protocol JsonLdPresentationBuilderProtocol: AnyObject {
     
     func issuePresentation(credentials: [ParsedCredential]) async throws  -> String
     
@@ -3352,9 +3298,6 @@ open class JsonLdPresentationBuilder: JsonLdPresentationBuilderProtocol, @unchec
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3417,7 +3360,7 @@ open func issuePresentation(credentials: [ParsedCredential])async throws  -> Str
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypePresentationBuilderError_lift
+            errorHandler: FfiConverterTypePresentationBuilderError.lift
         )
 }
     
@@ -3482,7 +3425,7 @@ public func FfiConverterTypeJsonLdPresentationBuilder_lower(_ value: JsonLdPrese
 /**
  * A verifiable credential secured as JSON.
  */
-public protocol JsonVcProtocol: AnyObject, Sendable {
+public protocol JsonVcProtocol: AnyObject {
     
     /**
      * Access the W3C VCDM credential as a JSON encoded UTF-8 string.
@@ -3539,9 +3482,6 @@ open class JsonVc: JsonVcProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -3647,7 +3587,7 @@ open func status()async throws  -> Status  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeStatus_lift,
-            errorHandler: FfiConverterTypeStatusListError_lift
+            errorHandler: FfiConverterTypeStatusListError.lift
         )
 }
     
@@ -3743,7 +3683,7 @@ public func FfiConverterTypeJsonVc_lower(_ value: JsonVc) -> UnsafeMutableRawPoi
 /**
  * A verifiable credential secured as a JWT.
  */
-public protocol JwtVcProtocol: AnyObject, Sendable {
+public protocol JwtVcProtocol: AnyObject {
     
     /**
      * Access the W3C VCDM credential as a JSON encoded UTF-8 string.
@@ -3804,9 +3744,6 @@ open class JwtVc: JwtVcProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4011,7 +3948,7 @@ public func FfiConverterTypeJwtVc_lower(_ value: JwtVc) -> UnsafeMutableRawPoint
 /**
  * An interface that can provide access to cryptographic keypairs from the native crypto API.
  */
-public protocol KeyStore: AnyObject, Sendable {
+public protocol KeyStore: AnyObject {
     
     /**
      * Retrieve a cryptographic keypair by alias. The cryptographic key must be usable for
@@ -4037,9 +3974,6 @@ open class KeyStoreImpl: KeyStore, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4197,7 +4131,7 @@ public func FfiConverterTypeKeyStore_lower(_ value: KeyStore) -> UnsafeMutableRa
 
 
 
-public protocol LogWriter: AnyObject, Sendable {
+public protocol LogWriter: AnyObject {
     
     func writeToBuffer(message: Data) 
     
@@ -4218,9 +4152,6 @@ open class LogWriterImpl: LogWriter, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4400,7 +4331,7 @@ public func FfiConverterTypeLogWriter_lower(_ value: LogWriter) -> UnsafeMutable
 
 
 
-public protocol MdlSessionManagerProtocol: AnyObject, Sendable {
+public protocol MdlSessionManagerProtocol: AnyObject {
     
 }
 open class MdlSessionManager: MdlSessionManagerProtocol, @unchecked Sendable {
@@ -4417,9 +4348,6 @@ open class MdlSessionManager: MdlSessionManagerProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4513,7 +4441,7 @@ public func FfiConverterTypeMDLSessionManager_lower(_ value: MdlSessionManager) 
 
 
 
-public protocol MdlPresentationSessionProtocol: AnyObject, Sendable {
+public protocol MdlPresentationSessionProtocol: AnyObject {
     
     /**
      * Constructs the response to be sent from the holder to the reader containing
@@ -4569,9 +4497,6 @@ open class MdlPresentationSession: MdlPresentationSessionProtocol, @unchecked Se
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4737,7 +4662,7 @@ public func FfiConverterTypeMdlPresentationSession_lower(_ value: MdlPresentatio
 
 
 
-public protocol MdocProtocol: AnyObject, Sendable {
+public protocol MdocProtocol: AnyObject {
     
     /**
      * Simple representation of mdoc namespace and data elements for display in the UI.
@@ -4771,9 +4696,6 @@ open class Mdoc: MdocProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -4947,7 +4869,7 @@ public func FfiConverterTypeMdoc_lower(_ value: Mdoc) -> UnsafeMutableRawPointer
  *
  * Notably this supports requests which use the URI scheme `mdoc-openid4vp://`.
  */
-public protocol Oid4vp180137Protocol: AnyObject, Sendable {
+public protocol Oid4vp180137Protocol: AnyObject {
     
     func processRequest(url: Url) async throws  -> InProgressRequest180137
     
@@ -4971,9 +4893,6 @@ open class Oid4vp180137: Oid4vp180137Protocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5031,7 +4950,7 @@ open func processRequest(url: Url)async throws  -> InProgressRequest180137  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeInProgressRequest180137_lift,
-            errorHandler: FfiConverterTypeOID4VP180137Error_lift
+            errorHandler: FfiConverterTypeOID4VP180137Error.lift
         )
 }
     
@@ -5093,7 +5012,7 @@ public func FfiConverterTypeOID4VP180137_lower(_ value: Oid4vp180137) -> UnsafeM
 
 
 
-public protocol Oid4vciProtocol: AnyObject, Sendable {
+public protocol Oid4vciProtocol: AnyObject {
     
     func clearContextMap() throws 
     
@@ -5124,9 +5043,6 @@ open class Oid4vci: Oid4vciProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5218,7 +5134,7 @@ open func exchangeCredential(proofsOfPossession: [String], options: Oid4vciExcha
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeCredentialResponse.lift,
-            errorHandler: FfiConverterTypeOid4vciError_lift
+            errorHandler: FfiConverterTypeOid4vciError.lift
         )
 }
     
@@ -5235,7 +5151,7 @@ open func exchangeToken()async throws  -> String?  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionString.lift,
-            errorHandler: FfiConverterTypeOid4vciError_lift
+            errorHandler: FfiConverterTypeOid4vciError.lift
         )
 }
     
@@ -5259,7 +5175,7 @@ open func initiate(baseUrl: String, clientId: String, redirectUrl: String)async 
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeOid4vciError_lift
+            errorHandler: FfiConverterTypeOid4vciError.lift
         )
 }
     
@@ -5276,7 +5192,7 @@ open func initiateWithOffer(credentialOffer: String, clientId: String, redirectU
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeOid4vciError_lift
+            errorHandler: FfiConverterTypeOid4vciError.lift
         )
 }
     
@@ -5345,7 +5261,7 @@ public func FfiConverterTypeOid4vci_lower(_ value: Oid4vci) -> UnsafeMutableRawP
 
 
 
-public protocol Oid4vciMetadataProtocol: AnyObject, Sendable {
+public protocol Oid4vciMetadataProtocol: AnyObject {
     
     func authorizationServers()  -> [String]?
     
@@ -5376,9 +5292,6 @@ open class Oid4vciMetadata: Oid4vciMetadataProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5521,7 +5434,7 @@ public func FfiConverterTypeOid4vciMetadata_lower(_ value: Oid4vciMetadata) -> U
 
 
 
-public protocol Oid4vciSessionProtocol: AnyObject, Sendable {
+public protocol Oid4vciSessionProtocol: AnyObject {
     
 }
 open class Oid4vciSession: Oid4vciSessionProtocol, @unchecked Sendable {
@@ -5538,9 +5451,6 @@ open class Oid4vciSession: Oid4vciSessionProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -5637,7 +5547,7 @@ public func FfiConverterTypeOid4vciSession_lower(_ value: Oid4vciSession) -> Uns
 /**
  * A credential that has been parsed as a known variant.
  */
-public protocol ParsedCredentialProtocol: AnyObject, Sendable {
+public protocol ParsedCredentialProtocol: AnyObject {
     
     /**
      * Return the credential as an CWT, if it is of that format.
@@ -5707,9 +5617,6 @@ open class ParsedCredential: ParsedCredentialProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6001,7 +5908,7 @@ public func FfiConverterTypeParsedCredential_lower(_ value: ParsedCredential) ->
 
 
 
-public protocol PermissionRequestProtocol: AnyObject, Sendable {
+public protocol PermissionRequestProtocol: AnyObject {
     
     /**
      * Return the client ID for the authorization request.
@@ -6062,9 +5969,6 @@ open class PermissionRequest: PermissionRequestProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6133,7 +6037,7 @@ open func createPermissionResponse(selectedCredentials: [PresentableCredential],
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypePermissionResponse_lift,
-            errorHandler: FfiConverterTypeOID4VPError_lift
+            errorHandler: FfiConverterTypeOID4VPError.lift
         )
 }
     
@@ -6251,7 +6155,7 @@ public func FfiConverterTypePermissionRequest_lower(_ value: PermissionRequest) 
  * The Requested Fields are created by calling the [PermissionRequest::requested_fields] method, and then
  * explicitly setting the permission to true or false, based on the holder's decision.
  */
-public protocol PermissionResponseProtocol: AnyObject, Sendable {
+public protocol PermissionResponseProtocol: AnyObject {
     
     /**
      * Return the selected credentials for the permission response.
@@ -6289,9 +6193,6 @@ open class PermissionResponse: PermissionResponseProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6411,7 +6312,7 @@ public func FfiConverterTypePermissionResponse_lower(_ value: PermissionResponse
 /**
  * A credential that has been parsed as a known variant.
  */
-public protocol PresentableCredentialProtocol: AnyObject, Sendable {
+public protocol PresentableCredentialProtocol: AnyObject {
     
     /**
      * Converts to the primitive ParsedCredential type
@@ -6442,9 +6343,6 @@ open class PresentableCredential: PresentableCredentialProtocol, @unchecked Send
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6562,7 +6460,7 @@ public func FfiConverterTypePresentableCredential_lower(_ value: PresentableCred
 /**
  * A viable match for the credential request.
  */
-public protocol RequestMatch180137Protocol: AnyObject, Sendable {
+public protocol RequestMatch180137Protocol: AnyObject {
     
     func credentialId()  -> Uuid
     
@@ -6586,9 +6484,6 @@ open class RequestMatch180137: RequestMatch180137Protocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6696,7 +6591,7 @@ public func FfiConverterTypeRequestMatch180137_lower(_ value: RequestMatch180137
 
 
 
-public protocol RequestedFieldProtocol: AnyObject, Sendable {
+public protocol RequestedFieldProtocol: AnyObject {
     
     /**
      * Return the unique ID for the request field.
@@ -6753,9 +6648,6 @@ open class RequestedField: RequestedFieldProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -6932,7 +6824,7 @@ public func FfiConverterTypeRequestedField_lower(_ value: RequestedField) -> Uns
 /**
  * A cryptographic keypair that can be used for signing.
  */
-public protocol SigningKey: AnyObject, Sendable {
+public protocol SigningKey: AnyObject {
     
     /**
      * Generates a public JWK for this key.
@@ -6962,9 +6854,6 @@ open class SigningKeyImpl: SigningKey, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -7161,7 +7050,7 @@ public func FfiConverterTypeSigningKey_lower(_ value: SigningKey) -> UnsafeMutab
  * and the purpose is the purpose of the credential, which is used
  * to interpret the value.
  */
-public protocol StatusProtocol: AnyObject, Sendable {
+public protocol StatusProtocol: AnyObject {
     
     /**
      * Return whether the credential status has a message.
@@ -7210,9 +7099,6 @@ open class Status: StatusProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -7363,7 +7249,7 @@ public func FfiConverterTypeStatus_lower(_ value: Status) -> UnsafeMutableRawPoi
  * and the purpose is the purpose of the credential, which is used
  * to interpret the value.
  */
-public protocol Status20240406Protocol: AnyObject, Sendable {
+public protocol Status20240406Protocol: AnyObject {
     
     /**
      * Return whether the credential status has a message.
@@ -7412,9 +7298,6 @@ open class Status20240406: Status20240406Protocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -7570,7 +7453,7 @@ public func FfiConverterTypeStatus20240406_lower(_ value: Status20240406) -> Uns
  * We use the older callback_interface to keep the required version level of our Android API
  * low.
  */
-public protocol StorageManagerInterface: AnyObject, Sendable {
+public protocol StorageManagerInterface: AnyObject {
     
     /**
      * Function: add
@@ -7636,9 +7519,6 @@ open class StorageManagerInterfaceImpl: StorageManagerInterface, @unchecked Send
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -7697,7 +7577,7 @@ open func add(key: Key, value: Value)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeStorageManagerError_lift
+            errorHandler: FfiConverterTypeStorageManagerError.lift
         )
 }
     
@@ -7720,7 +7600,7 @@ open func get(key: Key)async throws  -> Value?  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeValue.lift,
-            errorHandler: FfiConverterTypeStorageManagerError_lift
+            errorHandler: FfiConverterTypeStorageManagerError.lift
         )
 }
     
@@ -7742,7 +7622,7 @@ open func list()async throws  -> [Key]  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeKey.lift,
-            errorHandler: FfiConverterTypeStorageManagerError_lift
+            errorHandler: FfiConverterTypeStorageManagerError.lift
         )
 }
     
@@ -7767,7 +7647,7 @@ open func remove(key: Key)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeStorageManagerError_lift
+            errorHandler: FfiConverterTypeStorageManagerError.lift
         )
 }
     
@@ -8024,7 +7904,7 @@ public func FfiConverterTypeStorageManagerInterface_lower(_ value: StorageManage
 
 
 
-public protocol SyncHttpClient: AnyObject, Sendable {
+public protocol SyncHttpClient: AnyObject {
     
     func httpClient(request: HttpRequest) throws  -> HttpResponse
     
@@ -8043,9 +7923,6 @@ open class SyncHttpClientImpl: SyncHttpClient, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -8199,7 +8076,7 @@ public func FfiConverterTypeSyncHttpClient_lower(_ value: SyncHttpClient) -> Uns
 
 
 
-public protocol TokenResponseProtocol: AnyObject, Sendable {
+public protocol TokenResponseProtocol: AnyObject {
     
 }
 open class TokenResponse: TokenResponseProtocol, @unchecked Sendable {
@@ -8216,9 +8093,6 @@ open class TokenResponse: TokenResponseProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -8312,7 +8186,7 @@ public func FfiConverterTypeTokenResponse_lower(_ value: TokenResponse) -> Unsaf
 
 
 
-public protocol Vcdm2SdJwtProtocol: AnyObject, Sendable {
+public protocol Vcdm2SdJwtProtocol: AnyObject {
     
     /**
      * Return the ID for the SdJwt instance.
@@ -8356,9 +8230,6 @@ open class Vcdm2SdJwt: Vcdm2SdJwtProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -8464,7 +8335,7 @@ open func status()async throws  -> [Status20240406]  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeStatus20240406.lift,
-            errorHandler: FfiConverterTypeStatusListError_lift
+            errorHandler: FfiConverterTypeStatusListError.lift
         )
 }
     
@@ -8542,7 +8413,7 @@ public func FfiConverterTypeVCDM2SdJwt_lower(_ value: Vcdm2SdJwt) -> UnsafeMutab
  *
  * This is the main interface to credentials.
  */
-public protocol VdcCollectionProtocol: AnyObject, Sendable {
+public protocol VdcCollectionProtocol: AnyObject {
     
     /**
      * Add a credential to the set.
@@ -8594,9 +8465,6 @@ open class VdcCollection: VdcCollectionProtocol, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -8659,7 +8527,7 @@ open func add(credential: Credential)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVdcCollectionError_lift
+            errorHandler: FfiConverterTypeVdcCollectionError.lift
         )
 }
     
@@ -8679,7 +8547,7 @@ open func allEntries()async throws  -> [Uuid]  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeUuid.lift,
-            errorHandler: FfiConverterTypeVdcCollectionError_lift
+            errorHandler: FfiConverterTypeVdcCollectionError.lift
         )
 }
     
@@ -8699,7 +8567,7 @@ open func allEntriesByType(ctype: CredentialType)async throws  -> [Uuid]  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeUuid.lift,
-            errorHandler: FfiConverterTypeVdcCollectionError_lift
+            errorHandler: FfiConverterTypeVdcCollectionError.lift
         )
 }
     
@@ -8719,7 +8587,7 @@ open func delete(id: Uuid)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVdcCollectionError_lift
+            errorHandler: FfiConverterTypeVdcCollectionError.lift
         )
 }
     
@@ -8760,7 +8628,7 @@ open func get(id: Uuid)async throws  -> Credential?  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeCredential.lift,
-            errorHandler: FfiConverterTypeVdcCollectionError_lift
+            errorHandler: FfiConverterTypeVdcCollectionError.lift
         )
 }
     
@@ -8822,7 +8690,7 @@ public func FfiConverterTypeVdcCollection_lower(_ value: VdcCollection) -> Unsaf
 
 
 
-public protocol WalletServiceClientProtocol: AnyObject, Sendable {
+public protocol WalletServiceClientProtocol: AnyObject {
     
     /**
      * Helper method to get an authorization header with the current token
@@ -8866,9 +8734,6 @@ open class WalletServiceClient: WalletServiceClientProtocol, @unchecked Sendable
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
@@ -8965,7 +8830,7 @@ open func login(appAttestation: String)async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeWalletServiceError_lift
+            errorHandler: FfiConverterTypeWalletServiceError.lift
         )
 }
     
@@ -8985,7 +8850,7 @@ open func nonce()async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeWalletServiceError_lift
+            errorHandler: FfiConverterTypeWalletServiceError.lift
         )
 }
     
@@ -9112,76 +8977,6 @@ public func FfiConverterTypeApprovedResponse180137_lift(_ buf: RustBuffer) throw
 #endif
 public func FfiConverterTypeApprovedResponse180137_lower(_ value: ApprovedResponse180137) -> RustBuffer {
     return FfiConverterTypeApprovedResponse180137.lower(value)
-}
-
-
-public struct CheckStatusResponse {
-    public var state: String
-    public var openidCredentialOffer: String
-
-    // Default memberwise initializers are never public by default, so we
-    // declare one manually.
-    public init(state: String, openidCredentialOffer: String) {
-        self.state = state
-        self.openidCredentialOffer = openidCredentialOffer
-    }
-}
-
-#if compiler(>=6)
-extension CheckStatusResponse: Sendable {}
-#endif
-
-
-extension CheckStatusResponse: Equatable, Hashable {
-    public static func ==(lhs: CheckStatusResponse, rhs: CheckStatusResponse) -> Bool {
-        if lhs.state != rhs.state {
-            return false
-        }
-        if lhs.openidCredentialOffer != rhs.openidCredentialOffer {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(state)
-        hasher.combine(openidCredentialOffer)
-    }
-}
-
-
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public struct FfiConverterTypeCheckStatusResponse: FfiConverterRustBuffer {
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> CheckStatusResponse {
-        return
-            try CheckStatusResponse(
-                state: FfiConverterString.read(from: &buf), 
-                openidCredentialOffer: FfiConverterString.read(from: &buf)
-        )
-    }
-
-    public static func write(_ value: CheckStatusResponse, into buf: inout [UInt8]) {
-        FfiConverterString.write(value.state, into: &buf)
-        FfiConverterString.write(value.openidCredentialOffer, into: &buf)
-    }
-}
-
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public func FfiConverterTypeCheckStatusResponse_lift(_ buf: RustBuffer) throws -> CheckStatusResponse {
-    return try FfiConverterTypeCheckStatusResponse.lift(buf)
-}
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public func FfiConverterTypeCheckStatusResponse_lower(_ value: CheckStatusResponse) -> RustBuffer {
-    return FfiConverterTypeCheckStatusResponse.lower(value)
 }
 
 
@@ -10732,10 +10527,7 @@ extension AuthenticationStatus: Equatable, Hashable {}
 
 
 
-
-
-
-public enum CborLdEncodingError: Swift.Error {
+public enum CborLdEncodingError {
 
     
     
@@ -10810,14 +10602,11 @@ extension CborLdEncodingError: Equatable, Hashable {}
 
 
 
-
 extension CborLdEncodingError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
-
-
 
 
 // Note that we don't yet support `indirect` for enums.
@@ -10958,8 +10747,6 @@ public func FfiConverterTypeCborValue_lower(_ value: CborValue) -> RustBuffer {
 
 
 
-
-
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 /**
@@ -11056,10 +10843,7 @@ extension ClaimValue: Equatable, Hashable {}
 
 
 
-
-
-
-public enum CredentialDecodingError: Swift.Error {
+public enum CredentialDecodingError {
 
     
     
@@ -11194,7 +10978,6 @@ extension CredentialDecodingError: Equatable, Hashable {}
 
 
 
-
 extension CredentialDecodingError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -11203,9 +10986,7 @@ extension CredentialDecodingError: Foundation.LocalizedError {
 
 
 
-
-
-public enum CredentialEncodingError: Swift.Error {
+public enum CredentialEncodingError {
 
     
     
@@ -11310,14 +11091,11 @@ extension CredentialEncodingError: Equatable, Hashable {}
 
 
 
-
 extension CredentialEncodingError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
-
-
 
 
 // Note that we don't yet support `indirect` for enums.
@@ -11429,10 +11207,7 @@ extension CredentialFormat: Equatable, Hashable {}
 
 
 
-
-
-
-public enum CredentialPresentationError: Swift.Error {
+public enum CredentialPresentationError {
 
     
     
@@ -11507,7 +11282,6 @@ extension CredentialPresentationError: Equatable, Hashable {}
 
 
 
-
 extension CredentialPresentationError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -11516,9 +11290,7 @@ extension CredentialPresentationError: Foundation.LocalizedError {
 
 
 
-
-
-public enum CryptoError: Swift.Error {
+public enum CryptoError {
 
     
     
@@ -11583,7 +11355,6 @@ extension CryptoError: Equatable, Hashable {}
 
 
 
-
 extension CryptoError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -11592,9 +11363,7 @@ extension CryptoError: Foundation.LocalizedError {
 
 
 
-
-
-public enum CwtError: Swift.Error {
+public enum CwtError {
 
     
     
@@ -11857,7 +11626,6 @@ extension CwtError: Equatable, Hashable {}
 
 
 
-
 extension CwtError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -11866,9 +11634,7 @@ extension CwtError: Foundation.LocalizedError {
 
 
 
-
-
-public enum DcApiError: Swift.Error {
+public enum DcApiError {
 
     
     
@@ -11943,14 +11709,11 @@ extension DcApiError: Equatable, Hashable {}
 
 
 
-
 extension DcApiError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
-
-
 
 
 // Note that we don't yet support `indirect` for enums.
@@ -12035,10 +11798,7 @@ extension DelegatedVerifierStatus: Equatable, Hashable {}
 
 
 
-
-
-
-public enum DidError: Swift.Error {
+public enum DidError {
 
     
     
@@ -12127,14 +11887,11 @@ extension DidError: Equatable, Hashable {}
 
 
 
-
 extension DidError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
-
-
 
 
 // Note that we don't yet support `indirect` for enums.
@@ -12204,11 +11961,112 @@ extension DidMethod: Equatable, Hashable {}
 
 
 
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
+ * Issuance flow state.
+ */
+
+public enum FlowState {
+    
+    case proofingRequired(proofingUrl: Url
+    )
+    /**
+     * The credential needs manual review
+     */
+    case awaitingManualReview
+    /**
+     * The credential is ready to be provisioned.
+     */
+    case readyToProvision(
+        /**
+         * OID4VCI Credential Offer, to begin the OID4VCI flow.
+         *
+         * See: <https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-offer>
+         */openidCredentialOffer: Url
+    )
+    /**
+     * Application Denied
+     */
+    case applicationDenied
+}
+
+
+#if compiler(>=6)
+extension FlowState: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeFlowState: FfiConverterRustBuffer {
+    typealias SwiftType = FlowState
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> FlowState {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .proofingRequired(proofingUrl: try FfiConverterTypeUrl.read(from: &buf)
+        )
+        
+        case 2: return .awaitingManualReview
+        
+        case 3: return .readyToProvision(openidCredentialOffer: try FfiConverterTypeUrl.read(from: &buf)
+        )
+        
+        case 4: return .applicationDenied
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: FlowState, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case let .proofingRequired(proofingUrl):
+            writeInt(&buf, Int32(1))
+            FfiConverterTypeUrl.write(proofingUrl, into: &buf)
+            
+        
+        case .awaitingManualReview:
+            writeInt(&buf, Int32(2))
+        
+        
+        case let .readyToProvision(openidCredentialOffer):
+            writeInt(&buf, Int32(3))
+            FfiConverterTypeUrl.write(openidCredentialOffer, into: &buf)
+            
+        
+        case .applicationDenied:
+            writeInt(&buf, Int32(4))
+        
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFlowState_lift(_ buf: RustBuffer) throws -> FlowState {
+    return try FfiConverterTypeFlowState.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFlowState_lower(_ value: FlowState) -> RustBuffer {
+    return FfiConverterTypeFlowState.lower(value)
+}
+
+
+extension FlowState: Equatable, Hashable {}
 
 
 
 
-public enum HttpClientError: Swift.Error {
+public enum HttpClientError {
 
     
     
@@ -12335,7 +12193,6 @@ extension HttpClientError: Equatable, Hashable {}
 
 
 
-
 extension HttpClientError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -12344,12 +12201,10 @@ extension HttpClientError: Foundation.LocalizedError {
 
 
 
-
-
 /**
  * Represents errors that may occur during issuance operations
  */
-public enum IssuanceServiceError: Swift.Error {
+public enum IssuanceServiceError {
 
     
     
@@ -12471,7 +12326,6 @@ extension IssuanceServiceError: Equatable, Hashable {}
 
 
 
-
 extension IssuanceServiceError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -12480,9 +12334,7 @@ extension IssuanceServiceError: Foundation.LocalizedError {
 
 
 
-
-
-public enum JsonVcEncodingError: Swift.Error {
+public enum JsonVcEncodingError {
 
     
     
@@ -12543,7 +12395,6 @@ extension JsonVcEncodingError: Equatable, Hashable {}
 
 
 
-
 extension JsonVcEncodingError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -12552,9 +12403,7 @@ extension JsonVcEncodingError: Foundation.LocalizedError {
 
 
 
-
-
-public enum JsonVcInitError: Swift.Error {
+public enum JsonVcInitError {
 
     
     
@@ -12633,7 +12482,6 @@ extension JsonVcInitError: Equatable, Hashable {}
 
 
 
-
 extension JsonVcInitError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -12642,9 +12490,7 @@ extension JsonVcInitError: Foundation.LocalizedError {
 
 
 
-
-
-public enum JwtVcInitError: Swift.Error {
+public enum JwtVcInitError {
 
     
     
@@ -12747,7 +12593,6 @@ extension JwtVcInitError: Equatable, Hashable {}
 
 
 
-
 extension JwtVcInitError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -12756,9 +12601,7 @@ extension JwtVcInitError: Foundation.LocalizedError {
 
 
 
-
-
-public enum KeyTransformationError: Swift.Error {
+public enum KeyTransformationError {
 
     
     
@@ -12853,7 +12696,6 @@ extension KeyTransformationError: Equatable, Hashable {}
 
 
 
-
 extension KeyTransformationError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -12862,9 +12704,7 @@ extension KeyTransformationError: Foundation.LocalizedError {
 
 
 
-
-
-public enum MdlReaderResponseError: Swift.Error {
+public enum MdlReaderResponseError {
 
     
     
@@ -12953,7 +12793,6 @@ extension MdlReaderResponseError: Equatable, Hashable {}
 
 
 
-
 extension MdlReaderResponseError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -12962,9 +12801,7 @@ extension MdlReaderResponseError: Foundation.LocalizedError {
 
 
 
-
-
-public enum MdlReaderResponseSerializeError: Swift.Error {
+public enum MdlReaderResponseSerializeError {
 
     
     
@@ -13029,7 +12866,6 @@ extension MdlReaderResponseSerializeError: Equatable, Hashable {}
 
 
 
-
 extension MdlReaderResponseSerializeError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -13038,9 +12874,7 @@ extension MdlReaderResponseSerializeError: Foundation.LocalizedError {
 
 
 
-
-
-public enum MdlReaderSessionError: Swift.Error {
+public enum MdlReaderSessionError {
 
     
     
@@ -13105,14 +12939,11 @@ extension MdlReaderSessionError: Equatable, Hashable {}
 
 
 
-
 extension MdlReaderSessionError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
-
-
 
 
 // Note that we don't yet support `indirect` for enums.
@@ -13219,10 +13050,7 @@ extension MDocItem: Equatable, Hashable {}
 
 
 
-
-
-
-public enum MdlUtilError: Swift.Error {
+public enum MdlUtilError {
 
     
     
@@ -13287,7 +13115,6 @@ extension MdlUtilError: Equatable, Hashable {}
 
 
 
-
 extension MdlUtilError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -13296,9 +13123,7 @@ extension MdlUtilError: Foundation.LocalizedError {
 
 
 
-
-
-public enum MdocEncodingError: Swift.Error {
+public enum MdocEncodingError {
 
     
     
@@ -13359,7 +13184,6 @@ extension MdocEncodingError: Equatable, Hashable {}
 
 
 
-
 extension MdocEncodingError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -13368,9 +13192,7 @@ extension MdocEncodingError: Foundation.LocalizedError {
 
 
 
-
-
-public enum MdocInitError: Swift.Error {
+public enum MdocInitError {
 
     
     
@@ -13477,7 +13299,6 @@ extension MdocInitError: Equatable, Hashable {}
 
 
 
-
 extension MdocInitError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -13486,9 +13307,7 @@ extension MdocInitError: Foundation.LocalizedError {
 
 
 
-
-
-public enum Oid4vp180137Error: Swift.Error {
+public enum Oid4vp180137Error {
 
     
     
@@ -13573,7 +13392,6 @@ extension Oid4vp180137Error: Equatable, Hashable {}
 
 
 
-
 extension Oid4vp180137Error: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -13582,13 +13400,11 @@ extension Oid4vp180137Error: Foundation.LocalizedError {
 
 
 
-
-
 /**
  * The [OID4VPError] enum represents the errors that can occur
  * when using the oid4vp foreign library.
  */
-public enum Oid4vpError: Swift.Error {
+public enum Oid4vpError {
 
     
     
@@ -13959,7 +13775,6 @@ extension Oid4vpError: Equatable, Hashable {}
 
 
 
-
 extension Oid4vpError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -13968,9 +13783,7 @@ extension Oid4vpError: Foundation.LocalizedError {
 
 
 
-
-
-public enum Oid4vciError: Swift.Error {
+public enum Oid4vciError {
 
     
     
@@ -14123,7 +13936,6 @@ extension Oid4vciError: Equatable, Hashable {}
 
 
 
-
 extension Oid4vciError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -14132,9 +13944,7 @@ extension Oid4vciError: Foundation.LocalizedError {
 
 
 
-
-
-public enum Oid4vpVerifierError: Swift.Error {
+public enum Oid4vpVerifierError {
 
     
     
@@ -14209,14 +14019,11 @@ extension Oid4vpVerifierError: Equatable, Hashable {}
 
 
 
-
 extension Oid4vpVerifierError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
-
-
 
 
 // Note that we don't yet support `indirect` for enums.
@@ -14303,10 +14110,7 @@ extension Outcome: Equatable, Hashable {}
 
 
 
-
-
-
-public enum PermissionRequestError: Swift.Error {
+public enum PermissionRequestError {
 
     
     
@@ -14492,7 +14296,6 @@ extension PermissionRequestError: Equatable, Hashable {}
 
 
 
-
 extension PermissionRequestError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -14501,9 +14304,7 @@ extension PermissionRequestError: Foundation.LocalizedError {
 
 
 
-
-
-public enum PopError: Swift.Error {
+public enum PopError {
 
     
     
@@ -14600,7 +14401,6 @@ extension PopError: Equatable, Hashable {}
 
 
 
-
 extension PopError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -14609,9 +14409,7 @@ extension PopError: Foundation.LocalizedError {
 
 
 
-
-
-public enum PresentationBuilderError: Swift.Error {
+public enum PresentationBuilderError {
 
     
     
@@ -14756,7 +14554,6 @@ extension PresentationBuilderError: Equatable, Hashable {}
 
 
 
-
 extension PresentationBuilderError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -14765,9 +14562,7 @@ extension PresentationBuilderError: Foundation.LocalizedError {
 
 
 
-
-
-public enum PresentationError: Swift.Error {
+public enum PresentationError {
 
     
     
@@ -14872,7 +14667,6 @@ extension PresentationError: Equatable, Hashable {}
 
 
 
-
 extension PresentationError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -14881,9 +14675,7 @@ extension PresentationError: Foundation.LocalizedError {
 
 
 
-
-
-public enum RequestError: Swift.Error {
+public enum RequestError {
 
     
     
@@ -14948,7 +14740,6 @@ extension RequestError: Equatable, Hashable {}
 
 
 
-
 extension RequestError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -14957,9 +14748,7 @@ extension RequestError: Foundation.LocalizedError {
 
 
 
-
-
-public enum ResponseError: Swift.Error {
+public enum ResponseError {
 
     
     
@@ -15030,7 +14819,6 @@ extension ResponseError: Equatable, Hashable {}
 
 
 
-
 extension ResponseError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -15039,9 +14827,7 @@ extension ResponseError: Foundation.LocalizedError {
 
 
 
-
-
-public enum SdJwtError: Swift.Error {
+public enum SdJwtError {
 
     
     
@@ -15152,7 +14938,6 @@ extension SdJwtError: Equatable, Hashable {}
 
 
 
-
 extension SdJwtError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -15161,9 +14946,7 @@ extension SdJwtError: Foundation.LocalizedError {
 
 
 
-
-
-public enum SessionError: Swift.Error {
+public enum SessionError {
 
     
     
@@ -15228,7 +15011,6 @@ extension SessionError: Equatable, Hashable {}
 
 
 
-
 extension SessionError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -15237,9 +15019,7 @@ extension SessionError: Foundation.LocalizedError {
 
 
 
-
-
-public enum SignatureError: Swift.Error {
+public enum SignatureError {
 
     
     
@@ -15320,7 +15100,6 @@ extension SignatureError: Equatable, Hashable {}
 
 
 
-
 extension SignatureError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -15329,9 +15108,7 @@ extension SignatureError: Foundation.LocalizedError {
 
 
 
-
-
-public enum StatusListError: Swift.Error {
+public enum StatusListError {
 
     
     
@@ -15402,7 +15179,6 @@ extension StatusListError: Equatable, Hashable {}
 
 
 
-
 extension StatusListError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -15411,14 +15187,12 @@ extension StatusListError: Foundation.LocalizedError {
 
 
 
-
-
 /**
  * Enum: StorageManagerError
  *
  * Represents errors that may occur during storage management operations
  */
-public enum StorageManagerError: Swift.Error {
+public enum StorageManagerError {
 
     
     
@@ -15520,7 +15294,6 @@ extension StorageManagerError: Equatable, Hashable {}
 
 
 
-
 extension StorageManagerError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -15529,9 +15302,7 @@ extension StorageManagerError: Foundation.LocalizedError {
 
 
 
-
-
-public enum TerminationError: Swift.Error {
+public enum TerminationError {
 
     
     
@@ -15596,7 +15367,6 @@ extension TerminationError: Equatable, Hashable {}
 
 
 
-
 extension TerminationError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -15605,9 +15375,7 @@ extension TerminationError: Foundation.LocalizedError {
 
 
 
-
-
-public enum VcbVerificationError: Swift.Error {
+public enum VcbVerificationError {
 
     
     
@@ -15678,7 +15446,6 @@ extension VcbVerificationError: Equatable, Hashable {}
 
 
 
-
 extension VcbVerificationError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -15687,9 +15454,7 @@ extension VcbVerificationError: Foundation.LocalizedError {
 
 
 
-
-
-public enum VcVerificationError: Swift.Error {
+public enum VcVerificationError {
 
     
     
@@ -15754,7 +15519,6 @@ extension VcVerificationError: Equatable, Hashable {}
 
 
 
-
 extension VcVerificationError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
@@ -15763,9 +15527,7 @@ extension VcVerificationError: Foundation.LocalizedError {
 
 
 
-
-
-public enum VpError: Swift.Error {
+public enum VpError {
 
     
     
@@ -15852,14 +15614,11 @@ extension VpError: Equatable, Hashable {}
 
 
 
-
 extension VpError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
-
-
 
 
 // Note that we don't yet support `indirect` for enums.
@@ -15930,10 +15689,7 @@ extension VcdmVersion: Equatable, Hashable {}
 
 
 
-
-
-
-public enum VdcCollectionError: Swift.Error {
+public enum VdcCollectionError {
 
     
     
@@ -16045,14 +15801,11 @@ extension VdcCollectionError: Equatable, Hashable {}
 
 
 
-
 extension VdcCollectionError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
-
-
 
 
 // Note that we don't yet support `indirect` for enums.
@@ -16126,10 +15879,7 @@ extension VerificationResult: Equatable, Hashable {}
 
 
 
-
-
-
-public enum WalletServiceError: Swift.Error {
+public enum WalletServiceError {
 
     
     
@@ -16273,14 +16023,11 @@ extension WalletServiceError: Equatable, Hashable {}
 
 
 
-
 extension WalletServiceError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
-
-
 
 
 
@@ -16299,7 +16046,7 @@ extension WalletServiceError: Foundation.LocalizedError {
  * For example, in the case of `JwtVc` credential format,
  * the signing payload consists of the JWT header and payload (JWS).
  */
-public protocol PresentationSigner: AnyObject, Sendable {
+public protocol PresentationSigner: AnyObject {
     
     /**
      * Sign the payload with the private key and return the signature.
@@ -18412,7 +18159,7 @@ public func cborLdEncodeToBytes(credentialStr: String, loader: [String: String]?
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterData.lift,
-            errorHandler: FfiConverterTypeCborLdEncodingError_lift
+            errorHandler: FfiConverterTypeCborLdEncodingError.lift
         )
 }
 /**
@@ -18472,7 +18219,7 @@ public func generatePopPrepare(audience: String, nonce: String?, didMethod: DidM
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterData.lift,
-            errorHandler: FfiConverterTypePopError_lift
+            errorHandler: FfiConverterTypePopError.lift
         )
 }
 /**
@@ -18502,7 +18249,7 @@ public func handleDcApiRequest(dcqlCredentialId: String, mdoc: Mdoc, origin: Str
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeInProgressRequestDcApi_lift,
-            errorHandler: FfiConverterTypeDcApiError_lift
+            errorHandler: FfiConverterTypeDcApiError.lift
         )
 }
 public func handleResponse(state: MdlSessionManager, response: Data)throws  -> MdlReaderResponseData  {
@@ -18542,7 +18289,7 @@ public func initializeMdlPresentation(mdocId: Uuid, uuid: Uuid, storageManager: 
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeMdlPresentationSession_lift,
-            errorHandler: FfiConverterTypeSessionError_lift
+            errorHandler: FfiConverterTypeSessionError.lift
         )
 }
 /**
@@ -18588,7 +18335,7 @@ public func oid4vciExchangeCredential(session: Oid4vciSession, proofsOfPossessio
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceTypeCredentialResponse.lift,
-            errorHandler: FfiConverterTypeOid4vciError_lift
+            errorHandler: FfiConverterTypeOid4vciError.lift
         )
 }
 public func oid4vciExchangeToken(session: Oid4vciSession, httpClient: IHttpClient)async throws  -> String?  {
@@ -18602,7 +18349,7 @@ public func oid4vciExchangeToken(session: Oid4vciSession, httpClient: IHttpClien
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionString.lift,
-            errorHandler: FfiConverterTypeOid4vciError_lift
+            errorHandler: FfiConverterTypeOid4vciError.lift
         )
 }
 public func oid4vciGetMetadata(session: Oid4vciSession)throws  -> Oid4vciMetadata  {
@@ -18623,7 +18370,7 @@ public func oid4vciInitiate(baseUrl: String, clientId: String, redirectUrl: Stri
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeOid4vciSession_lift,
-            errorHandler: FfiConverterTypeOid4vciError_lift
+            errorHandler: FfiConverterTypeOid4vciError.lift
         )
 }
 public func oid4vciInitiateWithOffer(credentialOffer: String, clientId: String, redirectUrl: String, httpClient: IHttpClient)async throws  -> Oid4vciSession  {
@@ -18637,7 +18384,7 @@ public func oid4vciInitiateWithOffer(credentialOffer: String, clientId: String, 
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_pointer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_pointer,
             liftFunc: FfiConverterTypeOid4vciSession_lift,
-            errorHandler: FfiConverterTypeOid4vciError_lift
+            errorHandler: FfiConverterTypeOid4vciError.lift
         )
 }
 public func vcToSignedVp(vc: String, keyStr: String)async throws  -> String  {
@@ -18651,7 +18398,7 @@ public func vcToSignedVp(vc: String, keyStr: String)async throws  -> String  {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeVPError_lift
+            errorHandler: FfiConverterTypeVPError.lift
         )
 }
 public func verifiedResponseAsJsonString(response: MdlReaderResponseData)throws  -> String  {
@@ -18672,7 +18419,7 @@ public func verifyJsonVcString(json: String)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVCVerificationError_lift
+            errorHandler: FfiConverterTypeVCVerificationError.lift
         )
 }
 public func verifyJwtVp(jwtVp: String)async throws   {
@@ -18686,7 +18433,7 @@ public func verifyJwtVp(jwtVp: String)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVPError_lift
+            errorHandler: FfiConverterTypeVPError.lift
         )
 }
 public func verifyPdf417Barcode(payload: String)async throws   {
@@ -18700,7 +18447,7 @@ public func verifyPdf417Barcode(payload: String)async throws   {
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVCBVerificationError_lift
+            errorHandler: FfiConverterTypeVCBVerificationError.lift
         )
 }
 public func verifyVcbQrcodeAgainstMrz(mrzPayload: String, qrPayload: String)async throws   {
@@ -18714,7 +18461,7 @@ public func verifyVcbQrcodeAgainstMrz(mrzPayload: String, qrPayload: String)asyn
             completeFunc: ffi_mobile_sdk_rs_rust_future_complete_void,
             freeFunc: ffi_mobile_sdk_rs_rust_future_free_void,
             liftFunc: { $0 },
-            errorHandler: FfiConverterTypeVCBVerificationError_lift
+            errorHandler: FfiConverterTypeVCBVerificationError.lift
         )
 }
 
@@ -18877,7 +18624,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_method_inprogressrequestdcapi_respond() != 18977) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mobile_sdk_rs_checksum_method_issuanceserviceclient_check_status() != 43341) {
+    if (uniffi_mobile_sdk_rs_checksum_method_issuanceserviceclient_check_status() != 42578) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_issuanceserviceclient_new_issuance() != 231) {

--- a/rust/src/common.rs
+++ b/rust/src/common.rs
@@ -189,8 +189,7 @@ impl CborInteger {
         let upper = self.upper_bytes();
 
         // Safety: we are doing all the operations from splitting to joining
-        u128::cast_signed(((upper as u128) << 64) | (lower as u128))
-            .to_string()
+        u128::cast_signed(((upper as u128) << 64) | (lower as u128)).to_string()
     }
 }
 

--- a/rust/src/common.rs
+++ b/rust/src/common.rs
@@ -189,7 +189,7 @@ impl CborInteger {
         let upper = self.upper_bytes();
 
         // Safety: we are doing all the operations from splitting to joining
-        unsafe { std::mem::transmute::<u128, i128>(((upper as u128) << 64) | (lower as u128)) }
+        u128::cast_signed(((upper as u128) << 64) | (lower as u128))
             .to_string()
     }
 }

--- a/rust/src/haci/issuance_service_client.rs
+++ b/rust/src/haci/issuance_service_client.rs
@@ -210,9 +210,12 @@ mod tests {
         let result = client.check_status(issuance_id, wallet_attestation).await;
         assert!(result.is_ok(), "Status check should succeed");
         let response = result.unwrap();
-        assert_eq!(response, FlowState::ReadyToProvision {
-            openid_credential_offer: Url::parse("https://openid_credential_offer.com").unwrap(),
-        });
+        assert_eq!(
+            response,
+            FlowState::ReadyToProvision {
+                openid_credential_offer: Url::parse("https://openid_credential_offer.com").unwrap(),
+            }
+        );
     }
 
     #[tokio::test]

--- a/rust/src/haci/issuance_service_client.rs
+++ b/rust/src/haci/issuance_service_client.rs
@@ -201,7 +201,7 @@ mod tests {
             .and(path(format!("/issuance/{}/status", issuance_id)))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "state": "ReadyToProvision",
-                "openid_credential_offer": "https://openid_credential_offer.com"
+                "openid_credential_offer": "openid-credential-offer://"
             })))
             .expect(1)
             .mount(&mock_server)
@@ -213,7 +213,7 @@ mod tests {
         assert_eq!(
             response,
             FlowState::ReadyToProvision {
-                openid_credential_offer: Url::parse("https://openid_credential_offer.com").unwrap(),
+                openid_credential_offer: Url::parse("openid-credential-offer://").unwrap(),
             }
         );
     }


### PR DESCRIPTION
## Description

This adds support to new High Assurance Requisition states (AwaitingManualReview and ApplicationDenied) in both apps. This also updates the way we handle the ProofingRequired state.

### Other changes

N/A

### Optional section

This has more than 500 lines because it includes a new big component for displaying the application state in Kotlin and Swift.

## Tested

You can test the entire flow with the internal High Assurance flow version (not in staging or production yet).