### PR TITLE
Add QRCode scanning to share specific credential

### DIFF
--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/CredentialDetailsView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/CredentialDetailsView.kt
@@ -72,6 +72,7 @@ import com.spruceid.mobilesdkexample.utils.getCredentialIdTitleAndIssuer
 import com.spruceid.mobilesdkexample.viewmodels.CredentialPacksViewModel
 import com.spruceid.mobilesdkexample.viewmodels.StatusListViewModel
 import com.spruceid.mobilesdkexample.wallet.DispatchQRView
+import com.spruceid.mobilesdkexample.wallet.SupportedQRTypes
 import kotlinx.coroutines.launch
 import java.util.UUID
 
@@ -218,7 +219,7 @@ fun CredentialDetailsView(
                     contentAlignment = Alignment.Center
                 ) {
                     if (page == 0) { // Scan to verify
-                        DispatchQRView(navController, credentialPackId)
+                        DispatchQRView(navController, credentialPackId, SupportedQRTypes.OID4VP)
                     } else if (page == 1) { // Details
                         Column(
                             Modifier

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/CredentialDetailsView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/CredentialDetailsView.kt
@@ -98,19 +98,19 @@ fun CredentialDetailsView(
         mutableStateOf(
             listOf(
                 CredentialDetailsViewTabs(
-                    { painterResource(id = R.drawable.qrcode_scanner) },
-                    { stringResource(id = R.string.qrcode_scanner) }
-                ),
-                CredentialDetailsViewTabs(
                     { painterResource(id = R.drawable.info_icon) },
                     { stringResource(id = R.string.details_info) }
+                ),
+                CredentialDetailsViewTabs(
+                    { painterResource(id = R.drawable.qrcode_scanner) },
+                    { stringResource(id = R.string.qrcode_scanner) }
                 )
             )
         )
     }
 
     val pagerState = rememberPagerState(
-        initialPage = 1,
+        initialPage = 0,
         pageCount = { tabs.size }
     )
     val coroutineScope = rememberCoroutineScope()
@@ -218,9 +218,7 @@ fun CredentialDetailsView(
                         .background(ColorBase50),
                     contentAlignment = Alignment.Center
                 ) {
-                    if (page == 0) { // Scan to verify
-                        DispatchQRView(navController, credentialPackId, SupportedQRTypes.OID4VP)
-                    } else if (page == 1) { // Details
+                    if (page == 0) {  // Details
                         Column(
                             Modifier
                                 .padding(horizontal = 20.dp)
@@ -236,6 +234,12 @@ fun CredentialDetailsView(
                                 }
                             }
                         }
+                    } else if (page == 1) { // Scan to verify
+                        DispatchQRView(
+                            navController,
+                            credentialPackId,
+                            listOf(SupportedQRTypes.OID4VP, SupportedQRTypes.HTTP)
+                        )
                     } else if (page == 2) { // Share
                         GenericCredentialDetailsShareQRCode(credentialPack!!)
                     }

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/CredentialDetailsView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/CredentialDetailsView.kt
@@ -71,6 +71,7 @@ import com.spruceid.mobilesdkexample.utils.credentialPackHasMdoc
 import com.spruceid.mobilesdkexample.utils.getCredentialIdTitleAndIssuer
 import com.spruceid.mobilesdkexample.viewmodels.CredentialPacksViewModel
 import com.spruceid.mobilesdkexample.viewmodels.StatusListViewModel
+import com.spruceid.mobilesdkexample.wallet.DispatchQRView
 import kotlinx.coroutines.launch
 import java.util.UUID
 
@@ -96,6 +97,10 @@ fun CredentialDetailsView(
         mutableStateOf(
             listOf(
                 CredentialDetailsViewTabs(
+                    { painterResource(id = R.drawable.qrcode_scanner) },
+                    { stringResource(id = R.string.qrcode_scanner) }
+                ),
+                CredentialDetailsViewTabs(
                     { painterResource(id = R.drawable.info_icon) },
                     { stringResource(id = R.string.details_info) }
                 )
@@ -104,7 +109,7 @@ fun CredentialDetailsView(
     }
 
     val pagerState = rememberPagerState(
-        initialPage = 0,
+        initialPage = 1,
         pageCount = { tabs.size }
     )
     val coroutineScope = rememberCoroutineScope()
@@ -212,7 +217,9 @@ fun CredentialDetailsView(
                         .background(ColorBase50),
                     contentAlignment = Alignment.Center
                 ) {
-                    if (page == 0) { // Details
+                    if (page == 0) { // Scan to verify
+                        DispatchQRView(navController, credentialPackId)
+                    } else if (page == 1) { // Details
                         Column(
                             Modifier
                                 .padding(horizontal = 20.dp)
@@ -228,7 +235,7 @@ fun CredentialDetailsView(
                                 }
                             }
                         }
-                    } else if (page == 1) { // Share
+                    } else if (page == 2) { // Share
                         GenericCredentialDetailsShareQRCode(credentialPack!!)
                     }
                 }

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/navigation/Screen.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/navigation/Screen.kt
@@ -17,8 +17,8 @@ const val WALLET_SETTINGS_ACTIVITY_LOG = "wallet_settings_activity_log"
 const val ADD_TO_WALLET_PATH = "add_to_wallet/{rawCredential}"
 const val SCAN_QR_PATH = "scan_qr"
 const val HANDLE_OID4VCI_PATH = "oid4vci/{url}"
-const val HANDLE_OID4VP_PATH = "oid4vp/{url}"
-const val HANDLE_MDOC_OID4VP_PATH = "mdoc_oid4vp/{url}"
+const val HANDLE_OID4VP_PATH = "oid4vp/{url}?credential_pack_id={credential_pack_id}"
+const val HANDLE_MDOC_OID4VP_PATH = "mdoc_oid4vp/{url}?credential_pack_id={credential_pack_id}"
 const val CREDENTIAL_DETAILS_PATH = "credential_details/{credential_pack_id}"
 
 sealed class Screen(val route: String) {

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/navigation/Screen.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/navigation/Screen.kt
@@ -17,8 +17,10 @@ const val WALLET_SETTINGS_ACTIVITY_LOG = "wallet_settings_activity_log"
 const val ADD_TO_WALLET_PATH = "add_to_wallet/{rawCredential}"
 const val SCAN_QR_PATH = "scan_qr"
 const val HANDLE_OID4VCI_PATH = "oid4vci/{url}"
-const val HANDLE_OID4VP_PATH = "oid4vp/{url}?credential_pack_id={credential_pack_id}"
-const val HANDLE_MDOC_OID4VP_PATH = "mdoc_oid4vp/{url}?credential_pack_id={credential_pack_id}"
+const val HANDLE_OID4VP_PATH = "oid4vp/{url}"
+const val HANDLE_OID4VP_WITH_CREDENTIAL_PACK_PATH = "oid4vp/{url}/{credential_pack_id}"
+const val HANDLE_MDOC_OID4VP_PATH = "mdoc_oid4vp/{url}"
+const val HANDLE_MDOC_OID4VP_WITH_CREDENTIAL_PACK_PATH = "mdoc_oid4vp/{url}/{credential_pack_id}"
 const val CREDENTIAL_DETAILS_PATH = "credential_details/{credential_pack_id}"
 
 sealed class Screen(val route: String) {
@@ -42,6 +44,8 @@ sealed class Screen(val route: String) {
     object ScanQRScreen : Screen(SCAN_QR_PATH)
     object HandleOID4VCI : Screen(HANDLE_OID4VCI_PATH)
     object HandleOID4VP : Screen(HANDLE_OID4VP_PATH)
+    object HandleOID4VPWithCredentialPack : Screen(HANDLE_OID4VP_WITH_CREDENTIAL_PACK_PATH)
     object HandleMdocOID4VP : Screen(HANDLE_MDOC_OID4VP_PATH)
+    object HandleMdocOID4VPWithCredentialPack : Screen(HANDLE_MDOC_OID4VP_WITH_CREDENTIAL_PACK_PATH)
     object CredentialDetailsScreen : Screen(CREDENTIAL_DETAILS_PATH)
 }

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/navigation/SetupNavGraph.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/navigation/SetupNavGraph.kt
@@ -141,7 +141,7 @@ fun SetupNavGraph(
         }
         composable(
             route = Screen.ScanQRScreen.route,
-        ) { DispatchQRView(navController) }
+        ) { DispatchQRView(navController, null) }
         composable(
             route = Screen.HandleOID4VCI.route,
         ) { backStackEntry ->
@@ -153,28 +153,58 @@ fun SetupNavGraph(
         }
         composable(
             route = Screen.HandleOID4VP.route,
-            deepLinks = listOf(navDeepLink { uriPattern = "openid4vp://{url}" })
+            deepLinks = listOf(
+                navDeepLink { uriPattern = "openid4vp://{url}" },
+                navDeepLink { uriPattern = "openid4vp://{url}?credential_pack_id={credential_pack_id}" },
+            ),
+            arguments = listOf(
+                navArgument("url") {
+                    type = NavType.StringType
+                },
+                navArgument("credential_pack_id") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                }
+            )
         ) { backStackEntry ->
             var url = backStackEntry.arguments?.getString("url")!!
             if (!url.startsWith("openid4vp")) {
                 url = "openid4vp://$url"
             }
+            val credentialPackId = backStackEntry.arguments?.getString("credential_pack_id")
             HandleOID4VPView(
                 navController,
-                url
+                url,
+                credentialPackId,
             )
         }
         composable(
             route = Screen.HandleMdocOID4VP.route,
-            deepLinks = listOf(navDeepLink { uriPattern = "mdoc-openid4vp://{url}" })
+            deepLinks = listOf(
+                navDeepLink { uriPattern = "mdoc-openid4vp://{url}?credential_pack_id={credential_pack_id}" },
+                navDeepLink { uriPattern = "mdoc-openid4vp://{url}" }
+            ),
+            arguments = listOf(
+                navArgument("url") {
+                    type = NavType.StringType
+                },
+                navArgument("credential_pack_id") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                }
+            )
         ) { backStackEntry ->
             var url = backStackEntry.arguments?.getString("url")!!
             if (!url.startsWith("mdoc-openid4vp")) {
                 url = "mdoc-openid4vp://$url"
             }
+            val credentialPackId = backStackEntry.arguments?.getString("credential_pack_id")
             HandleMdocOID4VPView(
                 navController,
-                url
+                url,
+                credentialPackId
             )
         }
         composable(

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/navigation/SetupNavGraph.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/navigation/SetupNavGraph.kt
@@ -141,7 +141,7 @@ fun SetupNavGraph(
         }
         composable(
             route = Screen.ScanQRScreen.route,
-        ) { DispatchQRView(navController, null) }
+        ) { DispatchQRView(navController) }
         composable(
             route = Screen.HandleOID4VCI.route,
         ) { backStackEntry ->
@@ -153,10 +153,25 @@ fun SetupNavGraph(
         }
         composable(
             route = Screen.HandleOID4VP.route,
-            deepLinks = listOf(
-                navDeepLink { uriPattern = "openid4vp://{url}" },
-                navDeepLink { uriPattern = "openid4vp://{url}?credential_pack_id={credential_pack_id}" },
-            ),
+            deepLinks = listOf(navDeepLink { uriPattern = "openid4vp://{url}" }),
+            arguments = listOf(
+                navArgument("url") {
+                    type = NavType.StringType
+                }
+            )
+        ) { backStackEntry ->
+            var url = backStackEntry.arguments?.getString("url")!!
+            if (!url.startsWith("openid4vp")) {
+                url = "openid4vp://$url"
+            }
+            HandleOID4VPView(
+                navController,
+                url,
+                null,
+            )
+        }
+        composable(
+            route = Screen.HandleOID4VPWithCredentialPack.route,
             arguments = listOf(
                 navArgument("url") {
                     type = NavType.StringType
@@ -181,10 +196,25 @@ fun SetupNavGraph(
         }
         composable(
             route = Screen.HandleMdocOID4VP.route,
-            deepLinks = listOf(
-                navDeepLink { uriPattern = "mdoc-openid4vp://{url}?credential_pack_id={credential_pack_id}" },
-                navDeepLink { uriPattern = "mdoc-openid4vp://{url}" }
-            ),
+            deepLinks = listOf(navDeepLink { uriPattern = "mdoc-openid4vp://{url}" }),
+            arguments = listOf(
+                navArgument("url") {
+                    type = NavType.StringType
+                }
+            )
+        ) { backStackEntry ->
+            var url = backStackEntry.arguments?.getString("url")!!
+            if (!url.startsWith("mdoc-openid4vp")) {
+                url = "mdoc-openid4vp://$url"
+            }
+            HandleMdocOID4VPView(
+                navController,
+                url,
+                null
+            )
+        }
+        composable(
+            route = Screen.HandleMdocOID4VPWithCredentialPack.route,
             arguments = listOf(
                 navArgument("url") {
                     type = NavType.StringType

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/DispatchQRView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/DispatchQRView.kt
@@ -32,6 +32,7 @@ const val HTTPS_SCHEME = "https://"
 @Composable
 fun DispatchQRView(
     navController: NavController,
+    credentialPackId: String?
 ) {
     val scope = rememberCoroutineScope()
     val uriHandler = LocalUriHandler.current
@@ -54,7 +55,13 @@ fun DispatchQRView(
                 if (payload.startsWith(OID4VP_SCHEME)) {
                     val encodedUrl = URLEncoder.encode(payload, StandardCharsets.UTF_8.toString())
 
-                    navController.navigate("oid4vp/$encodedUrl") {
+                    val baseUrl = "oid4vp/$encodedUrl"
+                    val route = if (!credentialPackId.isNullOrEmpty()) {
+                        "$baseUrl?credential_pack_id=$credentialPackId"
+                    } else {
+                        baseUrl
+                    }
+                    navController.navigate(route) {
                         launchSingleTop = true
                         restoreState = true
                     }
@@ -71,7 +78,13 @@ fun DispatchQRView(
                 } else if (payload.startsWith(MDOC_OID4VP_SCHEME)) {
                     val encodedUrl = URLEncoder.encode(payload, StandardCharsets.UTF_8.toString())
 
-                    navController.navigate("mdoc_oid4vp/$encodedUrl") {
+                    val baseUrl = "mdoc_oid4vp/$encodedUrl"
+                    val route = if (!credentialPackId.isNullOrEmpty()) {
+                        "$baseUrl?credential_pack_id=$credentialPackId"
+                    } else {
+                        baseUrl
+                    }
+                    navController.navigate(route) {
                         launchSingleTop = true
                         restoreState = true
                     }

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleMdocOID4VPView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleMdocOID4VPView.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import androidx.navigation.navDeepLink
 import com.spruceid.mobile.sdk.KeyManager
 import com.spruceid.mobile.sdk.rs.ApprovedResponse180137
 import com.spruceid.mobile.sdk.rs.FieldId180137
@@ -87,7 +88,8 @@ class MdocOID4VPError(var title: String, var details: String)
 @Composable
 fun HandleMdocOID4VPView(
     navController: NavController,
-    url: String
+    url: String,
+    credentialPackId: String?
 ) {
     val credentialPacksViewModel: CredentialPacksViewModel = activityHiltViewModel()
     val walletActivityLogsViewModel: WalletActivityLogsViewModel = activityHiltViewModel()
@@ -121,8 +123,14 @@ fun HandleMdocOID4VPView(
         if (!isLoadingCredentials && credentialPacks.isNotEmpty()) {
             try {
                 withContext(Dispatchers.IO) {
+                    val usableCredentialPacks = credentialPackId
+                        ?.takeIf { it.isNotBlank() }
+                        ?.let { id -> credentialPacksViewModel.getById(id)}
+                        ?.let {listOf(it)}
+                        ?: credentialPacks
+
                     val credentials = mutableListOf<Mdoc>()
-                    credentialPacks.forEach { credentialPack ->
+                    usableCredentialPacks.forEach { credentialPack ->
                         credentialPack.list().forEach { credential ->
                             val mdoc = credential.asMsoMdoc()
                             if (mdoc != null) {

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleMdocOID4VPView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleMdocOID4VPView.kt
@@ -142,7 +142,14 @@ fun HandleMdocOID4VPView(
                         val handlerRef = Oid4vp180137(credentials, KeyManager())
                         handler = handlerRef
                         request = handlerRef.processRequest(url)
-                        state = MdocOID4VPState.SelectCredential
+
+                        if (credentials.count() > 1) {
+                            state = MdocOID4VPState.SelectCredential
+                        } else {
+                            val matches = request?.matches()
+                            selectedMatch = matches?.get(0)
+                            state = MdocOID4VPState.SelectiveDisclosure
+                        }
                     } else {
                         error =
                             MdocOID4VPError(

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleOID4VPView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleOID4VPView.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import com.spruceid.mobile.sdk.CredentialPack
 import com.spruceid.mobile.sdk.KeyManager
 import com.spruceid.mobile.sdk.rs.DidMethod
 import com.spruceid.mobile.sdk.rs.DidMethodUtils
@@ -150,7 +151,8 @@ class OID4VPError {
 @Composable
 fun HandleOID4VPView(
     navController: NavController,
-    url: String
+    url: String,
+    credentialPackId: String?
 ) {
     val credentialPacksViewModel: CredentialPacksViewModel = activityHiltViewModel()
     val walletActivityLogsViewModel: WalletActivityLogsViewModel = activityHiltViewModel()
@@ -174,8 +176,14 @@ fun HandleOID4VPView(
     when (state) {
         OID4VPState.None -> LaunchedEffect(Unit) {
             try {
+                val usableCredentialPacks: List<CredentialPack>  = credentialPackId
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { id -> credentialPacksViewModel.getById(id)}
+                    ?.let {listOf(it)}
+                    ?: credentialPacks.value
+
                 val credentials = mutableListOf<ParsedCredential>()
-                credentialPacks.value.forEach { credentialPack ->
+                usableCredentialPacks.forEach { credentialPack ->
                     credentials.addAll(credentialPack.list())
                     credentialClaims += credentialPack.findCredentialClaims(listOf("name", "type"))
                 }

--- a/ios/MobileSdk/Sources/MobileSdk/ui/AVMetadataObjectScanner.swift
+++ b/ios/MobileSdk/Sources/MobileSdk/ui/AVMetadataObjectScanner.swift
@@ -81,9 +81,9 @@ public struct AVMetadataObjectScanner: View {
 
     public var body: some View {
         ZStack(alignment: .top) {
-            GeometryReader {_ in
+            GeometryReader {geometry in
                 let size = UIScreen.screenSize
-
+                let clearCutOutYPosition = geometry.size.height / 2
                 ZStack {
                     CameraView(frameSize: CGSize(width: size.width, height: size.height), session: $session)
                     /// Blur layer with clear cut out
@@ -94,6 +94,7 @@ public struct AVMetadataObjectScanner: View {
                         Rectangle()
                             .frame(width: regionOfInterest.width, height: regionOfInterest.height)
                                 .blendMode(.destinationOut)
+                                .position(x: size.width / 2, y: clearCutOutYPosition)
                             }
                             .compositingGroup()
 
@@ -110,6 +111,7 @@ public struct AVMetadataObjectScanner: View {
                             .offset(y: isScanning ? (regionOfInterest.height)/2 : -(regionOfInterest.height)/2)
                     }
                     .frame(width: regionOfInterest.width, height: regionOfInterest.height)
+                    .position(x: size.width / 2, y: clearCutOutYPosition)
 
                 }
                 /// Square Shape

--- a/ios/Showcase/Targets/AppUIKit/Sources/ContentView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/ContentView.swift
@@ -170,7 +170,7 @@ public struct ContentView: View {
                         HandleMdocOID4VPView(
                             path: $path,
                             credentialPackId: handleMdocOID4VPParams.credentialPackId,
-                            url: handleMdocOID4VPParams.url,
+                            url: handleMdocOID4VPParams.url
                         )
                     }
                     .navigationDestination(for: CredentialDetails.self) {

--- a/ios/Showcase/Targets/AppUIKit/Sources/ContentView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/ContentView.swift
@@ -161,6 +161,7 @@ public struct ContentView: View {
                         handleOID4VPParams in
                         HandleOID4VPView(
                             path: $path,
+                            credentialPackId: handleOID4VPParams.credentialPackId,
                             url: handleOID4VPParams.url
                         )
                     }
@@ -168,7 +169,8 @@ public struct ContentView: View {
                         handleMdocOID4VPParams in
                         HandleMdocOID4VPView(
                             path: $path,
-                            url: handleMdocOID4VPParams.url
+                            credentialPackId: handleMdocOID4VPParams.credentialPackId,
+                            url: handleMdocOID4VPParams.url,
                         )
                     }
                     .navigationDestination(for: CredentialDetails.self) {

--- a/ios/Showcase/Targets/AppUIKit/Sources/credentials/CredentialDetailsView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/credentials/CredentialDetailsView.swift
@@ -61,7 +61,7 @@ struct CredentialDetailsView: View {
                         id: \.offset
                     ) { index, _ in
                         if index == 0 { // Scan to share
-                            DispatchQRView(path: $path, credentialPackId: credentialPackId)
+                            DispatchQRView(path: $path, credentialPackId: credentialPackId, supportedTypes: SupportedQRTypes.oid4vp)
                         } else if index == 1 {  // Details
                             VStack {
                                 if credentialItem != nil {

--- a/ios/Showcase/Targets/AppUIKit/Sources/credentials/CredentialDetailsView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/credentials/CredentialDetailsView.swift
@@ -1,5 +1,7 @@
 import SpruceIDMobileSdk
+import SpruceIDMobileSdkRs
 import SwiftUI
+
 
 struct CredentialDetails: Hashable {
     var credentialPackId: String
@@ -19,9 +21,10 @@ struct CredentialDetailsView: View {
     @State var credentialPack: CredentialPack?
     @State var credentialItem: (any ICredentialView)?
     @State var credentialDetailsViewTabs = [
+        CredentialDetailsViewTab(image: "QRCodeReader"),
         CredentialDetailsViewTab(image: "Info")
     ]
-    @State private var selectedTab = 0
+    @State private var selectedTab = 1
 
     func onBack() {
         path.removeLast()
@@ -57,7 +60,9 @@ struct CredentialDetailsView: View {
                         Array(credentialDetailsViewTabs.enumerated()),
                         id: \.offset
                     ) { index, _ in
-                        if index == 0 {  // Details
+                        if index == 0 { // Scan to share
+                            DispatchQRView(path: $path, credentialPackId: credentialPackId)
+                        } else if index == 1 {  // Details
                             VStack {
                                 if credentialItem != nil {
                                     if CredentialStatusList.revoked
@@ -78,7 +83,7 @@ struct CredentialDetailsView: View {
                             }
                             .tag(index)
 
-                        } else if index == 1, let credPack = credentialPack {  // Share
+                        } else if index == 2, let credPack = credentialPack {  // Share
                             ShareMdocView(credentialPack: credPack)
                             .tag(index)
                         }
@@ -110,7 +115,7 @@ struct CredentialDetailsView: View {
                                                     ? Color("ColorBlue600")
                                                     : Color("ColorBase50")
                                             )
-                                            .offset(y: -4),
+                                            .offset(y: -6),
                                         alignment: .top
                                     )
                             }

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/DispatchQRView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/DispatchQRView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import SpruceIDMobileSdk
 
 // The scheme for the OID4VP QR code.
 let OID4VP_SCHEME = "openid4vp://"
@@ -18,14 +19,15 @@ struct DispatchQRView: View {
     @State var success: Bool?
 
     @Binding var path: NavigationPath
+    var credentialPackId: String?
 
     func handleRequest(payload: String) {
         loading = true
         Task {
             if payload.hasPrefix(OID4VP_SCHEME) {
-                path.append(HandleOID4VP(url: payload))
+                path.append(HandleOID4VP(url: payload, credentialPackId: credentialPackId))
             } else if payload.hasPrefix(MDOC_OID4VP_SCHEME) {
-                path.append(HandleMdocOID4VP(url: payload))
+                path.append(HandleMdocOID4VP(url: payload, credentialPackId: credentialPackId))
             } else if payload.hasPrefix(OID4VCI_SCHEME) {
                 path.append(HandleOID4VCI(url: payload))
             } else if payload.hasPrefix(HTTPS_SCHEME)

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleMdocOID4VPView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleMdocOID4VPView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct HandleMdocOID4VP: Hashable {
     var url: String
+    var credentialPackId: String?
 }
 
 public enum MdocOID4VPState {
@@ -25,6 +26,8 @@ struct HandleMdocOID4VPView: View {
         CredentialPackObservable
     @EnvironmentObject private var keyManager: KeyManager
     @Binding var path: NavigationPath
+    var credentialPackId: String?
+    
     var url: String
 
     @State private var handler: Oid4vp180137?
@@ -37,7 +40,12 @@ struct HandleMdocOID4VPView: View {
 
     func presentCredential() async {
         do {
-            credentialPacks = credentialPackObservable.credentialPacks
+            if let id = credentialPackId,
+               let pack = credentialPackObservable.getById(credentialPackId: id) {
+                credentialPacks = [pack]
+            } else {
+                credentialPacks = credentialPackObservable.credentialPacks
+            }
 
             var credentials: [Mdoc] = []
             credentialPacks.forEach { credentialPack in

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleMdocOID4VPView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleMdocOID4VPView.swift
@@ -63,7 +63,14 @@ struct HandleMdocOID4VPView: View {
                 )
                 handler = handlerRef
                 request = try await handlerRef.processRequest(url: url)
-                state = .selectCredential
+                
+                if credentials.count > 1 {
+                    state = .selectCredential
+                } else {
+                    let matches = request!.matches()
+                    selectedMatch = matches[0]
+                    state = .selectiveDisclosure
+                }
             } else {
                 err = MdocOID4VPError(
                     title: "No matching credential(s)",

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleOID4VPView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleOID4VPView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct HandleOID4VP: Hashable {
     var url: String
+    var credentialPackId: String?
 }
 
 enum Oid4vpSignerError: Error {
@@ -84,6 +85,7 @@ struct HandleOID4VPView: View {
     @EnvironmentObject private var credentialPackObservable:
         CredentialPackObservable
     @Binding var path: NavigationPath
+    var credentialPackId: String?
     var url: String
 
     @State private var holder: Holder?
@@ -99,7 +101,12 @@ struct HandleOID4VPView: View {
 
     func presentCredential() async {
         do {
-            credentialPacks = credentialPackObservable.credentialPacks
+            if let id = credentialPackId,
+               let pack = credentialPackObservable.getById(credentialPackId: id) {
+                credentialPacks = [pack]
+            } else {
+                credentialPacks = credentialPackObservable.credentialPacks
+            }
             var credentials: [ParsedCredential] = []
             credentialPacks.forEach { credentialPack in
                 credentials += credentialPack.list()


### PR DESCRIPTION
## Description

Each credential details menu now includes a "Scan" button, allowing you to instantly share that specific credential without need to go through the selection menu.

### Other changes

N/A

### Optional section

There's one detail in this implementation I'd like your opinion on:

When the user has only one VC of the requested type, the flow now skips the credential selection screen and goes directly to the field selection step. This behavior is kind of a side effect of making the individual QR code scanner jump straight into field selection.

Do you think this is ok, or could it be confusing?

Edit: Just found this - https://linear.app/spruceid/issue/ACC-380/add-credential-name-and-values-during-selective-disclosure

I think that's ok then, since we are planning to do that.

## Tested

Tested with mock mDLs, haci mDLs and other VCs from vcplayground.
