### PR TITLE
Fix/overlapping permission requests

### DIFF
--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/CredentialsViewModel.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/CredentialsViewModel.kt
@@ -33,6 +33,12 @@ class CredentialsViewModel(application: Application) : AndroidViewModel(applicat
     private val _itemsRequests = MutableStateFlow<List<ItemsRequest>>(listOf())
     val itemsRequest = _itemsRequests.asStateFlow()
 
+    private val _bluetoothPermissionsGranted = MutableStateFlow<Boolean>(false)
+    val bluetoothPermissionsGranted = _bluetoothPermissionsGranted.asStateFlow()
+    fun setBluetoothPermissionsGranted(granted: Boolean) {
+        _bluetoothPermissionsGranted.value = granted
+    }
+
     private val _allowedNamespaces =
         MutableStateFlow<Map<String, Map<String, List<String>>>>(
             mapOf(

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/CredentialDetailsView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/CredentialDetailsView.kt
@@ -239,8 +239,7 @@ fun CredentialDetailsView(
         HorizontalDivider()
         Box(modifier = Modifier.weight(1f)) {
             HorizontalPager(
-                state = pagerState,
-                beyondViewportPageCount = 0
+                state = pagerState
             ) { page ->
                 Box(
                     modifier = Modifier

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/CredentialDetailsView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/CredentialDetailsView.kt
@@ -1,6 +1,9 @@
 package com.spruceid.mobilesdkexample.credentials
 
+import android.Manifest
 import android.app.Application
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -50,9 +53,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.NavController
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.spruceid.mobile.sdk.CredentialPack
 import com.spruceid.mobile.sdk.CredentialStatusList
 import com.spruceid.mobile.sdk.CredentialsViewModel
+import com.spruceid.mobile.sdk.getPermissions
 import com.spruceid.mobile.sdk.rs.ParsedCredential
 import com.spruceid.mobilesdkexample.LoadingView
 import com.spruceid.mobilesdkexample.R
@@ -87,6 +92,7 @@ fun CredentialDetailsView(
     credentialPackId: String
 ) {
     val credentialPacksViewModel: CredentialPacksViewModel = activityHiltViewModel()
+    val credentialViewModel: CredentialsViewModel = activityHiltViewModel()
     val statusListViewModel: StatusListViewModel = activityHiltViewModel()
     var credentialTitle by remember { mutableStateOf<String?>(null) }
     var credentialItem by remember { mutableStateOf<ICredentialView?>(null) }
@@ -117,6 +123,29 @@ fun CredentialDetailsView(
 
     val isLoading by credentialPacksViewModel.loading.collectAsState()
     val credentialPacks by credentialPacksViewModel.credentialPacks.collectAsState()
+
+    val permissionsLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { result ->
+        // Check if this was a Bluetooth permission request
+        val isBluetoothRequest = result.keys.containsAll(getPermissions())
+
+        if (isBluetoothRequest) {
+            val bluetoothGranted = getPermissions().all { result[it] == true }
+            credentialViewModel.setBluetoothPermissionsGranted(bluetoothGranted)
+            if (!bluetoothGranted) {
+                // TODO: Show Bluetooth error or fallback
+            }
+        }
+
+        // Check if this was a Camera permission request
+        if (result.containsKey(Manifest.permission.CAMERA)) {
+            val cameraGranted = result[Manifest.permission.CAMERA] == true
+            if (!cameraGranted) {
+                // TODO: Show camera error or fallback
+            }
+        }
+    }
 
     fun back() {
         navController.navigate(Screen.HomeScreen.route) {
@@ -210,7 +239,8 @@ fun CredentialDetailsView(
         HorizontalDivider()
         Box(modifier = Modifier.weight(1f)) {
             HorizontalPager(
-                state = pagerState
+                state = pagerState,
+                beyondViewportPageCount = 0
             ) { page ->
                 Box(
                     modifier = Modifier
@@ -218,32 +248,43 @@ fun CredentialDetailsView(
                         .background(ColorBase50),
                     contentAlignment = Alignment.Center
                 ) {
-                    if (page == 0) {  // Details
-                        Column(
-                            Modifier
-                                .padding(horizontal = 20.dp)
-                                .padding(vertical = 16.dp)
-                        ) {
-                            credentialItem?.let {
-                                if (statusList != CredentialStatusList.REVOKED) {
-                                    credentialItem!!.credentialDetails()
-                                } else {
-                                    credentialItem!!.credentialRevokedInfo {
-                                        back()
+                    when (page) {
+                        0 -> {
+                            // Ask for bluetooth and camera permissions
+                            val allPermissions = getPermissions().toMutableList().apply {
+                                add(Manifest.permission.CAMERA)
+                            }.toTypedArray()
+                            permissionsLauncher.launch(allPermissions)
+                            Column(
+                                Modifier
+                                    .padding(horizontal = 20.dp)
+                                    .padding(vertical = 16.dp)
+                            ) {
+                                credentialItem?.let {
+                                    if (statusList != CredentialStatusList.REVOKED) {
+                                        credentialItem!!.credentialDetails()
+                                    } else {
+                                        credentialItem!!.credentialRevokedInfo {
+                                            back()
+                                        }
                                     }
                                 }
                             }
                         }
-                    } else if (page == 1) { // Scan to verify
-                        DispatchQRView(
-                            navController,
-                            credentialPackId,
-                            listOf(SupportedQRTypes.OID4VP, SupportedQRTypes.HTTP),
-                            backgroundColor = ColorBase50,
-                            hideCancelButton = true
-                        )
-                    } else if (page == 2) { // Share
-                        GenericCredentialDetailsShareQRCode(credentialPack!!)
+
+                       1 ->  {  // Scan to verify
+                            DispatchQRView(
+                                navController,
+                                credentialPackId,
+                                listOf(SupportedQRTypes.OID4VP, SupportedQRTypes.HTTP),
+                                backgroundColor = ColorBase50,
+                                hideCancelButton = true
+                            )
+                        }
+
+                        2 -> { // Share
+                            GenericCredentialDetailsShareQRCode(credentialPack!!)
+                        }
                     }
                 }
             }

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/utils/Utils.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/utils/Utils.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.core.content.ContextCompat
 import com.spruceid.mobile.sdk.CredentialPack
+import com.spruceid.mobile.sdk.CredentialsViewModel
 import com.spruceid.mobile.sdk.rs.Cwt
 import com.spruceid.mobile.sdk.rs.JsonVc
 import com.spruceid.mobile.sdk.rs.JwtVc
@@ -89,7 +90,8 @@ fun BitmapImage(
 fun checkAndRequestBluetoothPermissions(
     context: Context,
     permissions: Array<String>,
-    launcher: ManagedActivityResultLauncher<Array<String>, Map<String, Boolean>>
+    launcher: ManagedActivityResultLauncher<Array<String>, Map<String, Boolean>>,
+    credentialViewModel: CredentialsViewModel? = null,
 ) {
     if (
         permissions.all {
@@ -100,6 +102,7 @@ fun checkAndRequestBluetoothPermissions(
         }
     ) {
         // Use bluetooth because permissions are already granted
+        credentialViewModel?.setBluetoothPermissionsGranted(true)
     } else {
         // Request permissions
         launcher.launch(permissions)


### PR DESCRIPTION
## Description

This PR aims to solve some inconsistencies on the Android side acting as a mDoc holder. 

1. Bluetooth permissions and premature QR presentation

Previously, the QR code used to initiate mDoc sharing was being displayed before Bluetooth permissions were fully granted. Since permission requests are asynchronous, this led to race conditions where the Bluetooth scanning would fail. This was one of the causes of the "Waiting for holder..." issue observed on the Verifier side.

Fix: The QR code is now only presented after all required Bluetooth permissions are confirmed, ensuring a reliable connection setup.

2. Overlapping permission requests due to eager rendering in `HorizontalPager`

The `CredentialDetailsView` uses an `HorizontalPager` to display its pages, and by default, the pager eagerly composes neighboring pages to improve swipe performance. Since the last two pages request permissions, first for the camera, then for Bluetooth, we ended up calling `rememberMultiplePermissionsState` twice in quick succession. This caused the permission dialogs to overlap or conflict, requiring users to exit and reopen the screen to trigger the other one properly.

Fix: We now request all required permissions (camera + Bluetooth) upfront, right when `CredentialDetailsView` is opened. This avoids overlapping permission flows.

### Other changes

N/A

### Optional section

We still observe cases where the Verifier gets stuck on "Waiting for holder...", but these now appear to be related to the iOS L2CAP implementation. Notably, restarting only the iOS app resolves the issue, which suggests the problem is not on the Android side.

Additionally, there are instances where the Android device receives the data sharing request twice, causing the selective disclosure prompt to appear two times. It's unclear where the root of this issue lies, but it seems to leave the iOS app in an inconsistent state. After that, any subsequent verification attempts also get stuck at "Waiting for holder...", until the iOS app is restarted.

## Tested

Use an Android phone as a holder and iOS as a verifier, go through the normal flow for mDL verification and it should be a little more consistent.
