### PR TITLE
Envelope encryption/decryption credentials

### DIFF
--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/CredentialPack.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/CredentialPack.kt
@@ -109,7 +109,7 @@ class CredentialPack {
     /**
      * Try to add a credential in any supported format (standard credential or mdoc).
      * Attempts to parse as standard credential first, then as mdoc if that fails.
-     * 
+     *
      * @param rawCredential The raw credential data as a string
      * @param mdocKeyAlias The key alias to use if parsing as mdoc is needed
      * @return List of parsed credentials

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/StorageManager.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/StorageManager.kt
@@ -4,6 +4,7 @@ import com.spruceid.mobile.sdk.KeyManager
 import com.spruceid.mobile.sdk.rs.StorageManagerInterface
 import java.io.File
 import java.io.FileNotFoundException
+import java.security.SecureRandom
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
@@ -16,12 +17,13 @@ class StorageManager(val context: Context) : StorageManagerInterface {
     /// Arguments:
     /// key - The key to add
     /// value - The value to add under the key
-    override suspend fun add(key: String, value: ByteArray) =
+    override suspend fun add(key: String, value: ByteArray) {
+        val encryptedValue = encryptHybrid(value)
         context.openFileOutput(filename(key), 0).use {
-            it.write(encrypt(value))
+            it.write(encryptedValue)
             it.close()
         }
-
+    }
 
     /// Function: get
     ///
@@ -30,7 +32,7 @@ class StorageManager(val context: Context) : StorageManagerInterface {
     /// Arguments:
     /// key - The key to retrieve
     override suspend fun get(key: String): ByteArray? {
-        var bytes: ByteArray
+        val bytes: ByteArray
         try {
             context.openFileInput(filename(key)).use {
                 bytes = it.readBytes()
@@ -39,7 +41,13 @@ class StorageManager(val context: Context) : StorageManagerInterface {
         } catch (e: FileNotFoundException) {
             return null
         }
-        return decrypt(bytes)
+
+        // Format detection based on structure
+        return if (isHybridFormat(bytes)) {
+            decryptHybrid(bytes)
+        } else {
+            decrypt(bytes)
+        }
     }
 
     /// Function: remove
@@ -51,7 +59,6 @@ class StorageManager(val context: Context) : StorageManagerInterface {
     override suspend fun remove(key: String) {
         File(context.filesDir, filename(key)).delete()
     }
-
 
     /// Function: list
     ///
@@ -68,17 +75,42 @@ class StorageManager(val context: Context) : StorageManagerInterface {
         }
     }
 
-
     companion object {
         private const val B64_FLAGS = Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP
         private const val KEY_NAME = "sprucekit/datastore"
+        private const val HYBRID_PREFIX = "HYBRID|"
+
+        /// Function: isHybridFormat
+        ///
+        /// Efficiently detects if the encrypted data uses hybrid format by checking the prefix.
+        /// Only converts the minimum necessary bytes to string for performance.
+        ///
+        /// Arguments:
+        /// bytes - The encrypted data to analyze
+        ///
+        /// Returns:
+        /// true if hybrid format, false if not hybrid format
+        private fun isHybridFormat(bytes: ByteArray): Boolean {
+            if (bytes.size < HYBRID_PREFIX.length) {
+                return false
+            }
+
+            val prefixBytes = bytes.sliceArray(0 until HYBRID_PREFIX.length)
+            val prefixString = try {
+                prefixBytes.decodeToString()
+            } catch (e: Exception) {
+                return false
+            }
+
+            return prefixString == HYBRID_PREFIX
+        }
 
         /// Function: encrypt
         ///
-        /// Encrypts the given string.
+        /// Encrypts the given string (legacy method).
         ///
         /// Arguments:
-        /// value - The string value to be encrypted
+        /// value - The byte array value to be encrypted
         private suspend fun encrypt(value: ByteArray): ByteArray {
             return suspendCoroutine { continuation ->
                 val keyManager = KeyManager()
@@ -93,9 +125,44 @@ class StorageManager(val context: Context) : StorageManagerInterface {
             }
         }
 
+        /// Function: encryptHybrid
+        ///
+        /// Encrypts large payloads using hybrid encryption (envelope pattern).
+        /// Android Keystore protects only a 32-byte AES key, data is encrypted with software AES.
+        ///
+        /// Arguments:
+        /// value - The byte array value to be encrypted
+        private suspend fun encryptHybrid(value: ByteArray): ByteArray {
+            return suspendCoroutine { continuation ->
+                val keyManager = KeyManager()
+                if (!keyManager.keyExists(KEY_NAME)) {
+                    keyManager.generateEncryptionKey(KEY_NAME)
+                }
+
+                // Generate random 256-bit AES key for data encryption
+                val dataKey = ByteArray(32)
+                SecureRandom().nextBytes(dataKey)
+
+                // Encrypt payload with software AES using data key
+                val (dataIv, encryptedData) = keyManager.encryptWithDirectKey(dataKey, value)
+
+                // Encrypt data key with Android Keystore
+                val (keyIv, encryptedDataKey) = keyManager.encryptPayload(KEY_NAME, dataKey)
+
+                // Combine everything in format: HYBRID|<key_iv>|<encrypted_key>|<data_iv>|<encrypted_data>
+                val keyIvB64 = Base64.encodeToString(keyIv, B64_FLAGS)
+                val encKeyB64 = Base64.encodeToString(encryptedDataKey, B64_FLAGS)
+                val dataIvB64 = Base64.encodeToString(dataIv, B64_FLAGS)
+                val encDataB64 = Base64.encodeToString(encryptedData, B64_FLAGS)
+
+                val result = "HYBRID|$keyIvB64|$encKeyB64|$dataIvB64|$encDataB64".toByteArray()
+                continuation.resume(result)
+            }
+        }
+
         /// Function: decrypt
         ///
-        /// Decrypts the given byte array.
+        /// Decrypts the given ByteArray (legacy method).
         ///
         /// Arguments:
         /// value - The byte array to be decrypted
@@ -111,6 +178,47 @@ class StorageManager(val context: Context) : StorageManagerInterface {
                 val encrypted = Base64.decode(decoded.last(), B64_FLAGS)
                 val decrypted = keyManager.decryptPayload(KEY_NAME, iv, encrypted)
                 continuation.resume(decrypted)
+            }
+        }
+
+        /// Function: decryptHybrid
+        ///
+        /// Decrypts hybrid format for maximum performance.
+        /// Only the 32-byte AES key is decrypted with Android Keystore, data with software AES.
+        ///
+        /// Arguments:
+        /// value - The byte array to be decrypted
+        private suspend fun decryptHybrid(value: ByteArray): ByteArray {
+            return suspendCoroutine { continuation ->
+                val keyManager = KeyManager()
+                if (!keyManager.keyExists(KEY_NAME)) {
+                    throw Exception("Cannot retrieve values before creating encryption keys")
+                }
+
+                // Parse hybrid format: HYBRID|<key_iv>|<encrypted_key>|<data_iv>|<encrypted_data>
+                val dataString = value.decodeToString()
+                if (!dataString.startsWith(HYBRID_PREFIX)) {
+                    throw Exception("Not hybrid format - doesn't start with $HYBRID_PREFIX")
+                }
+
+                val parts = dataString.split("|")
+                if (parts.size != 5) {
+                    throw Exception("Invalid hybrid format - expected 5 parts, got ${parts.size}")
+                }
+
+                val keyIv = Base64.decode(parts[1], B64_FLAGS)
+                val encryptedKey = Base64.decode(parts[2], B64_FLAGS)
+                val dataIv = Base64.decode(parts[3], B64_FLAGS)
+                val encryptedData = Base64.decode(parts[4], B64_FLAGS)
+
+                // Decrypt data key with Android Keystore
+                val dataKey = keyManager.decryptPayload(KEY_NAME, keyIv, encryptedKey)
+
+                // Decrypt payload with software AES
+                val decryptedData =
+                    keyManager.decryptWithDirectKey(dataKey, dataIv, encryptedData)
+
+                continuation.resume(decryptedData)
             }
         }
 

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/viewmodels/CredentialPacksViewModel.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/viewmodels/CredentialPacksViewModel.kt
@@ -33,7 +33,7 @@ class CredentialPacksViewModel(application: Application) : AndroidViewModel(appl
             }.await()
             _loading.value = false
 
-            // Listed for credential pack updates and update the registry.
+            // Listen for credential pack updates and update the registry.
             _credentialPacks.collect { packs -> dcApiRegistry.register(packs) }
         }
     }


### PR DESCRIPTION
## Description

This implements hybrid en/decryption methods to improve performance for big credentials.

Loading two credentials of 5MB each was taking 13+ seconds due to Android Keystore's poor performance with large payloads. Hardware Security Modules (HSM/TEE/Strongbox) have significant overhead for bulk data encryption, causing unacceptable load times on the initial screen.

This implemented hybrid encryption (envelope pattern) where Android Keystore protects only a 32-byte AES key while large credential data is encrypted with software AES/GCM. This follows industry standards used by Google Cloud KMS and AWS KMS. The solution maintains backward compatibility with existing encrypted data through automatic format detection.

### Other changes

N/A

### Optional section

N/A

## Tested

It's possible to test this by issuing a [VC Playground](https://vcplayground.org/issuer) Driver's License and checking how long it takes to save and load the credential. Unfortunately, it's broken, but I can help with some setup to make it locally.