### PR TITLE
iOS - Unify SQLite databases

### DIFF
--- a/ios/Showcase/Targets/AppUIKit/Sources/dataStores/DatabaseManager.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/dataStores/DatabaseManager.swift
@@ -1,0 +1,159 @@
+import Foundation
+import SQLite
+
+class DatabaseManager {
+    static let shared = DatabaseManager()
+
+    // Database configuration
+    static let DB_DIR = "AppDatabase"
+    static let DB_NAME = "showcase_app.sqlite3"
+    static let CURRENT_DB_VERSION = 1
+
+    // Table names
+    static let TABLE_HAC_APPLICATIONS = "hac_applications"
+    static let TABLE_TRUSTED_CERTIFICATES = "trusted_certificates"
+    static let TABLE_VERIFICATION_METHODS = "verification_methods"
+    static let TABLE_VERIFICATION_ACTIVITY_LOGS = "verification_activity_logs"
+    static let TABLE_WALLET_ACTIVITY_LOGS = "wallet_activity_logs"
+    static let TABLE_DB_VERSION = "db_version"
+
+    private var db: Connection?
+    private var isInitialized = false
+
+    private init() {}
+
+    func getDatabase() -> Connection? {
+        if !isInitialized {
+            initializeDatabase()
+        }
+        return db
+    }
+
+    func initializeDatabase() {
+        guard !isInitialized else { return }
+
+        if let docDir = FileManager.default.urls(
+            for: .documentDirectory,
+            in: .userDomainMask
+        ).first {
+            let dirPath = docDir.appendingPathComponent(Self.DB_DIR)
+
+            do {
+                try FileManager.default.createDirectory(
+                    atPath: dirPath.path,
+                    withIntermediateDirectories: true,
+                    attributes: nil
+                )
+
+                let dbPath = dirPath.appendingPathComponent(Self.DB_NAME).path
+                db = try Connection(dbPath)
+
+                createTables()
+
+                print("Database initialized successfully at: \(dbPath)")
+                isInitialized = true
+
+            } catch {
+                db = nil
+                print("Database initialization error: \(error)")
+            }
+        } else {
+            db = nil
+        }
+    }
+
+    private func createTables() {
+        guard let database = db else { return }
+
+        do {
+            // Create db_version table
+            let dbVersion = Table(Self.TABLE_DB_VERSION)
+            let version = SQLite.Expression<Int>("version")
+
+            try database.run(
+                dbVersion.create(ifNotExists: true) { table in
+                    table.column(version)
+                }
+            )
+
+            // Insert initial version if table is empty
+            let count = try database.scalar(dbVersion.count)
+            if count == 0 {
+                try database.run(
+                    dbVersion.insert(version <- Self.CURRENT_DB_VERSION)
+                )
+            }
+
+            print("Database tables created successfully")
+
+        } catch {
+            print("Error creating tables: \(error)")
+        }
+    }
+
+    // Method for DataStores to create their own tables
+    func createTableIfNotExists(
+        _ tableName: String,
+        createBlock: (TableBuilder) -> Void
+    ) {
+        guard let database = db else { return }
+
+        do {
+            let table = Table(tableName)
+            try database.run(
+                table.create(ifNotExists: true, block: createBlock)
+            )
+        } catch {
+            print("Error creating table \(tableName): \(error)")
+        }
+    }
+
+    // Method for DataStores to migrate their own data
+    func migrateFromOldDatabase(
+        _ oldDbPath: String,
+        tableName: String,
+        migrationBlock: (Connection, Connection) throws -> Void
+    ) {
+        guard let database = db else { return }
+
+        // Check if migration is needed (only if unified database is empty for this table)
+        do {
+            let table = Table(tableName)
+            let count = try database.scalar(table.count)
+            if count > 0 {
+                print("\(tableName): Data already exists, skipping migration")
+                // Data already exists. Skip migration
+                return
+            }
+        } catch {
+            print("\(tableName): Error checking table count: \(error)")
+            return
+        }
+
+        // Try to connect to old database
+        guard let oldDb = try? Connection(oldDbPath) else {
+            // Old database not found. Skip migration
+            return
+        }
+
+        do {
+            try database.transaction {
+                try migrationBlock(oldDb, database)
+            }
+            print("\(tableName): Migration completed successfully")
+        } catch {
+            print("\(tableName): Migration error: \(error)")
+        }
+    }
+
+    // Helper method to get old database path
+    func getOldDatabasePath(_ relativePath: String) -> String {
+        if let docDir = FileManager.default.urls(
+            for: .documentDirectory,
+            in: .userDomainMask
+        ).first {
+            return docDir.appendingPathComponent(relativePath).path
+        }
+        return ""
+    }
+}

--- a/ios/Showcase/Targets/AppUIKit/Sources/dataStores/VerificationActivityLogDataStore.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/dataStores/VerificationActivityLogDataStore.swift
@@ -2,87 +2,117 @@ import Foundation
 import SQLite
 
 class VerificationActivityLogDataStore {
-
-    static let DIR_ACTIVITY_LOG_DB = "ActivityLogDB"
-    static let STORE_NAME = "verification_activity_logs_2.sqlite3"
-    static let TABLE_NAME = "verification_activity_logs"
-
-    private let verificationActivityLogs = Table(TABLE_NAME)
+    private let verificationActivityLogs = Table(
+        DatabaseManager.TABLE_VERIFICATION_ACTIVITY_LOGS
+    )
 
     private let id = SQLite.Expression<Int64>("id")
     private let credentialTitle = SQLite.Expression<String>("credential_title")
     private let issuer = SQLite.Expression<String>("issuer")
     private let status = SQLite.Expression<String>("status")
     private let verificationDateTime = SQLite.Expression<Date>(
-        "verification_date_time")
+        "verification_date_time"
+    )
     private let additionalInformation = SQLite.Expression<String>(
-        "additional_information")
+        "additional_information"
+    )
 
     static let shared = VerificationActivityLogDataStore()
 
-    private var db: Connection?
-
     private init() {
-        if let docDir = FileManager.default.urls(
-            for: .documentDirectory, in: .userDomainMask
-        ).first {
-            let dirPath = docDir.appendingPathComponent(
-                Self.DIR_ACTIVITY_LOG_DB)
+        createTableIfNotExists()
+        migrateFromOldDatabase()
+    }
 
-            do {
-                try FileManager.default.createDirectory(
-                    atPath: dirPath.path,
-                    withIntermediateDirectories: true,
-                    attributes: nil
-                )
-                let dbPath = dirPath.appendingPathComponent(Self.STORE_NAME)
-                    .path
-                db = try Connection(dbPath)
-                createTable()
-                print("SQLiteDataStore init successfully at: \(dbPath) ")
-                try migration1(db: db.unwrap())
-            } catch {
-                db = nil
-                print("SQLiteDataStore init error: \(error)")
-            }
-        } else {
-            db = nil
+    private func getDatabase() -> Connection? {
+        return DatabaseManager.shared.getDatabase()
+    }
+
+    private func createTableIfNotExists() {
+        DatabaseManager.shared.createTableIfNotExists(
+            DatabaseManager.TABLE_VERIFICATION_ACTIVITY_LOGS
+        ) { table in
+            table.column(id, primaryKey: .autoincrement)
+            table.column(credentialTitle)
+            table.column(issuer)
+            table.column(status)
+            table.column(verificationDateTime)
+            table.column(additionalInformation)
         }
     }
 
-    private func createTable() {
-        guard let database = db else {
-            return
-        }
-        do {
-            try database.run(
-                verificationActivityLogs.create { table in
-                    table.column(id, primaryKey: .autoincrement)
-                    table.column(credentialTitle)
-                    table.column(issuer)
-                    table.column(status)
-                    table.column(verificationDateTime)
-                    table.column(additionalInformation)
-                })
-            print("Table Created...")
-        } catch {
-            print(error)
+    private func migrateFromOldDatabase() {
+        let oldDbPath = DatabaseManager.shared.getOldDatabasePath(
+            "ActivityLogDB/verification_activity_logs_2.sqlite3"
+        )
+
+        DatabaseManager.shared.migrateFromOldDatabase(
+            oldDbPath,
+            tableName: DatabaseManager.TABLE_VERIFICATION_ACTIVITY_LOGS
+        ) { oldDb, newDb in
+            let oldTable = Table("verification_activity_logs")
+            let oldId = SQLite.Expression<Int64>("id")
+            let oldCredentialTitle = SQLite.Expression<String>(
+                "credential_title"
+            )
+            let oldIssuer = SQLite.Expression<String>("issuer")
+            let oldStatus = SQLite.Expression<String>("status")
+            let oldVerificationDateTime = SQLite.Expression<Date>(
+                "verification_date_time"
+            )
+            let oldAdditionalInformation = SQLite.Expression<String>(
+                "additional_information"
+            )
+
+            let newTable = Table(
+                DatabaseManager.TABLE_VERIFICATION_ACTIVITY_LOGS
+            )
+            let newId = SQLite.Expression<Int64>("id")
+            let newCredentialTitle = SQLite.Expression<String>(
+                "credential_title"
+            )
+            let newIssuer = SQLite.Expression<String>("issuer")
+            let newStatus = SQLite.Expression<String>("status")
+            let newVerificationDateTime = SQLite.Expression<Date>(
+                "verification_date_time"
+            )
+            let newAdditionalInformation = SQLite.Expression<String>(
+                "additional_information"
+            )
+
+            for row in try oldDb.prepare(oldTable) {
+                let insert = newTable.insert(
+                    newId <- row[oldId],
+                    newCredentialTitle <- row[oldCredentialTitle],
+                    newIssuer <- row[oldIssuer],
+                    newStatus <- row[oldStatus],
+                    newVerificationDateTime <- row[oldVerificationDateTime],
+                    newAdditionalInformation <- row[oldAdditionalInformation]
+                )
+                try newDb.run(insert)
+            }
+
+            let count = try oldDb.scalar(oldTable.count)
+            print("Verification Activity Logs: Migrated \(count) records")
         }
     }
 
     func insert(
-        credentialTitle: String, issuer: String, status: String,
+        credentialTitle: String,
+        issuer: String,
+        status: String,
         verificationDateTime: Date,
         additionalInformation: String
     ) -> Int64? {
-        guard let database = db else { return nil }
+        guard let database = getDatabase() else { return nil }
 
         let insert = verificationActivityLogs.insert(
             self.credentialTitle <- credentialTitle,
             self.issuer <- issuer,
             self.status <- status,
             self.verificationDateTime <- verificationDateTime,
-            self.additionalInformation <- additionalInformation)
+            self.additionalInformation <- additionalInformation
+        )
         do {
             let rowID = try database.run(insert)
             return rowID
@@ -94,7 +124,7 @@ class VerificationActivityLogDataStore {
 
     func getAllVerificationActivityLogs() -> [VerificationActivityLog] {
         var verificationActivityLogs: [VerificationActivityLog] = []
-        guard let database = db else { return [] }
+        guard let database = getDatabase() else { return [] }
 
         let dateTimeFormatterDisplay = {
             let dtFormatter = DateFormatter()
@@ -106,18 +136,22 @@ class VerificationActivityLogDataStore {
 
         do {
             for verificationActivityLog in try database.prepare(
-                self.verificationActivityLogs.order(verificationDateTime.desc)) {
+                self.verificationActivityLogs.order(verificationDateTime.desc)
+            ) {
                 verificationActivityLogs.append(
                     VerificationActivityLog(
                         id: verificationActivityLog[id],
                         credential_title: verificationActivityLog[
-                            credentialTitle],
+                            credentialTitle
+                        ],
                         issuer: verificationActivityLog[issuer],
                         status: verificationActivityLog[status],
                         verification_date_time: dateTimeFormatterDisplay.string(
-                            from: verificationActivityLog[verificationDateTime]),
+                            from: verificationActivityLog[verificationDateTime]
+                        ),
                         additional_information: verificationActivityLog[
-                            additionalInformation]
+                            additionalInformation
+                        ]
                     )
                 )
             }
@@ -128,7 +162,7 @@ class VerificationActivityLogDataStore {
     }
 
     func delete(id: Int64) -> Bool {
-        guard let database = db else {
+        guard let database = getDatabase() else {
             return false
         }
         do {
@@ -142,12 +176,13 @@ class VerificationActivityLogDataStore {
     }
 
     func deleteAll() -> Bool {
-        guard let database = db else {
+        guard let database = getDatabase() else {
             return false
         }
         do {
             for verificationActivityLog in try database.prepare(
-                self.verificationActivityLogs)
+                self.verificationActivityLogs
+            )
             where !delete(id: verificationActivityLog[id]) {
                 return false
             }
@@ -158,11 +193,4 @@ class VerificationActivityLogDataStore {
         return true
     }
 
-    private func migration1(db: Connection) {
-        addColumnIfNotExists(
-            db: db,
-            tableName: VerificationActivityLogDataStore.TABLE_NAME,
-            columnName: "status",
-            columnDefinition: "TEXT DEFAULT 'UNDEFINED'")
-    }
 }

--- a/ios/Showcase/Targets/AppUIKit/Sources/dataStores/WalletActivityLogDataStore.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/dataStores/WalletActivityLogDataStore.swift
@@ -2,73 +2,106 @@ import Foundation
 import SQLite
 
 class WalletActivityLogDataStore {
-
-    static let DIR_ACTIVITY_LOG_DB = "ActivityLogDB"
-    static let STORE_NAME = "wallet_activity_logs.sqlite3"
-
-    private let walletActivityLogs = Table("wallet_activity_logs")
+    private let walletActivityLogs = Table(
+        DatabaseManager.TABLE_WALLET_ACTIVITY_LOGS
+    )
 
     private let id = SQLite.Expression<Int64>("id")
     private let credentialPackId = SQLite.Expression<String>(
-        "credential_pack_id")
+        "credential_pack_id"
+    )
     private let credentialId = SQLite.Expression<String>("credential_id")
     private let credentialTitle = SQLite.Expression<String>("credential_title")
     private let issuer = SQLite.Expression<String>("issuer")
     private let action = SQLite.Expression<String>("action")
     private let dateTime = SQLite.Expression<Date>("date_time")
     private let additionalInformation = SQLite.Expression<String>(
-        "additional_information")
+        "additional_information"
+    )
 
     static let shared = WalletActivityLogDataStore()
 
-    private var db: Connection?
-
     private init() {
-        if let docDir = FileManager.default.urls(
-            for: .documentDirectory, in: .userDomainMask
-        ).first {
-            let dirPath = docDir.appendingPathComponent(
-                Self.DIR_ACTIVITY_LOG_DB)
+        createTableIfNotExists()
+        migrateFromOldDatabase()
+    }
 
-            do {
-                try FileManager.default.createDirectory(
-                    atPath: dirPath.path,
-                    withIntermediateDirectories: true,
-                    attributes: nil
-                )
-                let dbPath = dirPath.appendingPathComponent(Self.STORE_NAME)
-                    .path
-                db = try Connection(dbPath)
-                createTable()
-                print("SQLiteDataStore init successfully at: \(dbPath) ")
-            } catch {
-                db = nil
-                print("SQLiteDataStore init error: \(error)")
-            }
-        } else {
-            db = nil
+    private func getDatabase() -> Connection? {
+        return DatabaseManager.shared.getDatabase()
+    }
+
+    private func createTableIfNotExists() {
+        DatabaseManager.shared.createTableIfNotExists(
+            DatabaseManager.TABLE_WALLET_ACTIVITY_LOGS
+        ) { table in
+            table.column(id, primaryKey: .autoincrement)
+            table.column(credentialPackId)
+            table.column(credentialId)
+            table.column(credentialTitle)
+            table.column(issuer)
+            table.column(action)
+            table.column(dateTime)
+            table.column(additionalInformation)
         }
     }
 
-    private func createTable() {
-        guard let database = db else {
-            return
-        }
-        do {
-            try database.run(
-                walletActivityLogs.create { table in
-                    table.column(id, primaryKey: .autoincrement)
-                    table.column(credentialPackId)
-                    table.column(credentialId)
-                    table.column(credentialTitle)
-                    table.column(issuer)
-                    table.column(action)
-                    table.column(dateTime)
-                    table.column(additionalInformation)
-                })
-            print("Table Created...")
-        } catch {
-            print(error)
+    private func migrateFromOldDatabase() {
+        let oldDbPath = DatabaseManager.shared.getOldDatabasePath(
+            "ActivityLogDB/wallet_activity_logs.sqlite3"
+        )
+
+        DatabaseManager.shared.migrateFromOldDatabase(
+            oldDbPath,
+            tableName: DatabaseManager.TABLE_WALLET_ACTIVITY_LOGS
+        ) { oldDb, newDb in
+            let oldTable = Table("wallet_activity_logs")
+            let oldId = SQLite.Expression<Int64>("id")
+            let oldCredentialPackId = SQLite.Expression<String>(
+                "credential_pack_id"
+            )
+            let oldCredentialId = SQLite.Expression<String>("credential_id")
+            let oldCredentialTitle = SQLite.Expression<String>(
+                "credential_title"
+            )
+            let oldIssuer = SQLite.Expression<String>("issuer")
+            let oldAction = SQLite.Expression<String>("action")
+            let oldDateTime = SQLite.Expression<Date>("date_time")
+            let oldAdditionalInformation = SQLite.Expression<String>(
+                "additional_information"
+            )
+
+            let newTable = Table(DatabaseManager.TABLE_WALLET_ACTIVITY_LOGS)
+            let newId = SQLite.Expression<Int64>("id")
+            let newCredentialPackId = SQLite.Expression<String>(
+                "credential_pack_id"
+            )
+            let newCredentialId = SQLite.Expression<String>("credential_id")
+            let newCredentialTitle = SQLite.Expression<String>(
+                "credential_title"
+            )
+            let newIssuer = SQLite.Expression<String>("issuer")
+            let newAction = SQLite.Expression<String>("action")
+            let newDateTime = SQLite.Expression<Date>("date_time")
+            let newAdditionalInformation = SQLite.Expression<String>(
+                "additional_information"
+            )
+
+            for row in try oldDb.prepare(oldTable) {
+                let insert = newTable.insert(
+                    newId <- row[oldId],
+                    newCredentialPackId <- row[oldCredentialPackId],
+                    newCredentialId <- row[oldCredentialId],
+                    newCredentialTitle <- row[oldCredentialTitle],
+                    newIssuer <- row[oldIssuer],
+                    newAction <- row[oldAction],
+                    newDateTime <- row[oldDateTime],
+                    newAdditionalInformation <- row[oldAdditionalInformation]
+                )
+                try newDb.run(insert)
+            }
+
+            let count = try oldDb.scalar(oldTable.count)
+            print("Wallet Activity Logs: Migrated \(count) records")
         }
     }
 
@@ -81,7 +114,7 @@ class WalletActivityLogDataStore {
         dateTime: Date,
         additionalInformation: String
     ) -> Int64? {
-        guard let database = db else { return nil }
+        guard let database = getDatabase() else { return nil }
 
         let insert = walletActivityLogs.insert(
             self.credentialPackId <- credentialPackId,
@@ -90,7 +123,8 @@ class WalletActivityLogDataStore {
             self.issuer <- issuer,
             self.action <- action,
             self.dateTime <- dateTime,
-            self.additionalInformation <- additionalInformation)
+            self.additionalInformation <- additionalInformation
+        )
         do {
             let rowID = try database.run(insert)
             return rowID
@@ -102,7 +136,7 @@ class WalletActivityLogDataStore {
 
     func getAllWalletActivityLogs() -> [WalletActivityLog] {
         var walletActivityLogs: [WalletActivityLog] = []
-        guard let database = db else { return [] }
+        guard let database = getDatabase() else { return [] }
 
         let dateTimeFormatterDisplay = {
             let dtFormatter = DateFormatter()
@@ -114,20 +148,24 @@ class WalletActivityLogDataStore {
 
         do {
             for walletActivityLog in try database.prepare(
-                self.walletActivityLogs.order(dateTime.desc)) {
+                self.walletActivityLogs.order(dateTime.desc)
+            ) {
                 walletActivityLogs.append(
                     WalletActivityLog(
                         id: walletActivityLog[id],
                         credential_pack_id: walletActivityLog[credentialPackId],
                         credential_id: walletActivityLog[credentialId],
                         credential_title: walletActivityLog[
-                            credentialTitle],
+                            credentialTitle
+                        ],
                         issuer: walletActivityLog[issuer],
                         action: walletActivityLog[action],
                         date_time: dateTimeFormatterDisplay.string(
-                            from: walletActivityLog[dateTime]),
+                            from: walletActivityLog[dateTime]
+                        ),
                         additional_information: walletActivityLog[
-                            additionalInformation]
+                            additionalInformation
+                        ]
                     )
                 )
             }
@@ -138,7 +176,7 @@ class WalletActivityLogDataStore {
     }
 
     func delete(id: Int64) -> Bool {
-        guard let database = db else {
+        guard let database = getDatabase() else {
             return false
         }
         do {
@@ -152,12 +190,11 @@ class WalletActivityLogDataStore {
     }
 
     func deleteAll() -> Bool {
-        guard let database = db else {
-            return false
-        }
+        guard let database = getDatabase() else { return false }
         do {
             for walletActivityLog in try database.prepare(
-                self.walletActivityLogs)
+                self.walletActivityLogs
+            )
             where !delete(id: walletActivityLog[id]) {
                 return false
             }


### PR DESCRIPTION
## Description

This unifies multiple separate SQLite databases into a single centralized database with automatic migration support. The unified database includes a db_version table for future schema versioning and supports lazy table creation on first DataStore access.

### Other changes

N/A

### Optional section

N/A

## Tested

You can populate your app with some HACI applications, verification logs, add/delete credentials. Then you can run the iOS app and check the logs. In the first run, you should see something like:

````
Database tables created successfully
Database initialized successfully at: /.../showcase_app.sqlite3
HAC Applications: Migrated X records
hac_applications: Migration completed successfully
...
Wallet Activity Logs: Migrated Y records
wallet_activity_logs: Migration completed successfully
```

This is a lazy migration. It won't migrate all at once, but the first time you try to access the table.