### PR TITLE
mDOC from Issuer Signed Dehydrated Hardening

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -817,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.56"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -836,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.56"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2267,7 +2267,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -2589,7 +2589,7 @@ dependencies = [
 [[package]]
 name = "isomdl"
 version = "0.2.0"
-source = "git+https://github.com/spruceid/isomdl?rev=17b6354#17b63542711754bda519ee59456ee888e6bdcb00"
+source = "git+https://github.com/spruceid/isomdl?rev=930d8c2#930d8c2a426db3b63f64cf70c594cbcbb836da80"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "isomdl-macros"
 version = "0.1.0"
-source = "git+https://github.com/spruceid/isomdl?rev=17b6354#17b63542711754bda519ee59456ee888e6bdcb00"
+source = "git+https://github.com/spruceid/isomdl?rev=930d8c2#930d8c2a426db3b63f64cf70c594cbcbb836da80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4453,7 +4453,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -7107,9 +7107,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7544,18 +7544,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.37"
+version = "0.8.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
+checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.37"
+version = "0.8.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
+checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,7 +19,7 @@ path = "uniffi-bindgen.rs"
 cose-rs = { git = "https://github.com/spruceid/cose-rs", rev = "0018c9b", features = [
     "time",
 ] }
-isomdl = { git = "https://github.com/spruceid/isomdl", rev = "17b6354" }
+isomdl = { git = "https://github.com/spruceid/isomdl", rev = "930d8c2" }
 oid4vci = { git = "https://github.com/spruceid/oid4vci-rs", rev = "e64ae8d", features = ["ssi", "integer-ts"] }
 openid4vp = { git = "https://github.com/spruceid/openid4vp", rev = "6127287" }
 ssi = { version = "0.14", features = ["secp256r1", "secp384r1"] }

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -7191,6 +7191,24 @@ public static func fromCborEncodedDocument(cborEncodedDocument: Data, keyAlias: 
 }
     
     /**
+     * Construct a new MDoc from IssuerSigned CBOR bytes.
+     *
+     * Provisioned data represents the element values in the issuer signed namespaces.
+     * If provisioned data exists, it will update the issuer signed namespace values
+     * with the provisioned data.
+     */
+public static func fromCborEncodedIssuerSignedDehydratedWithId(id: Uuid, cborEncodedIssuerSignedDehydrated: Data, namespacedData: Data, keyAlias: KeyAlias)throws  -> Mdoc  {
+    return try  FfiConverterTypeMdoc_lift(try rustCallWithError(FfiConverterTypeMdocInitError_lift) {
+    uniffi_mobile_sdk_rs_fn_constructor_mdoc_from_cbor_encoded_issuer_signed_dehydrated_with_id(
+        FfiConverterTypeUuid_lower(id),
+        FfiConverterData.lower(cborEncodedIssuerSignedDehydrated),
+        FfiConverterData.lower(namespacedData),
+        FfiConverterTypeKeyAlias_lower(keyAlias),$0
+    )
+})
+}
+    
+    /**
      * Compatibility feature: construct an MDoc from a
      * [stringified spruceid/isomdl `Document`](https://github.com/spruceid/isomdl/blob/main/src/presentation/mod.rs#L100)
      */
@@ -26475,6 +26493,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_constructor_mdoc_from_cbor_encoded_document() != 32979) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mobile_sdk_rs_checksum_constructor_mdoc_from_cbor_encoded_issuer_signed_dehydrated_with_id() != 49071) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_constructor_mdoc_from_stringified_document() != 58042) {


### PR DESCRIPTION
This pull request introduces a new constructor for creating `Mdoc` instances from issuer-signed CBOR data with a specified UUID, refactors related Rust and Swift code to support this, and adds comprehensive tests to ensure data integrity through serialization and deserialization cycles. Additionally, it updates the `isomdl` dependency to a newer revision.

**New Mdoc construction and API changes:**

* Added a new Rust constructor `from_cbor_encoded_issuer_signed_dehydrated_with_id` in `mdoc.rs`, allowing creation of an `Mdoc` with a specified UUID, and refactored internal logic to use this method for improved flexibility and testability. [[1]](diffhunk://#diff-570c43c4adf4727ca07e3677c67adac35594f03d483ffb45d946b01dfa4fbcc7L87-R112) [[2]](diffhunk://#diff-570c43c4adf4727ca07e3677c67adac35594f03d483ffb45d946b01dfa4fbcc7L407-R455)
* Exposed the new constructor to Swift by adding `fromCborEncodedIssuerSignedDehydratedWithId` to `mobile_sdk_rs.swift`, enabling mobile clients to use the new API.
* Updated API checksum validation in Swift to include the new constructor, ensuring version compatibility.

**Testing and reliability improvements:**

* Added a comprehensive roundtrip test in `mdoc.rs` to verify that mdoc element values are preserved through encoding, storage, serialization, and deserialization, ensuring data integrity.
* Refactored test setup to reuse base64 test data and expanded test coverage for the new constructor.

**Dependency updates:**

* Updated the `isomdl` crate dependency in `Cargo.toml` to a newer revision, pulling in upstream improvements and fixes.