### PR TITLE
Update ActivityLog to support user-namespaced StorageManagerInterface

### DIFF
--- a/rust/src/credential/activity_log.rs
+++ b/rust/src/credential/activity_log.rs
@@ -412,7 +412,8 @@ impl ActivityLog {
             .map_err(|e| ActivityLogError::Storage(e.to_string()))?
             .into_iter()
             .filter(|key: &Key| {
-                key.0.split_once(KEY_PREFIX)
+                key.0
+                    .split_once(KEY_PREFIX)
                     .map(|(_, rest)| !rest.is_empty())
                     .unwrap_or(false)
             })
@@ -474,7 +475,9 @@ mod test {
 
     use super::*;
 
-    async fn run_activity_log_test(storage: Arc<dyn StorageManagerInterface>) -> Result<(), ActivityLogError> {
+    async fn run_activity_log_test(
+        storage: Arc<dyn StorageManagerInterface>,
+    ) -> Result<(), ActivityLogError> {
         let credential_id = Uuid::new_v4();
 
         // Load activity Log


### PR DESCRIPTION
## Description

This feature adds support for user namespaced `StorageManagerInterface` implementations, building on #183 (filtering by `contains` instead of by key prefix). With the current implementation, users can add activity log entries, but cannot find them using `get`, `entries`, etc., due to only looking for `KEY_PREFIX`. This resolves that by splitting on `KEY_PREFIX` and taking everything after the prefix as the key.

## Tested

- Added a new `NamespacedDummyStorage` test utility to simulate a namespaced `StorageManagerInterface` implementation.
- Added a test for user namespaced activity log.
