### PR TITLE
add requested_by method to 18013-7 request

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3359,7 +3359,7 @@ dependencies = [
 
 [[package]]
 name = "mobile-sdk-rs"
-version = "0.12.10"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobile-sdk-rs"
-version = "0.12.10"
+version = "0.12.11"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0 OR MIT"

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -4072,6 +4072,13 @@ public protocol InProgressRequest180137Protocol: AnyObject, Sendable {
     
     func matches()  -> [RequestMatch180137]
     
+    /**
+     * Returns the verifier name requesting authorization.
+     * This value is derived from the `client_id` of the processed
+     * authorization request object.
+     */
+    func requestedBy()  -> String?
+    
     func respond(approvedResponse: ApprovedResponse180137) async throws  -> Url?
     
 }
@@ -4130,6 +4137,18 @@ open class InProgressRequest180137: InProgressRequest180137Protocol, @unchecked 
 open func matches() -> [RequestMatch180137]  {
     return try!  FfiConverterSequenceTypeRequestMatch180137.lift(try! rustCall() {
     uniffi_mobile_sdk_rs_fn_method_inprogressrequest180137_matches(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Returns the verifier name requesting authorization.
+     * This value is derived from the `client_id` of the processed
+     * authorization request object.
+     */
+open func requestedBy() -> String?  {
+    return try!  FfiConverterOptionString.lift(try! rustCall() {
+    uniffi_mobile_sdk_rs_fn_method_inprogressrequest180137_requested_by(self.uniffiClonePointer(),$0
     )
 })
 }
@@ -22463,6 +22482,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_inprogressrequest180137_matches() != 21157) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mobile_sdk_rs_checksum_method_inprogressrequest180137_requested_by() != 32235) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_inprogressrequest180137_respond() != 45984) {

--- a/rust/src/oid4vp/iso_18013_7/mod.rs
+++ b/rust/src/oid4vp/iso_18013_7/mod.rs
@@ -162,6 +162,13 @@ impl InProgressRequest180137 {
             .map_err(OID4VP180137Error::response_processing)
     }
 
+    /// Returns the verifier name requesting authorization.
+    /// This value is derived from the `client_id` of the processed
+    /// authorization request object.
+    pub fn requested_by(&self) -> Option<String> {
+        self.request.client_id().map(|id| id.0.clone())
+    }
+
     pub fn matches(&self) -> Vec<Arc<RequestMatch180137>> {
         self.request_matches.clone()
     }


### PR DESCRIPTION
## Description


This pull request introduces a new method to expose the verifier name (derived from the `client_id`) in the authorization flow, and updates the API checksums and versioning to reflect this addition.

**New API functionality:**

* Added a `requestedBy()` method to the `InProgressRequest180137Protocol` Swift protocol and its implementation, allowing consumers to retrieve the verifier name from the processed authorization request object. [[1]](diffhunk://#diff-f89d26565ff095881f17099b2445728373de0c09f188c8caa4f3d9e82d98d012R4075-R4081) [[2]](diffhunk://#diff-f89d26565ff095881f17099b2445728373de0c09f188c8caa4f3d9e82d98d012R4142-R4153)
* Added the corresponding `requested_by` method to the Rust `InProgressRequest180137` struct, returning the verifier name based on the `client_id`.

**API integrity and versioning:**

* Updated the API checksum validation logic to include the new `requested_by` method, ensuring interface consistency between Swift and Rust.
* Bumped the crate version in `Cargo.toml` from `0.12.10` to `0.12.11` to reflect the new API addition.

### Other changes



### Optional section



## Tested

TBT in CA