### PR TITLE
Showcase iOS - Update generic details display formatting

### DIFF
--- a/ios/Showcase/Targets/AppUIKit/Sources/credentials/CredentialObjectDisplayer.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/credentials/CredentialObjectDisplayer.swift
@@ -27,6 +27,15 @@ struct CredentialObjectDisplayer: View {
     }
 }
 
+func formatValueString(_ value: GenericJSON) -> String {
+    if case let .number(num) = value {
+        if num.truncatingRemainder(dividingBy: 1) == 0 {
+            return String(format: "%.0f", num)
+        }
+    }
+    return value.toString()
+}
+
 func genericObjectDisplayer(
     object: [String: GenericJSON], filter: [String] = [], level: Int = 1
 ) -> [AnyView] {
@@ -168,7 +177,7 @@ func genericObjectDisplayer(
                                     value.toString(),
                                     destination: URL(string: value.toString())!)
                             } else {
-                                Text(value.toString())
+                                Text(formatValueString(value))
                             }
                         }))
             }


### PR DESCRIPTION
## Description

This updates the generic credential displayer formatter to properly format integers as strings, removing the `.0` at the end.  

### Other changes

N/A

### Optional section

N/A

## Tested

You can add a mock mDL to your wallet and check if the `Age Birth Year` is displayed as `1990` instead of `1990.0`