### PR TITLE
Bump `ssi` version to 0.14

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,9 +20,9 @@ cose-rs = { git = "https://github.com/spruceid/cose-rs", rev = "0018c9b", featur
     "time",
 ] }
 isomdl = { git = "https://github.com/spruceid/isomdl", rev = "17b6354" }
-oid4vci = { git = "https://github.com/spruceid/oid4vci-rs", rev = "081eb4" }
-openid4vp = { git = "https://github.com/spruceid/openid4vp", rev = "2b0c8ba" }
-ssi = { version = "0.12", features = ["secp256r1", "secp384r1"] }
+oid4vci = { git = "https://github.com/spruceid/oid4vci-rs", rev = "490c135" }
+openid4vp = { git = "https://github.com/spruceid/openid4vp", rev = "2446e70" }
+ssi = { version = "0.14", features = ["secp256r1", "secp384r1"] }
 
 anyhow = "1"
 async-trait = "0.1"
@@ -72,7 +72,7 @@ uniffi = { version = "0.29", features = ["cli", "tokio"] }
 url = { version = "2.5", features = ["serde"] }
 urlencoding = "2.1.3"
 uuid = { version = "1.6.1", features = ["v4"] }
-w3c-vc-barcodes = { git = "https://github.com/spruceid/w3c-vc-barcodes", rev = "18f0b5a" }
+w3c-vc-barcodes = { git = "https://github.com/spruceid/w3c-vc-barcodes", rev = "db34b8e" }
 x509-cert = { version = "0.2.5", features = ["builder", "hazmat"] }
 csv = "1.3.1"
 chrono = { version = "0.4.42", features = ["serde"] }


### PR DESCRIPTION
## Description

Bumps `ssi` to version 0.14, and the dependencies that also depend on `ssi`:
- `oid4vci`
- `openid4vp`
- `w3c-vc-barcodes`