### PR TITLE
add fields to activity log entry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: cargo clippy
 
   ios:
-    runs-on: macos-latest # macos-latest is currently macos-14 and we need iOS 18.2
+    runs-on: macos-15 # macos-latest is currently macos-14 and we need iOS 18.2
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,13 @@ jobs:
           cd ../Showcase
           xcodegen generate
       - name: Test MobileSdk
-        uses: mxcl/xcodebuild@v3
+        uses: mxcl/xcodebuild@v2
         with:
           platform: iOS
           scheme: MobileSdk
           working-directory: ios/MobileSdk
       - name: Test Showcase
-        uses: mxcl/xcodebuild@v3
+        uses: mxcl/xcodebuild@v2
         with:
           platform: iOS
           scheme: debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: cargo clippy
 
   ios:
-    runs-on: macos-15 # macos-latest is currently macos-14 and we need iOS 18.2
+    runs-on: macos-latest # macos-latest is currently macos-14 and we need iOS 18.2
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -71,15 +71,6 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
       - name: Install XCodeGen
         run: brew install xcodegen
-      - name: Install iOS 18.0 simulator
-        run: |
-          sudo xcode-select -s /Applications/Xcode.app
-          xcrun simctl list
-          # Install the required iOS runtime if not present
-          if ! xcrun simctl list runtimes | grep "iOS 18.0"; then
-            echo "iOS 18.0 runtime not found; please install it in Xcode."
-            exit 1
-          fi
       - name: Generate XCode projects
         run: |
           cd ios/MobileSdk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,15 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
       - name: Install XCodeGen
         run: brew install xcodegen
+      - name: Install iOS 18.0 simulator
+        run: |
+          sudo xcode-select -s /Applications/Xcode.app
+          xcrun simctl list
+          # Install the required iOS runtime if not present
+          if ! xcrun simctl list runtimes | grep "iOS 18.0"; then
+            echo "iOS 18.0 runtime not found; please install it in Xcode."
+            exit 1
+          fi
       - name: Generate XCode projects
         run: |
           cd ios/MobileSdk
@@ -78,13 +87,13 @@ jobs:
           cd ../Showcase
           xcodegen generate
       - name: Test MobileSdk
-        uses: mxcl/xcodebuild@v2
+        uses: mxcl/xcodebuild@v3
         with:
           platform: iOS
           scheme: MobileSdk
           working-directory: ios/MobileSdk
       - name: Test Showcase
-        uses: mxcl/xcodebuild@v2
+        uses: mxcl/xcodebuild@v3
         with:
           platform: iOS
           scheme: debug

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -4910,6 +4910,19 @@ open class JsonVc: JsonVcProtocol, @unchecked Sendable {
     /**
      * Construct a new credential from UTF-8 encoded JSON.
      */
+public static func fromJsonWithIdAndKey(id: Uuid, utf8JsonString: String, keyAlias: KeyAlias)throws  -> JsonVc  {
+    return try  FfiConverterTypeJsonVc_lift(try rustCallWithError(FfiConverterTypeJsonVcInitError_lift) {
+    uniffi_mobile_sdk_rs_fn_constructor_jsonvc_from_json_with_id_and_key(
+        FfiConverterTypeUuid_lower(id),
+        FfiConverterString.lower(utf8JsonString),
+        FfiConverterTypeKeyAlias_lower(keyAlias),$0
+    )
+})
+}
+    
+    /**
+     * Construct a new credential from UTF-8 encoded JSON.
+     */
 public static func newFromJson(utf8JsonString: String)throws  -> JsonVc  {
     return try  FfiConverterTypeJsonVc_lift(try rustCallWithError(FfiConverterTypeJsonVcInitError_lift) {
     uniffi_mobile_sdk_rs_fn_constructor_jsonvc_new_from_json(
@@ -7102,6 +7115,22 @@ open class ParsedCredential: ParsedCredentialProtocol, @unchecked Sendable {
         try! rustCall { uniffi_mobile_sdk_rs_fn_free_parsedcredential(pointer, $0) }
     }
 
+    
+    /**
+     * This method attempts to parse the credential depending on the credential format type provided, and provides
+     * an external UUID that can be used instead of creating a new UUID for the credential. This allows external reference
+     * IDs to parsed credentials.
+     */
+public static func fromStringWithIdAndFormat(id: Uuid, format: String, credential: String, keyAlias: KeyAlias)throws  -> ParsedCredential  {
+    return try  FfiConverterTypeParsedCredential_lift(try rustCallWithError(FfiConverterTypeCredentialDecodingError_lift) {
+    uniffi_mobile_sdk_rs_fn_constructor_parsedcredential_from_string_with_id_and_format(
+        FfiConverterTypeUuid_lower(id),
+        FfiConverterString.lower(format),
+        FfiConverterString.lower(credential),
+        FfiConverterTypeKeyAlias_lower(keyAlias),$0
+    )
+})
+}
     
     /**
      * Construct a new `cwt` credential.
@@ -9807,6 +9836,16 @@ open class Vcdm2SdJwt: Vcdm2SdJwtProtocol, @unchecked Sendable {
         try! rustCall { uniffi_mobile_sdk_rs_fn_free_vcdm2sdjwt(pointer, $0) }
     }
 
+    
+public static func fromCompactSdJwtWithIdAndKey(id: Uuid, input: String, keyAlias: KeyAlias)throws  -> Vcdm2SdJwt  {
+    return try  FfiConverterTypeVCDM2SdJwt_lift(try rustCallWithError(FfiConverterTypeSdJwtError_lift) {
+    uniffi_mobile_sdk_rs_fn_constructor_vcdm2sdjwt_from_compact_sd_jwt_with_id_and_key(
+        FfiConverterTypeUuid_lower(id),
+        FfiConverterString.lower(input),
+        FfiConverterTypeKeyAlias_lower(keyAlias),$0
+    )
+})
+}
     
     /**
      * Create a new SdJwt instance from a compact SD-JWS string.
@@ -21843,6 +21882,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_constructor_jsonldpresentationbuilder_new() != 15501) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_mobile_sdk_rs_checksum_constructor_jsonvc_from_json_with_id_and_key() != 16299) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_mobile_sdk_rs_checksum_constructor_jsonvc_new_from_json() != 40674) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -21882,6 +21924,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_constructor_oid4vci_new_with_sync_client() != 31928) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_mobile_sdk_rs_checksum_constructor_parsedcredential_from_string_with_id_and_format() != 23185) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_mobile_sdk_rs_checksum_constructor_parsedcredential_new_cwt() != 43883) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -21907,6 +21952,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_constructor_parsedcredential_parse_from_credential() != 15018) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mobile_sdk_rs_checksum_constructor_vcdm2sdjwt_from_compact_sd_jwt_with_id_and_key() != 12914) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_constructor_vcdm2sdjwt_new_from_compact_sd_jwt() != 56155) {

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -879,6 +879,8 @@ public protocol ActivityLogEntryProtocol: AnyObject, Sendable {
     
     func getDescription()  -> String
     
+    func getFields()  -> [String]
+    
     func getHidden()  -> Bool
     
     func getId()  -> Uuid
@@ -939,7 +941,7 @@ open class ActivityLogEntry: ActivityLogEntryProtocol, @unchecked Sendable {
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_mobile_sdk_rs_fn_clone_activitylogentry(self.pointer, $0) }
     }
-public convenience init(credentialId: Uuid, type: ActivityLogEntryType, description: String, interactionWith: String, url: String?)throws  {
+public convenience init(credentialId: Uuid, type: ActivityLogEntryType, description: String, interactionWith: String, fields: [String]?, url: String?)throws  {
     let pointer =
         try rustCallWithError(FfiConverterTypeActivityLogError_lift) {
     uniffi_mobile_sdk_rs_fn_constructor_activitylogentry_new(
@@ -947,6 +949,7 @@ public convenience init(credentialId: Uuid, type: ActivityLogEntryType, descript
         FfiConverterTypeActivityLogEntryType_lower(type),
         FfiConverterString.lower(description),
         FfiConverterString.lower(interactionWith),
+        FfiConverterOptionSequenceString.lower(fields),
         FfiConverterOptionString.lower(url),$0
     )
 }
@@ -997,6 +1000,13 @@ open func getDate() -> UInt64  {
 open func getDescription() -> String  {
     return try!  FfiConverterString.lift(try! rustCall() {
     uniffi_mobile_sdk_rs_fn_method_activitylogentry_get_description(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func getFields() -> [String]  {
+    return try!  FfiConverterSequenceString.lift(try! rustCall() {
+    uniffi_mobile_sdk_rs_fn_method_activitylogentry_get_fields(self.uniffiClonePointer(),$0
     )
 })
 }
@@ -21323,6 +21333,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_method_activitylogentry_get_description() != 26368) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_mobile_sdk_rs_checksum_method_activitylogentry_get_fields() != 21671) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_mobile_sdk_rs_checksum_method_activitylogentry_get_hidden() != 22447) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -21782,7 +21795,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_constructor_activitylogentry_from_json_str() != 13043) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mobile_sdk_rs_checksum_constructor_activitylogentry_new() != 64574) {
+    if (uniffi_mobile_sdk_rs_checksum_constructor_activitylogentry_new() != 48598) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_constructor_cryptocurveutils_secp256r1() != 20735) {

--- a/rust/src/credential/activity_log.rs
+++ b/rust/src/credential/activity_log.rs
@@ -140,6 +140,10 @@ pub struct ActivityLogEntry {
     /// un-hide the entry, possibly using biometrics or
     /// PIN for user control.
     hidden: bool,
+    /// Fields that have been shared. This will be an empty
+    /// vector if there are no fields shared (i.e., when the
+    /// activity type is not `Shared`)
+    fields: Vec<String>,
 }
 
 #[uniffi::export]
@@ -150,12 +154,15 @@ impl ActivityLogEntry {
         r#type: ActivityLogEntryType,
         description: String,
         interaction_with: String,
+        fields: Option<Vec<String>>,
         url: Option<String>,
     ) -> Result<Self, ActivityLogError> {
         let date = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .map_err(|e| ActivityLogError::CreateActivityLogEntry(e.to_string()))?
             .as_secs();
+
+        let fields = fields.unwrap_or_default();
 
         Ok(Self {
             id: Uuid::new_v4(),
@@ -164,6 +171,7 @@ impl ActivityLogEntry {
             date,
             description,
             interaction_with,
+            fields,
             url,
             hidden: false,
         })
@@ -205,6 +213,10 @@ impl ActivityLogEntry {
 
     fn get_interaction_with(&self) -> String {
         self.interaction_with.clone()
+    }
+
+    fn get_fields(&self) -> Vec<String> {
+        self.fields.clone()
     }
 
     fn get_url(&self) -> Option<String> {
@@ -402,6 +414,8 @@ impl ActivityLog {
             .filter(|key| key.strip_prefix(KEY_PREFIX).is_some())
             .collect::<Vec<Key>>();
 
+        log::info!("Found Keys for Activity Log in storage: {keys:?}");
+
         let entries = futures::stream::iter(keys.into_iter())
             .filter_map(|key| async move { self.storage.get(key).await.ok().flatten() })
             .filter_map(|value| async move { ActivityLogEntry::try_from(value).ok() })
@@ -471,6 +485,7 @@ mod test {
             ActivityLogEntryType::Request,
             "requesting new credential issuance".into(),
             "ISSUING AUTHORITY".into(),
+            None,
             Some("www.example.com".into()),
         )?);
 

--- a/rust/src/credential/activity_log.rs
+++ b/rust/src/credential/activity_log.rs
@@ -416,6 +416,10 @@ impl ActivityLog {
 
         log::info!("Found Keys for Activity Log in storage: {keys:?}");
 
+        if keys.is_empty() {
+            return Ok(Vec::with_capacity(0));
+        }
+
         let entries = futures::stream::iter(keys.into_iter())
             .filter_map(|key| async move { self.storage.get(key).await.ok().flatten() })
             .filter_map(|value| async move { ActivityLogEntry::try_from(value).ok() })

--- a/rust/src/credential/json_vc.rs
+++ b/rust/src/credential/json_vc.rs
@@ -85,6 +85,16 @@ impl JsonVc {
         key_alias: KeyAlias,
     ) -> Result<Arc<Self>, JsonVcInitError> {
         let id = Uuid::new_v4();
+        Self::from_json_with_id_and_key(id, utf8_json_string, key_alias)
+    }
+
+    #[uniffi::constructor]
+    /// Construct a new credential from UTF-8 encoded JSON.
+    pub fn from_json_with_id_and_key(
+        id: Uuid,
+        utf8_json_string: String,
+        key_alias: KeyAlias,
+    ) -> Result<Arc<Self>, JsonVcInitError> {
         let json = serde_json::from_str(&utf8_json_string)
             .map_err(|_| JsonVcInitError::JsonStringDecoding)?;
         Self::from_json(id, json, Some(key_alias))

--- a/rust/src/credential/jwt_vc.rs
+++ b/rust/src/credential/jwt_vc.rs
@@ -119,7 +119,7 @@ impl JwtVc {
         Self::from_compact_jws(id, jws, key_alias)
     }
 
-    fn from_compact_jws(
+    pub(crate) fn from_compact_jws(
         id: Uuid,
         jws: String,
         key_alias: Option<KeyAlias>,

--- a/rust/src/credential/mod.rs
+++ b/rust/src/credential/mod.rs
@@ -152,6 +152,50 @@ impl ParsedCredential {
         }
     }
 
+    /// This method attempts to parse the credential depending on the credential format type provided, and provides
+    /// an external UUID that can be used instead of creating a new UUID for the credential. This allows external reference
+    /// IDs to parsed credentials.
+    #[uniffi::constructor]
+    pub fn from_string_with_id_and_format(
+        id: Uuid,
+        format: String,
+        credential: String,
+        key_alias: KeyAlias,
+    ) -> Result<Arc<Self>, CredentialDecodingError> {
+        let format = CredentialFormat::from(format);
+
+        match format {
+            CredentialFormat::MsoMdoc => {
+                let mdoc = Mdoc::from_stringified_document(credential, key_alias)?;
+                Ok(ParsedCredential::new_mso_mdoc(mdoc))
+            }
+            CredentialFormat::JwtVcJson => {
+                let jwt_vc = JwtVc::from_compact_jws(id, credential, Some(key_alias))?;
+                Ok(ParsedCredential::new_jwt_vc_json(jwt_vc))
+            }
+            CredentialFormat::JwtVcJsonLd => {
+                let jwt_vc = JwtVc::from_compact_jws(id, credential, Some(key_alias))?;
+                Ok(ParsedCredential::new_jwt_vc_json_ld(jwt_vc))
+            }
+            CredentialFormat::LdpVc => {
+                let json_vc = JsonVc::from_json_with_id_and_key(id, credential, key_alias)?;
+                Ok(ParsedCredential::new_ldp_vc(json_vc))
+            }
+            CredentialFormat::VCDM2SdJwt => {
+                let sd_jwt =
+                    VCDM2SdJwt::from_compact_sd_jwt_with_id_and_key(id, credential, key_alias)?;
+                Ok(ParsedCredential::new_sd_jwt(sd_jwt))
+            }
+            CredentialFormat::Cwt => {
+                let cwt = Cwt::from_base10(id, credential.as_bytes().into())?.into();
+                Ok(ParsedCredential::new_cwt(cwt))
+            }
+            CredentialFormat::Other(_) => Err(
+                CredentialDecodingError::UnsupportedCredentialFormat(format.to_string()),
+            ),
+        }
+    }
+
     #[uniffi::constructor]
     pub fn new_from_json(json_string: String) -> Result<Arc<Self>, CredentialDecodingError> {
         let credential: Credential = serde_json::from_str(&json_string)

--- a/rust/src/tests.rs
+++ b/rust/src/tests.rs
@@ -24,15 +24,10 @@ const OID4VCI_CREDENTIAL_OFFER_URI: &str = "openid-credential-offer://?credentia
 const MSO_MDOC_OID4VCI_CREDENTIAL_OFFER_URI: &str = "openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22https%3A%2F%2F0b16-2001-1284-f50e-a746-f8de-7ed-6278-9f7e.ngrok-free.app%22%2C%22credential_configuration_ids%22%3A%5B%22org.iso.18013.5.1.mDL%22%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%22JIHGFEDCBA%22%2C%22tx_code%22%3Anull%2C%22interval%22%3Anull%2C%22authorization_server%22%3Anull%7D%7D%7D";
 const OID4VP_URI: &str = "openid4vp://authorize?client_id=https%3A%2F%2Fqa.veresexchanger.dev%2Fexchangers%2Fz19vRLNoFaBKDeDaMzRjUj8hi%2Fexchanges%2Fz1AEkyzEHrWvfJX78zXZHiu6m%2Fopenid%2Fclient%2Fauthorization%2Fresponse&request_uri=https%3A%2F%2Fqa.veresexchanger.dev%2Fexchangers%2Fz19vRLNoFaBKDeDaMzRjUj8hi%2Fexchanges%2Fz1AEkyzEHrWvfJX78zXZHiu6m%2Fopenid%2Fclient%2Fauthorization%2Frequest";
 
+#[allow(dead_code)]
 #[derive(Debug, thiserror::Error)]
 #[error("HTTP error: {0}")]
 pub struct TestError(pub StatusCode);
-
-impl TestError {
-    pub fn new(status_code: StatusCode) -> Self {
-        Self(status_code)
-    }
-}
 
 // NOTE: This could be the basis for the default async client for oid4vci,
 // but it's currently only used for testing purposes.

--- a/rust/src/tests.rs
+++ b/rust/src/tests.rs
@@ -28,6 +28,12 @@ const OID4VP_URI: &str = "openid4vp://authorize?client_id=https%3A%2F%2Fqa.veres
 #[error("HTTP error: {0}")]
 pub struct TestError(pub StatusCode);
 
+impl TestError {
+    pub fn new(status_code: StatusCode) -> Self {
+        Self(status_code)
+    }
+}
+
 // NOTE: This could be the basis for the default async client for oid4vci,
 // but it's currently only used for testing purposes.
 //

--- a/rust/src/tests.rs
+++ b/rust/src/tests.rs
@@ -26,7 +26,7 @@ const OID4VP_URI: &str = "openid4vp://authorize?client_id=https%3A%2F%2Fqa.veres
 
 #[derive(Debug, thiserror::Error)]
 #[error("HTTP error: {0}")]
-pub struct TestError(StatusCode);
+pub struct TestError(pub StatusCode);
 
 // NOTE: This could be the basis for the default async client for oid4vci,
 // but it's currently only used for testing purposes.


### PR DESCRIPTION
## Description

Updates the activity log entry to include a list of fields that were shared. The fields list can be empty if the activity log type is not `ActivityLogEntryType.Share`.

### Other changes

To ensure the parsed credentials that are passed to the openid4vp handler can be referenced in the application, this PR includes a new interface to pass in a known or static UUID that can be used when parsing a credential.


### Optional section



## Tested

Testing in camv.