### PR TITLE
Make QRCode Scanner a little more customizable

### DIFF
--- a/android/MobileSdk/build.gradle.kts
+++ b/android/MobileSdk/build.gradle.kts
@@ -89,9 +89,9 @@ publishing {
     }
 }
 
-// Skip signing for local-only publications.  CLAUDE.md note:
-// `-PskipSigning` is the standard local-dev escape hatch — revert never
-// needed (it's a no-op in CI / release builds where the property is unset).
+// Skip GPG signing for local-only publications.
+// Usage (local dev, e.g. publishToMavenLocal): `./gradlew <task> -PskipSigning`
+// No-op in CI / release builds where the property is unset.
 if (!project.hasProperty("skipSigning")) {
     signing {
         useGpgCmd()

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ui/GenericCameraXScanner.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ui/GenericCameraXScanner.kt
@@ -53,7 +53,8 @@ fun GenericCameraXScanner(
     imageAnalyzer: ImageAnalysis.Analyzer,
     imageAnalysisTargetResolution: Size? = null,
     zoomRatio: Float = 2f,
-    background: @Composable () -> Unit
+    background: @Composable () -> Unit,
+    onCameraReady: (() -> Unit)? = null
 ) {
     val context = LocalContext.current
     val cameraProviderFuture =
@@ -70,6 +71,15 @@ fun GenericCameraXScanner(
 
     fun setupCamera(context: Context): PreviewView {
         val previewView = PreviewView(context)
+        if (onCameraReady != null) {
+            var fired = false
+            previewView.previewStreamState.observe(lifecycleOwner) { state ->
+                if (!fired && state == PreviewView.StreamState.STREAMING) {
+                    fired = true
+                    onCameraReady.invoke()
+                }
+            }
+        }
         val preview =
             Preview.Builder()
                 .setTargetFrameRate(Range(20, 45))

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ui/MRZScanner.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ui/MRZScanner.kt
@@ -50,6 +50,7 @@ fun MRZScanner(
     guidesColor: Color = Color.White,
     readerColor: Color = Color.White,
     backgroundOpacity: Float = 0.5f,
+    onCameraReady: (() -> Unit)? = null,
 ) {
 
     val textRecognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
@@ -126,7 +127,8 @@ fun MRZScanner(
                 readerColor = readerColor,
                 backgroundOpacity = backgroundOpacity,
             )
-        }
+        },
+        onCameraReady = onCameraReady
     )
 }
 

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ui/PDF417Scanner.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ui/PDF417Scanner.kt
@@ -55,6 +55,7 @@ fun PDF417Scanner(
     guidesColor: Color = Color.White,
     readerColor: Color = Color.White,
     backgroundOpacity: Float = 0.5f,
+    onCameraReady: (() -> Unit)? = null,
 ) {
 
     GenericCameraXScanner(
@@ -79,7 +80,8 @@ fun PDF417Scanner(
                 readerColor = readerColor,
                 backgroundOpacity = backgroundOpacity,
             )
-        }
+        },
+        onCameraReady = onCameraReady
     )
 }
 

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ui/QRCodeScanner.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ui/QRCodeScanner.kt
@@ -71,7 +71,8 @@ fun QRCodeScanner(
     backgroundColor: Color = Color.White,
     backgroundOpacity: Float = 1f,
     instructions: String = "",
-    instructionsDefaultColor: Color = Color.Gray
+    instructionsDefaultColor: Color = Color.Gray,
+    scanCooldownMs: Long = 0L
 ) {
 
     GenericCameraXScanner(
@@ -89,7 +90,9 @@ fun QRCodeScanner(
             isMatch = isMatch,
             onQrCodeScanned = { result ->
                 onRead(result)
-            }),
+            },
+            scanCooldownMs = scanCooldownMs,
+        ),
         background = {
             QRCodeScannerBackground(
                 guidesText = guidesText,
@@ -185,50 +188,52 @@ fun QRCodeScannerBackground(
         )
 
         // Blue pill component with loader and text
-        Box(
-            modifier = Modifier
-                .align(Alignment.TopCenter)
-                .offset {
-                    IntOffset(
-                        0,
-                        (guidesMessageOffsetTop - (bluePillHeight / 2) - 10.dp.toPx()).toInt() // offset - height - padding
+        if (guidesText.isNotEmpty()) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .offset {
+                        IntOffset(
+                            0,
+                            (guidesMessageOffsetTop - (bluePillHeight / 2) - 10.dp.toPx()).toInt() // offset - height - padding
+                        )
+                    }
+                    .background(
+                        color = guidesColor,
+                        shape = RoundedCornerShape(100f)
                     )
-                }
-                .background(
-                    color = guidesColor,
-                    shape = RoundedCornerShape(100f)
-                )
-                .padding(horizontal = 20.dp, vertical = 10.dp)
-                .onGloballyPositioned { coordinates ->
-                    bluePillHeight = coordinates.size.height.toFloat()
-                },
-            contentAlignment = Alignment.Center
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    .padding(horizontal = 20.dp, vertical = 10.dp)
+                    .onGloballyPositioned { coordinates ->
+                        bluePillHeight = coordinates.size.height.toFloat()
+                    },
+                contentAlignment = Alignment.Center
             ) {
-                // Rotating loader
-                Box(
-                    modifier = Modifier.size(20.dp),
-                    contentAlignment = Alignment.Center
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(16.dp),
-                        color = Color.Gray.copy(alpha = 0.6f),
-                        trackColor = Color.White,
-                        strokeWidth = 2.dp
+                    // Rotating loader
+                    Box(
+                        modifier = Modifier.size(20.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            color = Color.Gray.copy(alpha = 0.6f),
+                            trackColor = Color.White,
+                            strokeWidth = 2.dp
+                        )
+                    }
+
+                    // Text
+                    Text(
+                        text = guidesText,
+                        color = Color.White,
+                        fontSize = 16.sp,
+                        fontFamily = fontFamily,
+                        fontWeight = FontWeight.Normal
                     )
                 }
-
-                // Text
-                Text(
-                    text = guidesText,
-                    color = Color.White,
-                    fontSize = 16.sp,
-                    fontFamily = fontFamily,
-                    fontWeight = FontWeight.Normal
-                )
             }
         }
 
@@ -256,9 +261,12 @@ fun QRCodeScannerBackground(
 class QrCodeAnalyzer(
     private val onQrCodeScanned: (String) -> Unit,
     private val isMatch: (content: String) -> Boolean = { _ -> true },
+    private val scanCooldownMs: Long = 0L,
 ) : ImageAnalysis.Analyzer {
 
     private val supportedImageFormats = mutableListOf(ImageFormat.YUV_420_888)
+    @Volatile
+    private var lastReadAt: Long = 0L
 
     init {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
@@ -290,7 +298,11 @@ class QrCodeAnalyzer(
             try {
                 val result = QRCodeReader().decode(binaryBmp, hints)
                 if (isMatch(result.text)) {
-                    onQrCodeScanned(result.text)
+                    val now = System.currentTimeMillis()
+                    if (scanCooldownMs <= 0L || now - lastReadAt >= scanCooldownMs) {
+                        lastReadAt = now
+                        onQrCodeScanned(result.text)
+                    }
                 }
             } catch (e: Exception) {
                 e.printStackTrace()

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ui/QRCodeScanner.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ui/QRCodeScanner.kt
@@ -72,7 +72,8 @@ fun QRCodeScanner(
     backgroundOpacity: Float = 1f,
     instructions: String = "",
     instructionsDefaultColor: Color = Color.Gray,
-    scanCooldownMs: Long = 0L
+    scanCooldownMs: Long = 0L,
+    onCameraReady: (() -> Unit)? = null
 ) {
 
     GenericCameraXScanner(
@@ -104,7 +105,8 @@ fun QRCodeScanner(
                 instructionsDefaultColor = instructionsDefaultColor,
                 fontFamily = fontFamily
             )
-        }
+        },
+        onCameraReady = onCameraReady
     )
 }
 

--- a/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/ScannerPlatformView.kt
+++ b/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/ScannerPlatformView.kt
@@ -106,6 +106,9 @@ class ScannerPlatformView(
                     onCancel = {
                         channel.invokeMethod("onCancel", null)
                     },
+                    onCameraReady = {
+                        channel.invokeMethod("onCameraReady", null)
+                    },
                     backgroundOpacity = backgroundOpacity,
                     guidesColor = Color(guidesColorArgb),
                     readerColor = Color(readerColorArgb),
@@ -198,6 +201,7 @@ private fun ScannerContent(
     hideCancelButton: Boolean,
     onRead: (String) -> Unit,
     onCancel: () -> Unit,
+    onCameraReady: () -> Unit,
     backgroundOpacity: Float,
     guidesColor: Color,
     readerColor: Color,
@@ -217,7 +221,8 @@ private fun ScannerContent(
             readerColor = readerColor,
             guidesText = guidesText,
             instructions = instructions,
-            scanCooldownMs = scanCooldownMs
+            scanCooldownMs = scanCooldownMs,
+            onCameraReady = onCameraReady
         )
         // ML Kit-backed scanner with the same camera tuning the native
         // SD-JWT verifier showcase uses (4K analysis stream, no zoom).
@@ -234,7 +239,8 @@ private fun ScannerContent(
             subtitle = subtitle,
             onRead = onRead,
             onCancel = onCancel,
-            hideCancelButton = hideCancelButton
+            hideCancelButton = hideCancelButton,
+            onCameraReady = onCameraReady
         )
         // ML Kit-backed scanner with the same camera tuning the SD-JWT
         // verifier uses (4K analysis, no zoom). Required for dense
@@ -251,7 +257,8 @@ private fun ScannerContent(
             subtitle = subtitle,
             onRead = onRead,
             onCancel = onCancel,
-            hideCancelButton = hideCancelButton
+            hideCancelButton = hideCancelButton,
+            onCameraReady = onCameraReady
         )
         else -> QRCodeScanner(
             title = title,
@@ -264,7 +271,8 @@ private fun ScannerContent(
             readerColor = readerColor,
             guidesText = guidesText,
             instructions = instructions,
-            scanCooldownMs = scanCooldownMs
+            scanCooldownMs = scanCooldownMs,
+            onCameraReady = onCameraReady
         )
     }
 }

--- a/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/ScannerPlatformView.kt
+++ b/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/ScannerPlatformView.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.widget.FrameLayout
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Recomposer
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.AndroidUiDispatcher
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.compositionContext
@@ -71,6 +72,12 @@ class ScannerPlatformView(
     private val title: String = creationParams?.get("title") as? String ?: "Scan QR Code"
     private val subtitle: String = creationParams?.get("subtitle") as? String ?: "Please align within the guides"
     private val showCancelButton: Boolean = creationParams?.get("showCancelButton") as? Boolean ?: true
+    private val backgroundOpacity: Float = (creationParams?.get("backgroundOpacity") as? Double)?.toFloat() ?: 1.0f
+    private val guidesColorArgb: Int = (creationParams?.get("guidesColor") as? Int) ?: 0xFF2563EB.toInt()
+    private val readerColorArgb: Int = (creationParams?.get("readerColor") as? Int) ?: 0xFFFFFFFF.toInt()
+    private val guidesText: String = (creationParams?.get("guidesText") as? String) ?: "Detecting..."
+    private val instructions: String = (creationParams?.get("instructions") as? String) ?: ""
+    private val scanCooldownMs: Long = ((creationParams?.get("scanCooldownMs") as? Number)?.toLong()) ?: 0L
 
     // Create the lifecycle-aware container
     private val lifecycleOwnerView = ComposeLifecycleOwnerView(context)
@@ -98,7 +105,13 @@ class ScannerPlatformView(
                     },
                     onCancel = {
                         channel.invokeMethod("onCancel", null)
-                    }
+                    },
+                    backgroundOpacity = backgroundOpacity,
+                    guidesColor = Color(guidesColorArgb),
+                    readerColor = Color(readerColorArgb),
+                    guidesText = guidesText,
+                    instructions = instructions,
+                    scanCooldownMs = scanCooldownMs
                 )
             }
         }
@@ -184,7 +197,13 @@ private fun ScannerContent(
     subtitle: String,
     hideCancelButton: Boolean,
     onRead: (String) -> Unit,
-    onCancel: () -> Unit
+    onCancel: () -> Unit,
+    backgroundOpacity: Float,
+    guidesColor: Color,
+    readerColor: Color,
+    guidesText: String,
+    instructions: String,
+    scanCooldownMs: Long
 ) {
     when (scannerType) {
         "qrCode" -> QRCodeScanner(
@@ -192,7 +211,13 @@ private fun ScannerContent(
             subtitle = subtitle,
             onRead = onRead,
             onCancel = onCancel,
-            hideCancelButton = hideCancelButton
+            hideCancelButton = hideCancelButton,
+            backgroundOpacity = backgroundOpacity,
+            guidesColor = guidesColor,
+            readerColor = readerColor,
+            guidesText = guidesText,
+            instructions = instructions,
+            scanCooldownMs = scanCooldownMs
         )
         // ML Kit-backed scanner with the same camera tuning the native
         // SD-JWT verifier showcase uses (4K analysis stream, no zoom).
@@ -233,7 +258,13 @@ private fun ScannerContent(
             subtitle = subtitle,
             onRead = onRead,
             onCancel = onCancel,
-            hideCancelButton = hideCancelButton
+            hideCancelButton = hideCancelButton,
+            backgroundOpacity = backgroundOpacity,
+            guidesColor = guidesColor,
+            readerColor = readerColor,
+            guidesText = guidesText,
+            instructions = instructions,
+            scanCooldownMs = scanCooldownMs
         )
     }
 }

--- a/flutter/example/android/settings.gradle.kts
+++ b/flutter/example/android/settings.gradle.kts
@@ -17,6 +17,19 @@ pluginManagement {
     }
 }
 
+// Local-only: build the SpruceKit Android SDK from source instead of consuming
+// the published Maven Central artifact. Lets you iterate on `android/MobileSdk`
+// (and `android/MobileSdkRs`) and have `flutter run` pick up the changes
+// without `publishToMavenLocal`. Remove or comment out for normal builds.
+includeBuild("../../../android") {
+    dependencySubstitution {
+        substitute(module("com.spruceid.mobile.sdk:mobilesdk"))
+            .using(project(":MobileSdk"))
+        substitute(module("com.spruceid.mobile.sdk.rs:mobilesdkrs"))
+            .using(project(":MobileSdkRs"))
+    }
+}
+
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.11.1" apply false

--- a/flutter/example/ios/Podfile.lock
+++ b/flutter/example/ios/Podfile.lock
@@ -7,15 +7,15 @@ PODS:
     - Flutter
   - share_plus (0.0.1):
     - Flutter
-  - SpruceIDMobileSdk (0.15.4):
-    - SpruceIDMobileSdkRs (~> 0.15.4)
+  - SpruceIDMobileSdk (0.15.5):
+    - SpruceIDMobileSdkRs (~> 0.15.5)
     - SwiftAlgorithms (~> 1.0.0)
-  - SpruceIDMobileSdkRs (0.15.4):
-    - SpruceIDMobileSdkRsRustFramework (= 0.15.4)
-  - SpruceIDMobileSdkRsRustFramework (0.15.4)
-  - sprucekit_mobile (0.15.4):
+  - SpruceIDMobileSdkRs (0.15.5):
+    - SpruceIDMobileSdkRsRustFramework (= 0.15.5)
+  - SpruceIDMobileSdkRsRustFramework (0.15.5)
+  - sprucekit_mobile (0.15.5):
     - Flutter
-    - SpruceIDMobileSdk (~> 0.15.4)
+    - SpruceIDMobileSdk (~> 0.15.5)
   - SwiftAlgorithms (1.0.0)
 
 DEPENDENCIES:
@@ -56,10 +56,10 @@ SPEC CHECKSUMS:
   path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
   permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
-  SpruceIDMobileSdk: 61c1278c6d12a87fc84bc37cbe26bb80d52e806f
-  SpruceIDMobileSdkRs: 8438aaea8a421293dabc87d722236318674610af
-  SpruceIDMobileSdkRsRustFramework: fe6afb73b8cf3782aacf321a993550473ea5c575
-  sprucekit_mobile: 2172658d82ae4856b944ebe2d3ea6cfbeffcfe5d
+  SpruceIDMobileSdk: 9d5aad5a07db07c385394a2b13abfd5396676eea
+  SpruceIDMobileSdkRs: a62cc4a697371386073e026feba8bdc6874c4a70
+  SpruceIDMobileSdkRsRustFramework: 98015a06f5b65cbec2fce80bac31dbfc9a6ec4e7
+  sprucekit_mobile: 8fd47b2cd435b4228836a1b8afb6cfdb23b854e9
   SwiftAlgorithms: 38dda4731d19027fdeee1125f973111bf3386b53
 
 PODFILE CHECKSUM: b69b363296c914f73d8c30eef22e70abce1812bc

--- a/flutter/example/pubspec.lock
+++ b/flutter/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -156,18 +156,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -355,7 +355,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.15.4"
+    version: "0.15.5"
   stack_trace:
     dependency: transitive
     description:
@@ -392,10 +392,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:

--- a/flutter/example/pubspec.lock
+++ b/flutter/example/pubspec.lock
@@ -355,7 +355,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.15.3"
+    version: "0.15.4"
   stack_trace:
     dependency: transitive
     description:

--- a/flutter/ios/Classes/ScannerPlatformView.swift
+++ b/flutter/ios/Classes/ScannerPlatformView.swift
@@ -79,6 +79,13 @@ class ScannerPlatformView: NSObject, FlutterPlatformView {
         super.init()
 
         createHostingController()
+
+        // iOS uses UIKitView composition where Flutter widgets composite correctly
+        // above the platform view, so a real first-frame signal is unnecessary.
+        // Fire on next runloop turn so listeners attached after construction still receive it.
+        DispatchQueue.main.async { [weak self] in
+            self?.channel.invokeMethod("onCameraReady", arguments: nil)
+        }
     }
 
     func view() -> UIView {

--- a/flutter/ios/Classes/ScannerPlatformView.swift
+++ b/flutter/ios/Classes/ScannerPlatformView.swift
@@ -3,6 +3,14 @@ import SpruceIDMobileSdk
 import SwiftUI
 import UIKit
 
+private func colorFromArgb(_ argb: Int) -> Color {
+    let alpha = Double((argb >> 24) & 0xFF) / 255.0
+    let red = Double((argb >> 16) & 0xFF) / 255.0
+    let green = Double((argb >> 8) & 0xFF) / 255.0
+    let blue = Double(argb & 0xFF) / 255.0
+    return Color(.sRGB, red: red, green: green, blue: blue, opacity: alpha)
+}
+
 /// Factory for creating scanner platform views
 class ScannerPlatformViewFactory: NSObject, FlutterPlatformViewFactory {
     private var messenger: FlutterBinaryMessenger
@@ -39,6 +47,12 @@ class ScannerPlatformView: NSObject, FlutterPlatformView {
     private let title: String
     private let subtitle: String
     private let showCancelButton: Bool
+    private let backgroundOpacity: Double
+    private let guidesColorArgb: Int
+    private let readerColorArgb: Int
+    private let guidesText: String
+    private let instructions: String
+    private let scanCooldownMs: Int
 
     init(
         frame: CGRect,
@@ -55,6 +69,12 @@ class ScannerPlatformView: NSObject, FlutterPlatformView {
         self.title = args?["title"] as? String ?? "Scan QR Code"
         self.subtitle = args?["subtitle"] as? String ?? "Please align within the guides"
         self.showCancelButton = args?["showCancelButton"] as? Bool ?? true
+        self.backgroundOpacity = (args?["backgroundOpacity"] as? Double) ?? 1.0
+        self.guidesColorArgb = (args?["guidesColor"] as? Int) ?? 0xFF2563EB
+        self.readerColorArgb = (args?["readerColor"] as? Int) ?? 0xFFFFFFFF
+        self.guidesText = (args?["guidesText"] as? String) ?? "Detecting..."
+        self.instructions = (args?["instructions"] as? String) ?? ""
+        self.scanCooldownMs = (args?["scanCooldownMs"] as? Int) ?? 0
 
         super.init()
 
@@ -90,7 +110,13 @@ class ScannerPlatformView: NSObject, FlutterPlatformView {
                     subtitle: subtitle,
                     onRead: onRead,
                     onCancel: onCancel,
-                    hideCancelButton: hideCancelButton
+                    hideCancelButton: hideCancelButton,
+                    guidesColor: colorFromArgb(guidesColorArgb),
+                    guidesText: guidesText,
+                    readerColor: colorFromArgb(readerColorArgb),
+                    backgroundOpacity: backgroundOpacity,
+                    instructions: instructions,
+                    scanCooldownMs: scanCooldownMs
                 )
             )
         case "pdf417", "pdf417HighDensity":
@@ -123,7 +149,13 @@ class ScannerPlatformView: NSObject, FlutterPlatformView {
                     subtitle: subtitle,
                     onRead: onRead,
                     onCancel: onCancel,
-                    hideCancelButton: hideCancelButton
+                    hideCancelButton: hideCancelButton,
+                    guidesColor: colorFromArgb(guidesColorArgb),
+                    guidesText: guidesText,
+                    readerColor: colorFromArgb(readerColorArgb),
+                    backgroundOpacity: backgroundOpacity,
+                    instructions: instructions,
+                    scanCooldownMs: scanCooldownMs
                 )
             )
         }

--- a/flutter/lib/src/scanner.dart
+++ b/flutter/lib/src/scanner.dart
@@ -69,6 +69,7 @@ class SpruceScanner extends StatefulWidget {
     this.showCancelButton = true,
     this.headless = false,
     this.scanCooldownMs = 0,
+    this.onCameraReady,
   });
 
   /// The type of scanner to use.
@@ -104,6 +105,14 @@ class SpruceScanner extends StatefulWidget {
   /// and ignores reads within the cooldown window.
   final int scanCooldownMs;
 
+  /// Fired once when the camera preview is producing frames.
+  ///
+  /// Android: triggered when `PreviewView.previewStreamState` reaches
+  /// `STREAMING` (CameraX's first-frame signal).
+  /// iOS: fired immediately after the platform view is constructed
+  /// (UIKitView composition does not need a real frame signal).
+  final VoidCallback? onCameraReady;
+
   @override
   State<SpruceScanner> createState() => _SpruceScannerState();
 }
@@ -134,6 +143,9 @@ class _SpruceScannerState extends State<SpruceScanner> {
         return null;
       case 'onCancel':
         widget.onCancel();
+        return null;
+      case 'onCameraReady':
+        widget.onCameraReady?.call();
         return null;
       case 'isMatch':
         final content = call.arguments as String;

--- a/flutter/lib/src/scanner.dart
+++ b/flutter/lib/src/scanner.dart
@@ -67,6 +67,8 @@ class SpruceScanner extends StatefulWidget {
     this.subtitle = 'Please align within the guides',
     this.isMatch,
     this.showCancelButton = true,
+    this.headless = false,
+    this.scanCooldownMs = 0,
   });
 
   /// The type of scanner to use.
@@ -90,6 +92,17 @@ class SpruceScanner extends StatefulWidget {
 
   /// Whether to show the cancel button. Defaults to true.
   final bool showCancelButton;
+
+  /// When true, the scanner renders only the camera preview with no chrome
+  /// (no title, subtitle, overlay, guides, scan-line, or cancel button).
+  /// The caller is expected to draw its own UI on top.
+  final bool headless;
+
+  /// Cooldown between successive [onRead] emissions, in milliseconds.
+  /// When 0 (default), the scanner stops after the first read on iOS and
+  /// fires per-frame on Android. When > 0, the scanner runs continuously
+  /// and ignores reads within the cooldown window.
+  final int scanCooldownMs;
 
   @override
   State<SpruceScanner> createState() => _SpruceScannerState();
@@ -137,11 +150,27 @@ class _SpruceScannerState extends State<SpruceScanner> {
   }
 
   Map<String, dynamic> _creationParams() {
+    if (widget.headless) {
+      // Native scanners render no chrome when text is empty and overlays are transparent.
+      return {
+        'type': widget.type.name,
+        'title': '',
+        'subtitle': '',
+        'instructions': '',
+        'guidesText': '',
+        'showCancelButton': false,
+        'backgroundOpacity': 0.0,
+        'guidesColor': 0x00000000,
+        'readerColor': 0x00000000,
+        'scanCooldownMs': widget.scanCooldownMs,
+      };
+    }
     return {
       'type': widget.type.name,
       'title': widget.title,
       'subtitle': widget.subtitle,
       'showCancelButton': widget.showCancelButton,
+      'scanCooldownMs': widget.scanCooldownMs,
     };
   }
 

--- a/ios/MobileSdk/Sources/MobileSdk/ui/AVMetadataObjectScanner.swift
+++ b/ios/MobileSdk/Sources/MobileSdk/ui/AVMetadataObjectScanner.swift
@@ -36,6 +36,9 @@ public struct AVMetadataObjectScanner: View {
     /// Scanned code
     @State private var scannedCode: String = ""
 
+    /// Last read timestamp; used to throttle reads when scanCooldownMs > 0.
+    @State private var lastReadAt: Date?
+
     var metadataObjectTypes: [AVMetadataObject.ObjectType]
     var title: String
     var subtitle: String
@@ -55,6 +58,9 @@ public struct AVMetadataObjectScanner: View {
     var backgroundOpacity: Double
     var regionOfInterest: CGSize
     var scannerGuides: (any View)?
+    /// When > 0, the scanner runs continuously and throttles onRead to at most
+    /// once per window. When 0 (default), the camera stops after the first read.
+    var scanCooldownMs: Int
 
     public init(
         metadataObjectTypes: [AVMetadataObject.ObjectType] = [.qr],
@@ -75,7 +81,8 @@ public struct AVMetadataObjectScanner: View {
         backgroundColor: Color = .black,
         backgroundOpacity: Double = 0.75,
         regionOfInterest: CGSize = CGSize(width: 0, height: 0),
-        scannerGuides: (any View)? = nil
+        scannerGuides: (any View)? = nil,
+        scanCooldownMs: Int = 0
     ) {
         self.metadataObjectTypes = metadataObjectTypes
         self.title = title
@@ -96,6 +103,7 @@ public struct AVMetadataObjectScanner: View {
         self.backgroundOpacity = backgroundOpacity
         self.regionOfInterest = regionOfInterest
         self.scannerGuides = scannerGuides
+        self.scanCooldownMs = scanCooldownMs
     }
 
     public var body: some View {
@@ -221,20 +229,26 @@ public struct AVMetadataObjectScanner: View {
         }
 
         .onChange(of: qrDelegate.scannedCode) { newValue in
-            if let code = newValue {
+            guard let code = newValue else { return }
+
+            if scanCooldownMs > 0 {
+                let now = Date()
+                if let last = lastReadAt,
+                   now.timeIntervalSince(last) * 1000 < Double(scanCooldownMs) {
+                    qrDelegate.scannedCode = nil
+                    return
+                }
+                lastReadAt = now
                 scannedCode = code
-
-                /// When the first code scan is available, immediately stop the camera.
-                session.stopRunning()
-
-                /// Stopping scanner animation
-                deActivateScannerAnimation()
-                /// Clearing the data on delegate
                 qrDelegate.scannedCode = nil
-
+                onRead(code)
+            } else {
+                scannedCode = code
+                session.stopRunning()
+                deActivateScannerAnimation()
+                qrDelegate.scannedCode = nil
                 onRead(code)
             }
-
         }
 
     }

--- a/ios/MobileSdk/Sources/MobileSdk/ui/QRCodeScanner.swift
+++ b/ios/MobileSdk/Sources/MobileSdk/ui/QRCodeScanner.swift
@@ -140,9 +140,11 @@ public struct QRCodeScanner: View {
                             RoundedRectangle(cornerRadius: 100)
                         )
                     )
-                    //INFO: Since this iOS version uses hstackHeight to calculate the positioning of the ProgressRing+guideText
-                    // we have to use this opacity trick instead of conditional rendering, so the layout is not messed up
-                    .opacity(guidesText.isEmpty ? 0 : 1) 
+                    // INFO: Since this iOS version uses hstackHeight 
+                    // to calculate the positioning of the ProgressRing+guideText
+                    // we have to use this opacity trick instead of conditional 
+                    // rendering, so the layout is not messed up
+                    .opacity(guidesText.isEmpty ? 0 : 1)
                     .background(
                         GeometryReader { geometry in
                             Color.clear

--- a/ios/MobileSdk/Sources/MobileSdk/ui/QRCodeScanner.swift
+++ b/ios/MobileSdk/Sources/MobileSdk/ui/QRCodeScanner.swift
@@ -41,6 +41,7 @@ public struct QRCodeScanner: View {
     var instructions: String
     var instructionsFont: Font?
     var instructionsDefaultColor: Color
+    var scanCooldownMs: Int
 
     public init(
         title: String = "Scan QR Code",
@@ -63,7 +64,8 @@ public struct QRCodeScanner: View {
         backgroundOpacity: Double = 1,
         instructions: String = "",
         instructionsFont: Font? = nil,
-        instructionsDefaultColor: Color = .gray
+        instructionsDefaultColor: Color = .gray,
+        scanCooldownMs: Int = 0
     ) {
         self.title = title
         self.subtitle = subtitle
@@ -86,6 +88,7 @@ public struct QRCodeScanner: View {
         self.instructions = instructions
         self.instructionsFont = instructionsFont
         self.instructionsDefaultColor = instructionsDefaultColor
+        self.scanCooldownMs = scanCooldownMs
     }
 
     func calculateRegionOfInterest() -> CGSize {
@@ -137,6 +140,9 @@ public struct QRCodeScanner: View {
                             RoundedRectangle(cornerRadius: 100)
                         )
                     )
+                    //INFO: Since this iOS version uses hstackHeight to calculate the positioning of the ProgressRing+guideText
+                    // we have to use this opacity trick instead of conditional rendering, so the layout is not messed up
+                    .opacity(guidesText.isEmpty ? 0 : 1) 
                     .background(
                         GeometryReader { geometry in
                             Color.clear
@@ -171,7 +177,8 @@ public struct QRCodeScanner: View {
                     vstackHeight = height
                 }
                 .offset(y: vstackHeight - (hstackHeight / 2))
-            }
+            },
+            scanCooldownMs: scanCooldownMs
         )
     }
 }


### PR DESCRIPTION
REF ACC-1359

## Description

Changes to make it easier to accommodate the current native scanner implementations to be used in Safe. 
If you think this does not fit here or that people will want more customization in the future, I guess we should go and implement a specific scanner in Flutter

-  `headless` mode: new `headless: bool` parameter on `SpruceScanner` in the Flutter plugin. When `true`, suppresses all native chrome (title, subtitle, overlay, guides, scan line, cancel button, and the spinner pill) so the consumer can draw its own UI over just the camera preview.
- Scan cooldown:  new `scanCooldownMs: Int` parameter on `SpruceScanner`. Default `0` keeps current behavior. When > 0, the scanner runs continuously and throttles onRead to one emission per window, replacing the iOS auto-stop and the Android per-frame firing.


### Optional section

- For testing, just run the flutter example app, sprucekit showcase iOS and Android. All the scanner should be working properly.



## Tested

- [x] Tested Sprucekit scan in both iOS and Android, they compile just fine — which means its backwards compatible — and the visuals are the same. And I managed to use the scanners (both in the Wallet and the Verifier part of the app) without major problems — which is expected since nothing here changes scanning behaviour.