### PR TITLE
restore vdc collection prefix

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3263,7 +3263,7 @@ dependencies = [
 
 [[package]]
 name = "mobile-sdk-rs"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobile-sdk-rs"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0 OR MIT"

--- a/rust/src/vdc_collection.rs
+++ b/rust/src/vdc_collection.rs
@@ -10,7 +10,7 @@ use tracing::info;
 use uuid::Uuid;
 
 /// Internal prefix for credential keys.
-const KEY_PREFIX: &str = "CredentialPack:";
+const KEY_PREFIX: &str = "Credential.";
 
 #[derive(uniffi::Object)]
 /// Verifiable Digital Credential Collection


### PR DESCRIPTION
Restores VDC collection key prefix to `Credential.`
