### PR TITLE
Make iOS `readerName` publicly usable

### DIFF
--- a/ios/MobileSdk/Sources/MobileSdk/IsoMdlPresentation.swift
+++ b/ios/MobileSdk/Sources/MobileSdk/IsoMdlPresentation.swift
@@ -87,6 +87,10 @@ public class IsoMdlPresentation {
             self.cancel()
         }
     }
+    
+    public func readerName() throws -> String {
+        try session.readerName()
+    }
 }
 
 extension IsoMdlPresentation: MDocBLEDelegate {

--- a/ios/MobileSdk/Sources/MobileSdk/IsoMdlPresentation.swift
+++ b/ios/MobileSdk/Sources/MobileSdk/IsoMdlPresentation.swift
@@ -87,7 +87,7 @@ public class IsoMdlPresentation {
             self.cancel()
         }
     }
-    
+
     public func readerName() throws -> String {
         try session.readerName()
     }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3263,7 +3263,7 @@ dependencies = [
 
 [[package]]
 name = "mobile-sdk-rs"
-version = "0.12.6"
+version = "0.12.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobile-sdk-rs"
-version = "0.12.6"
+version = "0.12.7"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
## Description

Small change to make `MdlPresentationSession#readerName` publicly accessible in iOS code - see #191 

### Other changes

Bumped version number for SpruceKit release after this is merged.
