### PR TITLE
fix vdc collection prefix to match credential pack prefix

### DIFF
--- a/android/MobileSdk/build.gradle.kts
+++ b/android/MobileSdk/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
         //    artifactId = "mobilesdk"
         //    version = System.getenv("VERSION")
         //  afterEvaluate { from(components["release"]) }
-        //}
+        // }
 
         // Creates a Maven publication called "release".
         create<MavenPublication>("release") {

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/CredentialPack.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/CredentialPack.kt
@@ -357,7 +357,7 @@ class CredentialPack {
         suspend fun clearPacks(storage: StorageManagerInterface) {
             try {
                 storage.list()
-                    .filter { it.startsWith(CredentialPackContents.STORAGE_PREFIX) }
+                    .filter { it.contains(CredentialPackContents.STORAGE_PREFIX) }
                     .forEach { storage.remove(it) }
             } catch (e: Exception) {
                 throw ClearingException("unable to clear CredentialPacks", e)
@@ -375,7 +375,7 @@ class CredentialPack {
             try {
                 contents =
                     storage.list()
-                        .filter { it.startsWith(CredentialPackContents.STORAGE_PREFIX) }
+                        .filter { it.contains(CredentialPackContents.STORAGE_PREFIX) }
                         .mapNotNull { storage.get(it) }
                         .map { CredentialPackContents(it) }
             } catch (e: Exception) {

--- a/ios/MobileSdk/Sources/MobileSdk/CredentialPack.swift
+++ b/ios/MobileSdk/Sources/MobileSdk/CredentialPack.swift
@@ -515,7 +515,7 @@ public struct CredentialPackContents {
         do {
             try await storageManager.list()
                 .filter { file in
-                    file.hasPrefix(Self.storagePrefix)
+                    file.contains(Self.storagePrefix)
                 }
                 .asyncForEach { file in
                     try await storageManager.remove(key: file)
@@ -533,7 +533,7 @@ public struct CredentialPackContents {
         do {
             return try await storageManager.list()
                 .filter { file in
-                    file.hasPrefix(Self.storagePrefix)
+                    file.contains(Self.storagePrefix)
                 }
                 .asyncMap { file in
                     guard let contents = try await storageManager.get(key: file)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3263,7 +3263,7 @@ dependencies = [
 
 [[package]]
 name = "mobile-sdk-rs"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobile-sdk-rs"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0 OR MIT"

--- a/rust/src/mdl/holder.rs
+++ b/rust/src/mdl/holder.rs
@@ -44,7 +44,7 @@ use uuid::Uuid;
 /// the state of the presentation, a String containing the QR code URI, and a
 /// String containing the BLE ident.
 ///
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 pub async fn initialize_mdl_presentation(
     mdoc_id: Uuid,
     uuid: Uuid,

--- a/rust/src/vdc_collection.rs
+++ b/rust/src/vdc_collection.rs
@@ -10,7 +10,7 @@ use tracing::info;
 use uuid::Uuid;
 
 /// Internal prefix for credential keys.
-const KEY_PREFIX: &str = "Credential.";
+const KEY_PREFIX: &str = "CredentialPack:";
 
 #[derive(uniffi::Object)]
 /// Verifiable Digital Credential Collection


### PR DESCRIPTION
This PR updates the key prefix to match the key prefix used by the CredentialPack.

I noticed when using the VDC collection, entries were filtered out due to using `Credential.` for the prefix instead of what is shown, `CredentialPack:`. Additionally, the changes herein enable additional prefixes (e.g., a username namespace) to be included in in the storage manager implementation. That said, the prefix is stripped and not filtering on additional prefixes, just the `CredentialPack:` prefix using `contains` instead of `startsWith`.

No interfaces changes are made in this PR, only updating how the prefix is detected for credential pack and vdc collection.