### PR TITLE
Fix activity log entries not appearing for mDL-related actions

### DIFF
--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/utils/Utils.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/utils/Utils.kt
@@ -252,7 +252,7 @@ fun getCredentialIdTitleAndIssuer(
     val claims =
         credentialPack.findCredentialClaims(listOf("name", "type", "issuer", "issuing_authority"))
 
-    val cred = if (credential != null) {
+    var cred = if (credential != null) {
         claims.entries.firstNotNullOf { claim ->
             if (claim.key == credential.id()) {
                 claim
@@ -280,6 +280,16 @@ fun getCredentialIdTitleAndIssuer(
             } else {
                 null
             }
+        }
+    }
+    // Assume mDL.
+    if (credential?.asMsoMdoc() != null || cred.equals(null)) {
+        cred = claims.entries.firstNotNullOf { claim ->
+            val issuer = claim.value.get("issuing_authority")
+            claim.value.put("issuer", issuer)
+            val title = "Mobile Drivers License"
+            claim.value.put("name", title)
+            claim
         }
     }
 

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/WalletHomeView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/WalletHomeView.kt
@@ -267,7 +267,7 @@ fun WalletHomeBody(
                     WalletHomeViewNoCredentials(onGenerateMockMdl = {
                         isRefreshing = true
                         scope.launch {
-                            generateMockMdl(credentialPacksViewModel)
+                            generateMockMdl(credentialPacksViewModel, walletActivityLogsViewModel)
                         }
                         isRefreshing = false
                     })

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/walletsettings/GenerateMockMdlButton.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/walletsettings/GenerateMockMdlButton.kt
@@ -24,11 +24,13 @@ import com.spruceid.mobilesdkexample.ui.theme.ColorStone600
 import com.spruceid.mobilesdkexample.ui.theme.ColorStone950
 import com.spruceid.mobilesdkexample.ui.theme.Inter
 import com.spruceid.mobilesdkexample.viewmodels.CredentialPacksViewModel
+import com.spruceid.mobilesdkexample.viewmodels.WalletActivityLogsViewModel
 import kotlinx.coroutines.launch
 
 @Composable
 fun GenerateMockMdlButton(
-    credentialPacksViewModel: CredentialPacksViewModel
+    credentialPacksViewModel: CredentialPacksViewModel,
+    walletActivityLogsViewModel: WalletActivityLogsViewModel
 ) {
     val scope = rememberCoroutineScope()
     Box(
@@ -37,7 +39,7 @@ fun GenerateMockMdlButton(
             .padding(bottom = 20.dp)
             .clickable {
                 scope.launch {
-                    generateMockMdl(credentialPacksViewModel)
+                    generateMockMdl(credentialPacksViewModel, walletActivityLogsViewModel)
                 }
             },
     ) {

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/walletsettings/WalletSettingsHomeView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/walletsettings/WalletSettingsHomeView.kt
@@ -149,7 +149,7 @@ fun WalletSettingsHomeBody(
             }
         )
 
-        GenerateMockMdlButton(credentialPacksViewModel = credentialPacksViewModel)
+        GenerateMockMdlButton(credentialPacksViewModel = credentialPacksViewModel, walletActivityLogsViewModel = walletActivityLogsViewModel)
 
         SettingsHomeItem(
             icon = {

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/walletsettings/WalletSettingsUtils.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/walletsettings/WalletSettingsUtils.kt
@@ -1,12 +1,18 @@
 package com.spruceid.mobilesdkexample.walletsettings
 
+import androidx.compose.runtime.Composable
 import com.spruceid.mobile.sdk.CredentialPack
 import com.spruceid.mobile.sdk.KeyManager
 import com.spruceid.mobile.sdk.rs.generateTestMdl
+import com.spruceid.mobilesdkexample.db.WalletActivityLogs
 import com.spruceid.mobilesdkexample.utils.Toast
+import com.spruceid.mobilesdkexample.utils.activityHiltViewModel
+import com.spruceid.mobilesdkexample.utils.getCredentialIdTitleAndIssuer
+import com.spruceid.mobilesdkexample.utils.getCurrentSqlDate
 import com.spruceid.mobilesdkexample.viewmodels.CredentialPacksViewModel
+import com.spruceid.mobilesdkexample.viewmodels.WalletActivityLogsViewModel
 
-suspend fun generateMockMdl(credentialPacksViewModel:CredentialPacksViewModel) {
+suspend fun generateMockMdl(credentialPacksViewModel:CredentialPacksViewModel, walletActivityLogsViewModel: WalletActivityLogsViewModel) {
     try {
         val keyManager = KeyManager()
         val keyAlias = "testMdl"
@@ -16,8 +22,23 @@ suspend fun generateMockMdl(credentialPacksViewModel:CredentialPacksViewModel) {
         val mdl = generateTestMdl(KeyManager(), keyAlias)
         val mdocPack = CredentialPack()
 
-        mdocPack.addMdoc(mdl);
+        var credentials = mdocPack.addMdoc(mdl);
         credentialPacksViewModel.saveCredentialPack(mdocPack)
+
+        val credentialInfo = getCredentialIdTitleAndIssuer(mdocPack, credentials[0])
+        walletActivityLogsViewModel.saveWalletActivityLog(
+            walletActivityLogs = WalletActivityLogs(
+                credentialPackId = mdocPack.id().toString(),
+                credentialId = credentialInfo.first,
+                credentialTitle = credentialInfo.second,
+                issuer = credentialInfo.third,
+                action = "Claimed",
+                dateTime = getCurrentSqlDate(),
+                additionalInformation = ""
+            )
+        )
+
+
         Toast.showSuccess("Test mDL added to your wallet")
     } catch (_: Exception) {
         Toast.showError("Error generating mDL")

--- a/ios/Showcase/Targets/AppUIKit/Sources/credentials/CredentialUtils.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/credentials/CredentialUtils.swift
@@ -143,21 +143,21 @@ func getCredentialIdTitleAndIssuer(
                 || credential?.asJsonVc() != nil
                 || credential?.asSdJwt() != nil
         })
-        // Mdoc
-        if cred == nil {
-            cred =
-                claims
-                .first(where: {
-                    return credentialPack.get(credentialId: $0.key)?.asMsoMdoc()
-                        != nil
-                }).map { claim in
-                    var tmpClaim = claim
-                    tmpClaim.value["issuer"] = claim.value["issuing_authority"]
-                    tmpClaim.value["name"] = GenericJSON.string(
-                        "Mobile Drivers License")
-                    return tmpClaim
-                }
-        }
+    }
+    // Mdoc
+    if credential?.asMsoMdoc() != nil || cred == nil{
+        cred =
+            claims
+            .first(where: {
+                return credentialPack.get(credentialId: $0.key)?.asMsoMdoc()
+                    != nil
+            }).map { claim in
+                var tmpClaim = claim
+                tmpClaim.value["issuer"] = claim.value["issuing_authority"]
+                tmpClaim.value["name"] = GenericJSON.string(
+                    "Mobile Drivers License")
+                return tmpClaim
+            }
     }
 
     let credentialKey = cred.map { $0.key } ?? ""

--- a/ios/Showcase/Targets/AppUIKit/Sources/walletSettings/WalletSettingsUtils.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/walletSettings/WalletSettingsUtils.swift
@@ -16,7 +16,7 @@ public func generateMockMdl() async {
         )
         let mdocPack = CredentialPack()
 
-        _ = try await mdocPack.addMDoc(mdoc: mdl)
+        let credentials = try await mdocPack.addMDoc(mdoc: mdl)
 
         let bundle = Bundle.main
         let storageManager = StorageManager(
@@ -24,6 +24,20 @@ public func generateMockMdl() async {
         try await mdocPack.save(
             storageManager: storageManager
         )
+        let credentialInfo = getCredentialIdTitleAndIssuer(
+            credentialPack: mdocPack,
+            credential: credentials[0]
+        )
+        _ = WalletActivityLogDataStore.shared.insert(
+            credentialPackId: mdocPack.id.uuidString,
+            credentialId: credentialInfo.0,
+            credentialTitle: credentialInfo.1,
+            issuer: credentialInfo.2,
+            action: "Claimed",
+            dateTime: Date(),
+            additionalInformation: ""
+        )
+        
         ToastManager.shared.showSuccess(
             message: "Test mDL added to your wallet"
         )


### PR DESCRIPTION
## Description

Since mDLs don't include standard fields like "issuer" or "name", we need to handle them as a special case. Additionally, the creation of mock mDLs was previously not being recorded in the activity logs.

### Other changes

N/A

### Optional section

N/A

## Tested

Create and delete both mock and HACI mDLs,  you should see both actions correctly recorded in the activity logs.
