### PR TITLE
[ACC 869] - Android UI: Fix double tap bug on "close" button in Credentail Details

### DIFF
--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/credentialDetailsView/CredentialDetailsView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/credentialDetailsView/CredentialDetailsView.kt
@@ -96,6 +96,8 @@ fun CredentialDetailsView(
     var currentMode by remember { mutableStateOf(CredentialMode.NONE) }
     // Show/Hide action menu for a credential
     var showBottomSheet by remember { mutableStateOf(false) }
+    // Prevent double-tap navigation
+    var isNavigatingBack by remember { mutableStateOf(false) }
 
     val isLoading by credentialPacksViewModel.loading.collectAsState()
     val credentialPacks by credentialPacksViewModel.credentialPacks.collectAsState()
@@ -125,6 +127,10 @@ fun CredentialDetailsView(
     }
 
     fun back() {
+        // Prevent double-tap navigation
+        if (isNavigatingBack) return
+        isNavigatingBack = true
+
         // Immediately disable scan mode to cleanup camera faster
         if (currentMode == CredentialMode.SCAN) {
             currentMode = CredentialMode.NONE


### PR DESCRIPTION
## Description

Double-taps on the "close" button in Credential Details screen were causing double navigation, resulting in a blank screen.

### Other changes

N/A

### Optional section

N/A

## Tested

Before

https://github.com/user-attachments/assets/39c9be29-f150-43b4-99d1-ec9508221d84

After

https://github.com/user-attachments/assets/6d2f534c-538f-4c5a-97f2-fe3f34bb849a

