### PR TITLE
Podspecs for Flutter plugin

### DIFF
--- a/SpruceIDMobileSdk.podspec
+++ b/SpruceIDMobileSdk.podspec
@@ -1,0 +1,26 @@
+Pod::Spec.new do |spec|
+  spec.name             = 'SpruceIDMobileSdk'
+  spec.version          = '0.13.1'
+  spec.summary          = 'SpruceID Mobile SDK for iOS'
+  spec.description      = <<-DESC
+                   SpruceID Swift Mobile SDK for credential management, OID4VCI issuance, and verifiable credentials.
+                   DESC
+  spec.homepage         = 'https://github.com/spruceid/sprucekit-mobile'
+  spec.license          = { :type => 'MIT & Apache License, Version 2.0', :text => <<-LICENSE
+                          Refer to LICENSE-MIT and LICENSE-APACHE in the repository.
+                        LICENSE
+                      }
+  spec.author           = { 'Spruce Systems, Inc.' => 'hello@spruceid.com' }
+  spec.platform         = :ios
+  spec.swift_version    = '5.9'
+
+  spec.ios.deployment_target = '14.0'
+
+  spec.source           = { :git => 'https://github.com/spruceid/sprucekit-mobile.git', :tag => "#{spec.version}" }
+  spec.source_files     = 'ios/MobileSdk/Sources/MobileSdk/**/*.swift'
+
+  spec.static_framework = true
+  spec.dependency 'SpruceIDMobileSdkRs', '~> 0.13.1'
+  spec.dependency 'SwiftAlgorithms', '~> 1.0.0'
+  spec.frameworks = 'Foundation', 'CoreBluetooth', 'CryptoKit'
+end

--- a/SpruceIDMobileSdkRs.podspec
+++ b/SpruceIDMobileSdkRs.podspec
@@ -1,0 +1,25 @@
+Pod::Spec.new do |spec|
+  spec.name         = 'SpruceIDMobileSdkRs'
+  spec.version      = '0.13.1'
+  spec.summary      = 'Rust-generated Swift Mobile SDK.'
+  spec.description  = <<-DESC
+                   Rust layer for the Swift Mobile SDK.
+                   DESC
+  spec.homepage     = 'https://github.com/spruceid/sprucekit-mobile'
+  spec.license      = { :type => 'MIT & Apache License, Version 2.0', :text => <<-LICENSE
+                          Refer to LICENSE-MIT and LICENSE-APACHE in the repository.
+                        LICENSE
+                      }
+  spec.author       = { 'Spruce Systems, Inc.' => 'hello@spruceid.com' }
+  spec.platform     = :ios
+  spec.swift_version = '5.9'
+
+  spec.ios.deployment_target = '14.0'
+
+  spec.static_framework = true
+  spec.source        = { :git => 'https://github.com/spruceid/sprucekit-mobile.git', :tag => "#{spec.version}" }
+  spec.source_files  = 'rust/MobileSdkRs/Sources/MobileSdkRs/**/*.swift'
+  spec.frameworks    = 'Foundation'
+
+  spec.dependency 'SpruceIDMobileSdkRsRustFramework', "#{spec.version}"
+end

--- a/SpruceIDMobileSdkRsRustFramework.podspec
+++ b/SpruceIDMobileSdkRsRustFramework.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |spec|
+  spec.name         = 'SpruceIDMobileSdkRsRustFramework'
+  spec.version      = '0.13.1'
+  spec.summary      = 'Rust-generated Framework for Swift Mobile SDK.'
+  spec.description  = <<-DESC
+                   Rust layer framework for the Swift Mobile SDK.
+                   DESC
+  spec.homepage     = 'https://github.com/spruceid/sprucekit-mobile'
+  spec.license      = { :type => 'MIT & Apache License, Version 2.0', :text => <<-LICENSE
+                          Refer to LICENSE-MIT and LICENSE-APACHE in the repository.
+                        LICENSE
+                      }
+  spec.author       = { 'Spruce Systems, Inc.' => 'hello@spruceid.com' }
+  spec.platform     = :ios
+
+  spec.ios.deployment_target = '14.0'
+
+  spec.static_framework = true
+  # For releases, the framework is downloaded from GitHub releases
+  # For local development, use: 
+  # spec.source = { :path => '../../../' }
+  spec.source = { :http => "https://github.com/spruceid/sprucekit-mobile/releases/download/#{spec.version}/RustFramework.xcframework.zip" }
+  spec.vendored_frameworks = 'rust/MobileSdkRs/RustFramework.xcframework'
+end


### PR DESCRIPTION
## Description

This adds podspecs to enable the Flutter plugin to work remotely without requiring Cocoapods publication.

### Other changes

N/A

### Optional section

N/A

## Tested

N/A