### PR TITLE
Update OID4VP Version Configuration to Facade

### DIFF
--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -10686,6 +10686,8 @@ public protocol Oid4vpHolderProtocol: AnyObject, Sendable {
     
     func start(request: String) async throws  -> Oid4vpSession
     
+    func startWithCompatibilityMode(request: String, compatibilityMode: Oid4vpCompatibilityMode) async throws  -> Oid4vpSession
+    
 }
 open class Oid4vpHolder: Oid4vpHolderProtocol, @unchecked Sendable {
     fileprivate let handle: UInt64
@@ -10812,6 +10814,23 @@ open func start(request: String)async throws  -> Oid4vpSession  {
                 uniffi_mobile_sdk_rs_fn_method_oid4vpholder_start(
                     self.uniffiCloneHandle(),
                     FfiConverterString.lower(request)
+                )
+            },
+            pollFunc: ffi_mobile_sdk_rs_rust_future_poll_u64,
+            completeFunc: ffi_mobile_sdk_rs_rust_future_complete_u64,
+            freeFunc: ffi_mobile_sdk_rs_rust_future_free_u64,
+            liftFunc: FfiConverterTypeOid4vpSession_lift,
+            errorHandler: FfiConverterTypeOid4vpFacadeError_lift
+        )
+}
+    
+open func startWithCompatibilityMode(request: String, compatibilityMode: Oid4vpCompatibilityMode)async throws  -> Oid4vpSession  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_mobile_sdk_rs_fn_method_oid4vpholder_start_with_compatibility_mode(
+                    self.uniffiCloneHandle(),
+                    FfiConverterString.lower(request),FfiConverterTypeOid4vpCompatibilityMode_lower(compatibilityMode)
                 )
             },
             pollFunc: ffi_mobile_sdk_rs_rust_future_poll_u64,
@@ -24761,6 +24780,80 @@ public func FfiConverterTypeOid4vciVersion_lower(_ value: Oid4vciVersion) -> Rus
 }
 
 
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
+public enum Oid4vpCompatibilityMode: Equatable, Hashable {
+    
+    case auto
+    case v1
+    case draft18
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension Oid4vpCompatibilityMode: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeOid4vpCompatibilityMode: FfiConverterRustBuffer {
+    typealias SwiftType = Oid4vpCompatibilityMode
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Oid4vpCompatibilityMode {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .auto
+        
+        case 2: return .v1
+        
+        case 3: return .draft18
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: Oid4vpCompatibilityMode, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .auto:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .v1:
+            writeInt(&buf, Int32(2))
+        
+        
+        case .draft18:
+            writeInt(&buf, Int32(3))
+        
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeOid4vpCompatibilityMode_lift(_ buf: RustBuffer) throws -> Oid4vpCompatibilityMode {
+    return try FfiConverterTypeOid4vpCompatibilityMode.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeOid4vpCompatibilityMode_lower(_ value: Oid4vpCompatibilityMode) -> RustBuffer {
+    return FfiConverterTypeOid4vpCompatibilityMode.lower(value)
+}
+
+
 
 public enum Oid4vpFacadeError: Swift.Error, Equatable, Hashable, Foundation.LocalizedError {
 
@@ -32210,6 +32303,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_oid4vpholder_start() != 11945) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mobile_sdk_rs_checksum_method_oid4vpholder_start_with_compatibility_mode() != 60396) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_oid4vppermissionresponse_selected_credentials() != 5574) {

--- a/rust/src/oid4vp/facade.rs
+++ b/rust/src/oid4vp/facade.rs
@@ -63,6 +63,17 @@ pub struct Oid4vpResponseOptions {
 #[deprecated(
     note = "Compatibility facade for legacy OID4VP integrations only. Prefer the OID4VP v1 APIs for new integrations; this facade may be removed in a future release."
 )]
+#[derive(uniffi::Enum, Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Oid4vpCompatibilityMode {
+    #[default]
+    Auto,
+    V1,
+    Draft18,
+}
+
+#[deprecated(
+    note = "Compatibility facade for legacy OID4VP integrations only. Prefer the OID4VP v1 APIs for new integrations; this facade may be removed in a future release."
+)]
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct Oid4vpRequestedField {
     pub id: uuid::Uuid,
@@ -284,7 +295,22 @@ impl Oid4vpHolder {
     }
 
     pub async fn start(&self, request: String) -> Result<Arc<Oid4vpSession>, Oid4vpFacadeError> {
-        match get_oid4vp_version(request.clone()) {
+        self.start_with_compatibility_mode(request, Oid4vpCompatibilityMode::Auto)
+            .await
+    }
+
+    pub async fn start_with_compatibility_mode(
+        &self,
+        request: String,
+        compatibility_mode: Oid4vpCompatibilityMode,
+    ) -> Result<Arc<Oid4vpSession>, Oid4vpFacadeError> {
+        let version = match compatibility_mode {
+            Oid4vpCompatibilityMode::Auto => get_oid4vp_version(request.clone()),
+            Oid4vpCompatibilityMode::V1 => Oid4vpVersion::V1,
+            Oid4vpCompatibilityMode::Draft18 => Oid4vpVersion::Draft18,
+        };
+
+        match version {
             Oid4vpVersion::V1 => {
                 let holder = self.new_v1_holder().await?;
                 let permission_request = holder
@@ -873,6 +899,71 @@ mod tests {
         .to_string()
     }
 
+    fn hybrid_request() -> String {
+        json!({
+            "client_id": "redirect_uri:https://wallet.example/callback",
+            "client_id_scheme": "redirect_uri",
+            "response_uri": "https://wallet.example/callback",
+            "response_type": "vp_token",
+            "response_mode": "direct_post",
+            "state": "state-hybrid",
+            "nonce": "nonce-hybrid",
+            "client_metadata": {
+                "vp_formats": {
+                    "ldp_vp": {
+                        "proof_type": ["ecdsa-rdfc-2019"]
+                    }
+                }
+            },
+            "dcql_query": {
+                "credentials": [
+                    {
+                        "id": "alumni_vc_0",
+                        "format": "ldp_vc",
+                        "claims": [
+                            {
+                                "path": ["credentialSubject", "alumniOf", "name"],
+                                "intent_to_retain": true
+                            }
+                        ]
+                    }
+                ],
+                "credential_sets": [
+                    {
+                        "options": [["alumni_vc_0"]]
+                    }
+                ]
+            },
+            "presentation_definition": {
+                "id": "pd-alumni",
+                "purpose": "Prove university alumni status",
+                "input_descriptors": [
+                    {
+                        "id": "alumni_descriptor",
+                        "name": "Alumni Credential",
+                        "purpose": "Prove university alumni status",
+                        "format": {
+                            "ldp_vc": {
+                                "proof_type": ["DataIntegrityProof"]
+                            }
+                        },
+                        "constraints": {
+                            "fields": [
+                                {
+                                    "path": ["$.credentialSubject.alumniOf.name"],
+                                    "name": "Alumni organization",
+                                    "purpose": "Verify alumni relationship",
+                                    "intent_to_retain": true
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        })
+        .to_string()
+    }
+
     #[test]
     fn facade_wraps_v1_presentable_credentials() {
         let parsed = alumni_credential();
@@ -922,6 +1013,48 @@ mod tests {
             .start("openid4vp://?client_id=test&nonce=123".into())
             .await;
         assert!(matches!(err, Err(Oid4vpFacadeError::UnsupportedRequest)));
+    }
+
+    #[tokio::test]
+    async fn facade_holder_can_force_v1_mode() {
+        let credential = alumni_credential();
+        let holder = Oid4vpHolder::new_with_credentials(
+            vec![credential],
+            Vec::new(),
+            Box::new(TestSigner { jwk: load_jwk() }),
+            Some(default_ld_json_context()),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let session = holder
+            .start_with_compatibility_mode(hybrid_request(), Oid4vpCompatibilityMode::V1)
+            .await
+            .unwrap();
+
+        assert_eq!(session.version(), Oid4vpVersion::V1);
+    }
+
+    #[tokio::test]
+    async fn facade_holder_can_force_draft18_mode() {
+        let credential = alumni_credential();
+        let holder = Oid4vpHolder::new_with_credentials(
+            vec![credential],
+            Vec::new(),
+            Box::new(TestSigner { jwk: load_jwk() }),
+            Some(default_ld_json_context()),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let session = holder
+            .start_with_compatibility_mode(hybrid_request(), Oid4vpCompatibilityMode::Draft18)
+            .await
+            .unwrap();
+
+        assert_eq!(session.version(), Oid4vpVersion::Draft18);
     }
 
     #[tokio::test]


### PR DESCRIPTION
This PR updates the OID4VP facade to allow the consumer to specify either Auto, Draft or Version 1.

It also includes updated tests to handle these scenarios, and the regenerated swift bindings.