### PR TITLE
Update isomdl for NFC reader handover updates

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2743,7 +2743,7 @@ dependencies = [
 [[package]]
 name = "isomdl"
 version = "0.2.0"
-source = "git+https://github.com/spruceid/isomdl?rev=909c361#909c361e443e5e5843a726a3e9cf8cf35e0c4bec"
+source = "git+https://github.com/spruceid/isomdl?rev=a4f92cc#a4f92ccd4a8f4ef5e0e11fe4fa6c3320cce707bf"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2763,7 +2763,7 @@ dependencies = [
  "hex",
  "hkdf",
  "hmac",
- "isomdl-macros 0.1.0 (git+https://github.com/spruceid/isomdl?rev=909c361)",
+ "isomdl-macros 0.1.0 (git+https://github.com/spruceid/isomdl?rev=a4f92cc)",
  "ndef-rs",
  "p256",
  "p384",
@@ -2799,7 +2799,7 @@ dependencies = [
 [[package]]
 name = "isomdl-macros"
 version = "0.1.0"
-source = "git+https://github.com/spruceid/isomdl?rev=909c361#909c361e443e5e5843a726a3e9cf8cf35e0c4bec"
+source = "git+https://github.com/spruceid/isomdl?rev=a4f92cc#a4f92ccd4a8f4ef5e0e11fe4fa6c3320cce707bf"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "mobile-sdk-rs"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,7 +19,7 @@ path = "uniffi-bindgen.rs"
 cose-rs = { git = "https://github.com/spruceid/cose-rs", rev = "0018c9b", features = [
     "time",
 ] }
-isomdl = { git = "https://github.com/spruceid/isomdl", rev = "909c361" }
+isomdl = { git = "https://github.com/spruceid/isomdl", rev = "a4f92cc" }
 oid4vci = { git = "https://github.com/spruceid/oid4vci-rs", rev = "e64ae8d", features = ["ssi", "integer-ts"] }
 oid4vci_legacy = { package = "oid4vci", git = "https://github.com/spruceid/oid4vci-rs", rev = "490c135" }
 openid4vp = { git = "https://github.com/spruceid/openid4vp", rev = "6127287" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobile-sdk-rs"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
Bump isomdl to get the following changes:
* Add support for negotiated NFC handover
* Add support for out-of-order NDEF records