### PR TITLE
add is multi credential selection helper method

### DIFF
--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -6190,6 +6190,29 @@ public protocol PermissionRequestProtocol: AnyObject, Sendable {
     func domain()  -> String?
     
     /**
+     * Returns boolean whether the presentation definition
+     * matches multiple credentials of the same type that
+     * can satisfy the request.
+     */
+    func isMultiCredentialMatching()  -> Bool
+    
+    /**
+     * Return whether the presentation definition is requesting
+     * multiple credentials to satisfy the presentation.
+     *
+     * Will return true IFF multiple input descriptors exist
+     * in the presentation definition.
+     *
+     * NOTE: Based on the oid4vp specification that each input descriptor
+     * corresponds to a single credential type.
+     *
+     * In cases where multiple credentials are requested, for example,
+     * an mDL and a vehicle title, each input descriptor would match
+     * only one credential type.
+     */
+    func isMultiCredentialSelection()  -> Bool
+    
+    /**
      * Return the purpose of the presentation request.
      */
     func purpose()  -> String?
@@ -6312,6 +6335,39 @@ open func credentials() -> [PresentableCredential]  {
 open func domain() -> String?  {
     return try!  FfiConverterOptionString.lift(try! rustCall() {
     uniffi_mobile_sdk_rs_fn_method_permissionrequest_domain(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Returns boolean whether the presentation definition
+     * matches multiple credentials of the same type that
+     * can satisfy the request.
+     */
+open func isMultiCredentialMatching() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_mobile_sdk_rs_fn_method_permissionrequest_is_multi_credential_matching(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Return whether the presentation definition is requesting
+     * multiple credentials to satisfy the presentation.
+     *
+     * Will return true IFF multiple input descriptors exist
+     * in the presentation definition.
+     *
+     * NOTE: Based on the oid4vp specification that each input descriptor
+     * corresponds to a single credential type.
+     *
+     * In cases where multiple credentials are requested, for example,
+     * an mDL and a vehicle title, each input descriptor would match
+     * only one credential type.
+     */
+open func isMultiCredentialSelection() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_mobile_sdk_rs_fn_method_permissionrequest_is_multi_credential_selection(self.uniffiClonePointer(),$0
     )
 })
 }
@@ -19436,6 +19492,12 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_permissionrequest_domain() != 60512) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mobile_sdk_rs_checksum_method_permissionrequest_is_multi_credential_matching() != 46216) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mobile_sdk_rs_checksum_method_permissionrequest_is_multi_credential_selection() != 28994) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_permissionrequest_purpose() != 28780) {

--- a/rust/src/credential/mod.rs
+++ b/rust/src/credential/mod.rs
@@ -67,6 +67,9 @@ pub struct PresentableCredential {
     pub(crate) inner: ParsedCredentialInner,
     pub(crate) limit_disclosure: bool,
     pub(crate) selected_fields: Option<Vec<String>>,
+    // This is the ID of the input descriptor that matches
+    // the credential being presented.
+    pub(crate) input_descriptor_id: String,
 }
 
 /// A credential that has been parsed as a known variant.

--- a/rust/src/oid4vp/holder.rs
+++ b/rust/src/oid4vp/holder.rs
@@ -304,6 +304,15 @@ impl Holder {
         let credentials = credentials
             .into_iter()
             .map(|c| {
+                let input_descriptor_id = presentation_definition
+                    .input_descriptors()
+                    .iter()
+                    .find(|_| !c.requested_fields(&presentation_definition).is_empty())
+                    .map(|descriptor| descriptor.id.clone())
+                    // SAFETY: the credential will always match at least one input descriptor
+                    // at this point.
+                    .unwrap();
+
                 Arc::new(PresentableCredential {
                     inner: c.inner.clone(),
                     limit_disclosure: presentation_definition.input_descriptors().iter().any(
@@ -316,6 +325,7 @@ impl Holder {
                         },
                     ),
                     selected_fields: None,
+                    input_descriptor_id,
                 })
             })
             .collect::<Vec<_>>();


### PR DESCRIPTION
This pull request introduces enhancements to the credential handling logic in the `oid4vp` module, focusing on associating credentials with input descriptors and providing additional utilities for multi-credential scenarios. The most important changes include adding an `input_descriptor_id` field to `PresentableCredential`, updating its usage in the `Holder` and `PermissionRequest` implementations, and introducing methods for determining multi-credential selection and matching.

### Credential Association Enhancements:
* **Added `input_descriptor_id` field to `PresentableCredential`:** This field stores the ID of the input descriptor that matches the credential being presented, enabling better association between credentials and presentation definitions. (`rust/src/credential/mod.rs`, [rust/src/credential/mod.rsR70-R72](diffhunk://#diff-9445e2f1c416292363756c47c3e27362eb1068f52ec96c68684a46323b4ee7c3R70-R72))

* **Populated `input_descriptor_id` in `Holder` implementation:** Updated the logic for mapping credentials to include the matching `input_descriptor_id` based on the presentation definition. (`rust/src/oid4vp/holder.rs`, [[1]](diffhunk://#diff-4e5171e3c17d6828d9f543c21c352ac9b5f3f685f054bfa2aa56556def716dc8R307-R315) [[2]](diffhunk://#diff-4e5171e3c17d6828d9f543c21c352ac9b5f3f685f054bfa2aa56556def716dc8R328)

* **Propagated `input_descriptor_id` in `PermissionRequest`:** Ensured `input_descriptor_id` is cloned and passed along when constructing permission requests. (`rust/src/oid4vp/permission_request.rs`, [rust/src/oid4vp/permission_request.rsR268](diffhunk://#diff-33b955ef0c55a0f83e9b686ff6b8a67ef120a7909464084179fc98210e4e24caR268))

### Multi-Credential Utilities:
* **Added `is_multi_credential_selection` method:** Determines if the presentation definition requests multiple credentials by checking the number of input descriptors. (`rust/src/oid4vp/permission_request.rs`, [rust/src/oid4vp/permission_request.rsR304-R333](diffhunk://#diff-33b955ef0c55a0f83e9b686ff6b8a67ef120a7909464084179fc98210e4e24caR304-R333))

* **Added `is_multi_credential_matching` method:** Checks if multiple credentials of the same type can satisfy the request by grouping credentials by `input_descriptor_id`. (`rust/src/oid4vp/permission_request.rs`, [rust/src/oid4vp/permission_request.rsR304-R333](diffhunk://#diff-33b955ef0c55a0f83e9b686ff6b8a67ef120a7909464084179fc98210e4e24caR304-R333))
