### PR TITLE
parameterize access group key security attribute

### DIFF
--- a/ios/MobileSdk/Sources/MobileSdk/KeyManager.swift
+++ b/ios/MobileSdk/Sources/MobileSdk/KeyManager.swift
@@ -5,14 +5,13 @@ import SpruceIDMobileSdkRs
 
 public class KeyManager: NSObject, SpruceIDMobileSdkRs.KeyStore, ObservableObject,
     @unchecked
-    Sendable
-{
+    Sendable {
     /// Migrate keys between access groups. For more information see
     /// https://developer.apple.com/documentation/Security/kSecAttrAccessGroup
     public func migrateToAccessGroup(oldAccessGroup: String, newAccessGroup: String) throws {
         let searchAttrs: [String: Any] = [
             kSecClass as String: kSecClassKey,
-            kSecAttrAccessGroup as String: oldAccessGroup,
+            kSecAttrAccessGroup as String: oldAccessGroup
         ]
         let targetAttrs: [String: Any] = [
             kSecAttrAccessGroup as String: newAccessGroup
@@ -30,7 +29,7 @@ public class KeyManager: NSObject, SpruceIDMobileSdkRs.KeyStore, ObservableObjec
         var query: [String: Any] = [
             kSecClass as String: kSecClassKey,
             kSecAttrApplicationTag as String: tag,
-            kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
+            kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom
         ]
 
         let attributes: [String: Any] = [
@@ -53,8 +52,7 @@ public class KeyManager: NSObject, SpruceIDMobileSdkRs.KeyStore, ObservableObjec
     }
 
     public func getSigningKey(alias: SpruceIDMobileSdkRs.KeyAlias) throws -> any SpruceIDMobileSdkRs
-        .SigningKey
-    {
+        .SigningKey {
         guard let jwkString = Self.getJwk(id: alias) else {
             throw KeyManError.missing
         }
@@ -82,7 +80,7 @@ public class KeyManager: NSObject, SpruceIDMobileSdkRs.KeyStore, ObservableObjec
             kSecClass as String: kSecClassKey,
             kSecAttrApplicationTag as String: tag,
             kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
-            kSecReturnRef as String: true,
+            kSecReturnRef as String: true
         ]
 
         if let accessGroup = accessGroup {
@@ -103,7 +101,7 @@ public class KeyManager: NSObject, SpruceIDMobileSdkRs.KeyStore, ObservableObjec
             kSecClass as String: kSecClassKey,
             kSecAttrApplicationTag as String: tag,
             kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
-            kSecReturnRef as String: true,
+            kSecReturnRef as String: true
         ]
 
         if let accessGroup = accessGroup {
@@ -142,8 +140,8 @@ public class KeyManager: NSObject, SpruceIDMobileSdkRs.KeyStore, ObservableObjec
             kSecPrivateKeyAttrs as String: [
                 kSecAttrIsPermanent as String: true,
                 kSecAttrApplicationTag as String: tag,
-                kSecAttrAccessControl as String: access,
-            ],
+                kSecAttrAccessControl as String: access
+            ]
         ]
 
         // Set the access group, if it exists.
@@ -184,7 +182,7 @@ public class KeyManager: NSObject, SpruceIDMobileSdkRs.KeyStore, ObservableObjec
             "crv": "P-256",
             "alg": "ES256",
             "x": xCoordinate,
-            "y": yCoordinate,
+            "y": yCoordinate
         ]
 
         guard let jsonData = try? JSONSerialization.data(withJSONObject: jsonObject, options: [])
@@ -224,8 +222,7 @@ public class KeyManager: NSObject, SpruceIDMobileSdkRs.KeyStore, ObservableObjec
      * Signs the provided payload with a ecdsaSignatureMessageX962SHA256 private key.
      */
     public static func signPayload(id: String, payload: [UInt8], accessGroup: String? = nil)
-        -> [UInt8]?
-    {
+        -> [UInt8]? {
         guard let key = getSecretKey(id: id, accessGroup: accessGroup) else { return nil }
 
         guard let data = CFDataCreate(kCFAllocatorDefault, payload, payload.count) else {
@@ -269,8 +266,8 @@ public class KeyManager: NSObject, SpruceIDMobileSdkRs.KeyStore, ObservableObjec
             kSecPrivateKeyAttrs as String: [
                 kSecAttrIsPermanent as String: true,
                 kSecAttrApplicationTag as String: tag,
-                kSecAttrAccessControl as String: access,
-            ],
+                kSecAttrAccessControl as String: access
+            ]
         ]
 
         // Set the access group, if it exists.
@@ -321,8 +318,7 @@ public class KeyManager: NSObject, SpruceIDMobileSdkRs.KeyStore, ObservableObjec
      * Decrypts the provided payload by a key id and initialization vector.
      */
     public static func decryptPayload(id: String, payload: [UInt8], accessGroup: String? = nil)
-        -> [UInt8]?
-    {
+        -> [UInt8]? {
         guard let key = getSecretKey(id: id, accessGroup: accessGroup) else { return nil }
 
         guard let data = CFDataCreate(kCFAllocatorDefault, payload, payload.count) else {


### PR DESCRIPTION
This pull request enhances the `KeyManager` class in the iOS SDK to support specifying a Keychain access group for all key management operations. This improves flexibility for apps using multiple Keychain groups and enables more granular control over key storage and retrieval. The update adds optional `accessGroup` parameters to most static methods and ensures all relevant Keychain queries and mutations respect this parameter.

Keychain Access Group Support:

* Added an optional `accessGroup` parameter to all key management methods in `KeyManager`, including key generation, retrieval, signing, encryption, and decryption, so that keys can be managed in specific Keychain access groups. All relevant Keychain queries and attributes now use this parameter if provided. [[1]](diffhunk://#diff-46b7086a66988a0e7fb2a085c6d0d2b56af00f210d2ea311a05c92d40a2d2f3eL47-R91) [[2]](diffhunk://#diff-46b7086a66988a0e7fb2a085c6d0d2b56af00f210d2ea311a05c92d40a2d2f3eL64-R112) [[3]](diffhunk://#diff-46b7086a66988a0e7fb2a085c6d0d2b56af00f210d2ea311a05c92d40a2d2f3eL88-R128) [[4]](diffhunk://#diff-46b7086a66988a0e7fb2a085c6d0d2b56af00f210d2ea311a05c92d40a2d2f3eL105-R153) [[5]](diffhunk://#diff-46b7086a66988a0e7fb2a085c6d0d2b56af00f210d2ea311a05c92d40a2d2f3eL118-R164) [[6]](diffhunk://#diff-46b7086a66988a0e7fb2a085c6d0d2b56af00f210d2ea311a05c92d40a2d2f3eL155-R201) [[7]](diffhunk://#diff-46b7086a66988a0e7fb2a085c6d0d2b56af00f210d2ea311a05c92d40a2d2f3eL181-R244) [[8]](diffhunk://#diff-46b7086a66988a0e7fb2a085c6d0d2b56af00f210d2ea311a05c92d40a2d2f3eL206-R255) [[9]](diffhunk://#diff-46b7086a66988a0e7fb2a085c6d0d2b56af00f210d2ea311a05c92d40a2d2f3eL223-R280) [[10]](diffhunk://#diff-46b7086a66988a0e7fb2a085c6d0d2b56af00f210d2ea311a05c92d40a2d2f3eL236-R293) [[11]](diffhunk://#diff-46b7086a66988a0e7fb2a085c6d0d2b56af00f210d2ea311a05c92d40a2d2f3eL265-R341)

* Added a new instance method `updateKeychainGroupForKey(id:accessGroup:)` to allow updating the access group for an existing key.

Key Usage Updates:

* Updated the `P256SigningKey` class to accept and store an optional `accessGroup`, and to use it when signing payloads, ensuring signatures use the correct Keychain group.

Code Quality and Consistency:

* Improved code formatting and consistency, such as trailing commas in dictionary literals and better error handling/printing, for easier maintenance and readability. [[1]](diffhunk://#diff-46b7086a66988a0e7fb2a085c6d0d2b56af00f210d2ea311a05c92d40a2d2f3eL6-R57) [[2]](diffhunk://#diff-46b7086a66988a0e7fb2a085c6d0d2b56af00f210d2ea311a05c92d40a2d2f3eL142-R187) [[3]](diffhunk://#diff-46b7086a66988a0e7fb2a085c6d0d2b56af00f210d2ea311a05c92d40a2d2f3eL250-R313)

These changes make the SDK more robust for apps with advanced Keychain usage and improve maintainability.
