### PR TITLE
Feat/mdl session reader common name

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3263,7 +3263,7 @@ dependencies = [
 
 [[package]]
 name = "mobile-sdk-rs"
-version = "0.12.4"
+version = "0.12.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobile-sdk-rs"
-version = "0.12.4"
+version = "0.12.6"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0 OR MIT"

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -5890,6 +5890,13 @@ public protocol MdlPresentationSessionProtocol: AnyObject, Sendable {
      */
     func handleRequest(request: Data) throws  -> [ItemsRequest]
     
+    /**
+     * Return the Reader common name, if available from the session
+     *
+     * Will return an error if the session mutex lock cannot be acquired.
+     */
+    func readerName() throws  -> String
+    
     func submitResponse(signature: Data) throws  -> Data
     
     /**
@@ -6000,6 +6007,18 @@ open func handleRequest(request: Data)throws  -> [ItemsRequest]  {
     return try  FfiConverterSequenceTypeItemsRequest.lift(try rustCallWithError(FfiConverterTypeRequestError_lift) {
     uniffi_mobile_sdk_rs_fn_method_mdlpresentationsession_handle_request(self.uniffiClonePointer(),
         FfiConverterData.lower(request),$0
+    )
+})
+}
+    
+    /**
+     * Return the Reader common name, if available from the session
+     *
+     * Will return an error if the session mutex lock cannot be acquired.
+     */
+open func readerName()throws  -> String  {
+    return try  FfiConverterString.lift(try rustCallWithError(FfiConverterTypeSessionError_lift) {
+    uniffi_mobile_sdk_rs_fn_method_mdlpresentationsession_reader_name(self.uniffiClonePointer(),$0
     )
 })
 }
@@ -17424,6 +17443,8 @@ public enum SessionError: Swift.Error {
 
     
     
+    case Mutex(value: String
+    )
     case Generic(value: String
     )
 }
@@ -17442,7 +17463,10 @@ public struct FfiConverterTypeSessionError: FfiConverterRustBuffer {
         
 
         
-        case 1: return .Generic(
+        case 1: return .Mutex(
+            value: try FfiConverterString.read(from: &buf)
+            )
+        case 2: return .Generic(
             value: try FfiConverterString.read(from: &buf)
             )
 
@@ -17457,8 +17481,13 @@ public struct FfiConverterTypeSessionError: FfiConverterRustBuffer {
 
         
         
-        case let .Generic(value):
+        case let .Mutex(value):
             writeInt(&buf, Int32(1))
+            FfiConverterString.write(value, into: &buf)
+            
+        
+        case let .Generic(value):
+            writeInt(&buf, Int32(2))
             FfiConverterString.write(value, into: &buf)
             
         }
@@ -21550,6 +21579,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_mdlpresentationsession_handle_request() != 21650) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mobile_sdk_rs_checksum_method_mdlpresentationsession_reader_name() != 65172) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_mdlpresentationsession_submit_response() != 53424) {

--- a/rust/src/mdl/holder.rs
+++ b/rust/src/mdl/holder.rs
@@ -157,6 +157,7 @@ pub struct MdlPresentationSession {
 struct InProcessRecord {
     session: device::SessionManager,
     items_request: device::RequestedItems,
+    reader_common_name: Option<String>,
 }
 
 #[uniffi::export]
@@ -193,6 +194,7 @@ impl MdlPresentationSession {
         *in_process = Some(InProcessRecord {
             session: session_manager,
             items_request: items_requests.items_request.clone(),
+            reader_common_name: items_requests.common_name,
         });
 
         Ok(items_requests
@@ -297,10 +299,34 @@ impl MdlPresentationSession {
     pub fn get_ble_ident(&self) -> Vec<u8> {
         self.ble_ident.clone()
     }
+
+    /// Return the Reader common name, if available from the session
+    ///
+    /// Will return an error if the session mutex lock cannot be acquired.
+    pub fn reader_name(&self) -> Result<String, SessionError> {
+        self.in_process
+            .lock()
+            .map_err(|e| SessionError::Mutex {
+                value: e.to_string(),
+            })?
+            .as_ref()
+            .and_then(|r| r.reader_common_name.clone())
+            .ok_or(SessionError::Generic {
+                value: "Reader common name unknown".into(),
+            })
+    }
+}
+
+#[derive(uniffi::Record, Clone)]
+pub struct ItemsRequest {
+    doc_type: String,
+    namespaces: HashMap<String, HashMap<String, bool>>,
 }
 
 #[derive(thiserror::Error, uniffi::Error, Debug)]
 pub enum SessionError {
+    #[error("Session mutex error: {value}")]
+    Mutex { value: String },
     #[error("{value}")]
     Generic { value: String },
 }
@@ -309,12 +335,6 @@ pub enum SessionError {
 pub enum RequestError {
     #[error("{value}")]
     Generic { value: String },
-}
-
-#[derive(uniffi::Record, Clone)]
-pub struct ItemsRequest {
-    doc_type: String,
-    namespaces: HashMap<String, HashMap<String, bool>>,
 }
 
 #[derive(thiserror::Error, uniffi::Error, Debug)]


### PR DESCRIPTION
## Description

Adds a `reader_name` method to the `MdlPresentationSession` to pull the name from the `InProcessRecord`.

### Other changes

bumping sprucekit version to 0.12.6

### Optional section



## Tested

