### PR TITLE
Update targetSdk to 35 (Android 15) and dependencies

### DIFF
--- a/android/Showcase/build.gradle.kts
+++ b/android/Showcase/build.gradle.kts
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         applicationId = "com.spruceid.mobilesdkexample"
         minSdk = 26
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 53
         versionName = "1.13.0"
 
@@ -59,27 +59,26 @@ ksp {
 }
 
 dependencies {
-    val roomVersion = "2.4.0"
+    val roomVersion = "2.6.1"
 
     implementation("androidx.room:room-runtime:$roomVersion")
     ksp("androidx.room:room-compiler:$roomVersion")
     implementation("androidx.room:room-ktx:$roomVersion")
     annotationProcessor("androidx.room:room-compiler:$roomVersion")
-    implementation("androidx.core:core-ktx:1.12.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
-    implementation("androidx.activity:activity-compose:1.8.2")
-    implementation(platform("androidx.compose:compose-bom:2025.04.00"))
+    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.6")
+    implementation("androidx.activity:activity-compose:1.9.3")
+    implementation(platform("androidx.compose:compose-bom:2025.05.01"))
     implementation("com.google.accompanist:accompanist-permissions:0.35.1-alpha")
     implementation("com.google.accompanist:accompanist-swiperefresh:0.36.0")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
-    implementation("androidx.navigation:navigation-compose:2.7.7")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.4")
+    implementation("androidx.navigation:navigation-compose:2.8.4")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.6")
     implementation("app.rive:rive-android:8.7.0")
     implementation("androidx.startup:startup-runtime:1.1.1")
-    //implementation(project(":MobileSdk"))
     implementation(project(mapOf("path" to ":MobileSdk")))
     implementation("com.google.zxing:core:3.5.1")
     implementation("io.ktor:ktor-client-core:2.3.12")
@@ -89,7 +88,7 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
-    androidTestImplementation(platform("androidx.compose:compose-bom:2025.04.00"))
+    androidTestImplementation(platform("androidx.compose:compose-bom:2025.05.01"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/MainActivity.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/MainActivity.kt
@@ -53,8 +53,8 @@ class MainActivity : ComponentActivity() {
     private lateinit var connectionLiveData: ConnectionLiveData
     private lateinit var hacApplicationsViewModel: HacApplicationsViewModel
 
-    override fun onNewIntent(intent: Intent?) {
-        if (intent != null && intent.action == "android.intent.action.VIEW" && intent.data != null) {
+    override fun onNewIntent(intent: Intent) {
+        if (intent.action == "android.intent.action.VIEW" && intent.data != null) {
             if (intent.data!!.toString().startsWith("spruceid://?sd-jwt=")) {
                 navController.navigate(
                     Screen.AddToWalletScreen.route.replace(


### PR DESCRIPTION
## Description

This updates targetSdk from 34 to 35 (Android 15), critical dependencies for Android 15 compatibility, and fixes MainActivity.onNewIntent for Android 15 API changes.

Updated Dependencies:
- Room: 2.6.1
- Core KTX: 1.15.0
- Lifecycle Runtime: 2.8.6
- Activity Compose: 1.9.3
- Navigation Compose: 2.8.4
- Compose BOM: 2025.05.01

### Other changes

N/A

### Optional section

N/A

## Tested

- [x] App compiles successfully
- [x] AGP 8.9.1 compatible with targetSdk 35
- [x] MainActivity onNewIntent method fixed for Android 15

