### PR TITLE
[ACC 809] - Android: HAC application list styling

### DIFF
--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HacApplicationListItem.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HacApplicationListItem.kt
@@ -99,8 +99,8 @@ fun HacApplicationListItem(
                     brush = Brush.verticalGradient(
                         colorStops = arrayOf(
                             0.0f to Color(0xFFC8BFAD),
-                            0.1f to Color.White.copy(alpha = 0.2f),
-                            0.9f to Color.White.copy(alpha = 0.2f),
+                            0.3f to Color.White.copy(alpha = 0.2f),
+                            0.8f to Color.White.copy(alpha = 0.2f),
                             1.0f to Color(0xFFC8BFAD),
                         ),
                     )


### PR DESCRIPTION
## Description

Cards for non-approved hac applications are different from credential cards, to match the new styles I've made them to look similar to the credential cards.


https://github.com/user-attachments/assets/fa0689a7-1645-471c-b07e-4441a9423ad5


### Other changes

- Added a loading animation for the HAC application status fetching

### Optional section

N/A

## Tested

- Build it and see it
