### PR TITLE
Add NFC reader support in Android

### DIFF
--- a/android/MobileSdk/src/main/AndroidManifest.xml
+++ b/android/MobileSdk/src/main/AndroidManifest.xml
@@ -17,4 +17,9 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.NFC" />
+
+    <uses-feature
+        android:name="android.hardware.nfc"
+        android:required="false" />
 </manifest>

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/IsoMdlReader.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/IsoMdlReader.kt
@@ -15,7 +15,7 @@ import java.util.UUID
 
 class IsoMdlReader(
     val callback: BLESessionStateDelegate,
-    uri: String,
+    handover: ReaderHandover,
     requestedItems: Map<String, Map<String, Boolean>>,
     trustAnchorRegistry: List<String>?,
     platformBluetooth: BluetoothManager,
@@ -24,9 +24,25 @@ class IsoMdlReader(
     private lateinit var session: MdlSessionManager
     private lateinit var bleManager: Transport
 
+    constructor(
+        callback: BLESessionStateDelegate,
+        uri: String,
+        requestedItems: Map<String, Map<String, Boolean>>,
+        trustAnchorRegistry: List<String>?,
+        platformBluetooth: BluetoothManager,
+        context: Context,
+    ) : this(
+        callback,
+        ReaderHandover.newQr(uri),
+        requestedItems,
+        trustAnchorRegistry,
+        platformBluetooth,
+        context,
+    )
+
     init {
         try {
-            val sessionData = establishSession(ReaderHandover.newQr(uri), requestedItems, trustAnchorRegistry)
+            val sessionData = establishSession(handover, requestedItems, trustAnchorRegistry)
 
             session = sessionData.state
             try {

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/IsoMdlReader.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/IsoMdlReader.kt
@@ -87,14 +87,14 @@ class IsoMdlReader(
                         )
                     }
 
-                    else -> throw Error("No BLE transport options in Device Engagement")
+                    else -> throw IllegalStateException("No BLE transport options in Device Engagement")
                 }
             } catch (e: SecurityException) {
                 Log.e("IsoMdlReader", "SecurityException during BLE initialization: ${e.message}", e)
                 callback.update(mapOf("error" to "Bluetooth permission denied: ${e.message}"))
             }
 
-        } catch (e: Error) {
+        } catch (e: Exception) {
             Log.e("IsoMdlReader.constructor", "Error during initialization: ${e.message}", e)
             callback.update(mapOf("error" to (e.message ?: "Unknown initialization error")))
         }

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NFC.md
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NFC.md
@@ -51,7 +51,7 @@ For non-Compose hosts, the underlying `NfcReaderEngagement` class can be driven 
 
 ### Reader-side caveats
 
-- **Samsung "Unknown tag" on first tap.** When a holder advertises NDEF over HCE, Samsung's modified NFC service runs its own NDEF read in parallel with reader mode and briefly displays an "Unknown tag" overlay. Subsequent taps in the same engagement go through reader mode normally. See the inline comment on `READER_FLAGS` in `NfcReaderEngagement.kt` for details — this cannot be fully suppressed from app code.
+- **Samsung camera/NFC mutex.** On Samsung devices, opening the camera forces NFC active polling off (`NfcService: setReaderMode: active polling is forced to disable now`). When the camera is then closed, Samsung's NfcService internally clears the app's reader mode and falls back to the default tag dispatcher, so the next tap surfaces the OS "new tag scanned" / "Unknown tag" overlay instead of hitting the app callback. `NfcReaderEngagement` watches `CameraManager.AvailabilityCallback` and re-arms reader mode whenever a camera transitions back to available — so for most consumers this is invisible. If the host UI has a camera preview *and* a reader simultaneously (e.g. a QR-or-NFC verifier screen), prefer releasing the camera fully before soliciting an NFC tap to avoid the brief overlay window between camera-close and the SDK's re-arm.
 
 ## Holder (HCE) NFC engagement
 

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NFC.md
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NFC.md
@@ -53,6 +53,8 @@ For non-Compose hosts, the underlying `NfcReaderEngagement` class can be driven 
 
 - **Samsung camera/NFC mutex.** On Samsung devices, opening the camera forces NFC active polling off (`NfcService: setReaderMode: active polling is forced to disable now`). When the camera is then closed, Samsung's NfcService internally clears the app's reader mode and falls back to the default tag dispatcher, so the next tap surfaces the OS "new tag scanned" / "Unknown tag" overlay instead of hitting the app callback. `NfcReaderEngagement` watches `CameraManager.AvailabilityCallback` and re-arms reader mode whenever a camera transitions back to available — so for most consumers this is invisible. If the host UI has a camera preview *and* a reader simultaneously (e.g. a QR-or-NFC verifier screen), prefer releasing the camera fully before soliciting an NFC tap to avoid the brief overlay window between camera-close and the SDK's re-arm.
 
+- **Reader-mode tech set must be narrow.** Adding `FLAG_READER_NFC_F`, `FLAG_READER_NFC_V`, or `FLAG_READER_NFC_BARCODE` to the reader flags re-introduces the Samsung overlay even with the camera re-arm active. Mdoc engagement only needs NFC-A IsoDep; NFC-B is harmless. Don't be tempted to "claim every tech to suppress OS tag dispatch" — on Samsung it routes through a path the re-arm doesn't recover.
+
 ## Holder (HCE) NFC engagement
 
 ### Creating the service handler

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NFC.md
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NFC.md
@@ -1,5 +1,60 @@
 # NFC for credential presentation
 
+This SDK supports NFC on both sides of an ISO 18013-5 mDL engagement:
+
+- **Holder (HCE)** — your wallet emulates a contactless card and is tapped by a verifier. See [Holder (HCE) NFC engagement](#holder-hce-nfc-engagement) below.
+- **Reader (verifier)** — your app drives the NFC controller to read a holder's tap. See [Reader (verifier) NFC engagement](#reader-verifier-nfc-engagement) below.
+
+The SDK manifest contributes the following automatically, so you do not need to add them in your app manifest:
+
+```xml
+<uses-permission android:name="android.permission.NFC" />
+<uses-feature android:name="android.hardware.nfc" android:required="false" />
+```
+
+If your app does not use any NFC features and you want the permission gone from your merged manifest, add this to your `AndroidManifest.xml` (ensure the `<manifest>` tag declares `xmlns:tools="http://schemas.android.com/tools"`):
+
+```xml
+<uses-permission android:name="android.permission.NFC" tools:node="remove" />
+```
+
+## Reader (verifier) NFC engagement
+
+For Compose-based verifier apps, `rememberNfcReaderEngagement` is a single entry point that handles activity discovery, lifecycle binding, NFC adapter state tracking, and the APDU exchange. The handover it returns is passed to `IsoMdlReader` to start the BLE session, exactly as with QR engagement.
+
+```kotlin
+@Composable
+fun MyVerifierScreen() {
+    val nfcActive = /* true while your UI is actively soliciting a tap */
+    val phase by rememberNfcReaderEngagement(
+        onHandover = { handover ->
+            // Start your BLE session, e.g.:
+            // IsoMdlReader(callback, handover, requestedItems, trustAnchors, bluetooth, context)
+        },
+        active = nfcActive,
+    )
+    when (phase) {
+        NfcReaderPhase.Unsupported -> Text("This device does not support NFC.")
+        NfcReaderPhase.Disabled -> Text("NFC is off. Enable it in system settings.")
+        NfcReaderPhase.WaitingForTag -> Text("Tap the holder's phone to share their credential.")
+        NfcReaderPhase.Exchanging -> CircularProgressIndicator()
+        is NfcReaderPhase.ProtocolError -> Text(
+            (phase as NfcReaderPhase.ProtocolError).cause.message ?: "Handover failed",
+        )
+    }
+}
+```
+
+Flip `active` off whenever your UI is foreground but not actively soliciting a tap — e.g. when the user is on a different tab, or while a BLE session is already running. Reader mode stays on so the device keeps the NFC controller in initiator role; this suppresses wallet pickers, foreign HCE services, and OS tag dispatchers from triggering on stray taps.
+
+For non-Compose hosts, the underlying `NfcReaderEngagement` class can be driven directly — see its KDoc.
+
+### Reader-side caveats
+
+- **Samsung "Unknown tag" on first tap.** When a holder advertises NDEF over HCE, Samsung's modified NFC service runs its own NDEF read in parallel with reader mode and briefly displays an "Unknown tag" overlay. Subsequent taps in the same engagement go through reader mode normally. See the inline comment on `READER_FLAGS` in `NfcReaderEngagement.kt` for details — this cannot be fully suppressed from app code.
+
+## Holder (HCE) NFC engagement
+
 ### Creating the service handler
 
 You must create a class that inherits from SpruceKit's `BaseNfcPresentationService` for handling NFC messages.

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NfcReaderEngagement.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NfcReaderEngagement.kt
@@ -24,8 +24,12 @@ import java.io.IOException
  *     [Event.WaitingForTag].
  *  3. On tap, the APDU exchange runs on a binder thread; events are always
  *     delivered to the consumer on the main thread.
- *  4. Call [stop] when leaving the screen. Reader mode is also released
- *     automatically after [Event.Success] is delivered.
+ *  4. Call [stop] when leaving the screen. After [Event.Success] reader
+ *     mode is intentionally NOT released — only [engageOnTap] is flipped
+ *     to false. Callers typically keep the device in initiator role
+ *     through the post-handover BLE phase so foreign HCE services,
+ *     wallet pickers, and OS tag dispatchers stay suppressed while the
+ *     phones may still be in proximity.
  *
  * Transient failures (tag lost, I/O) are recovered automatically: reader
  * mode stays on and the next tap starts a fresh handover. This handles
@@ -87,10 +91,10 @@ class NfcReaderEngagement(
             // Fresh driver per tap: holders that disconnect mid-handover
             // (e.g. wallet picker) reconnect with a new SELECT, so resumption
             // is not possible.
-            val init = newReaderApduHandoverDriver()
-            var rapdu = isoDep.transceive(init.initialApdu)
+            val driverInit = newReaderApduHandoverDriver()
+            var rapdu = isoDep.transceive(driverInit.initialApdu)
             while (true) {
-                when (val progress = init.driver.processRapdu(rapdu)) {
+                when (val progress = driverInit.driver.processRapdu(rapdu)) {
                     is ReaderApduProgress.InProgress -> {
                         rapdu = isoDep.transceive(progress.v1)
                     }

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NfcReaderEngagement.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NfcReaderEngagement.kt
@@ -21,6 +21,7 @@ import com.spruceid.mobile.sdk.rs.ReaderApduProgress
 import com.spruceid.mobile.sdk.rs.ReaderHandover
 import com.spruceid.mobile.sdk.rs.newReaderApduHandoverDriver
 import java.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Drives the reader (verifier) side of ISO 18013-5 NFC engagement.
@@ -92,7 +93,11 @@ class NfcReaderEngagement(
 
     private val mainHandler = Handler(Looper.getMainLooper())
     @Volatile private var running = false
-    @Volatile private var active: Boolean = true
+    // Atomic so the reader callback (which the OS may dispatch on a worker
+    // thread, potentially concurrently for rapid double-taps) can claim the
+    // engagement with compareAndSet, preventing two APDU flows on the same
+    // IsoDep from racing.
+    private val active = AtomicBoolean(true)
     private var lifecycleObserver: LifecycleEventObserver? = null
     private var boundOwner: LifecycleOwner? = null
     private var receiverRegistered = false
@@ -165,13 +170,19 @@ class NfcReaderEngagement(
             Log.d(TAG, "Ignoring tag detection after stop()")
             return@ReaderCallback
         }
-        if (!active) {
-            Log.d(TAG, "Tag detected but engagement is inactive; swallowing")
+        // Atomically claim the engagement: if active was false (host
+        // disabled, or another tap is already in flight), bail. If true,
+        // we now own it (flag flipped to false). Transient/protocol errors
+        // restore it so the next tap can retry; Done leaves it false as
+        // a sticky disable until the host calls setActive(true) again.
+        if (!active.compareAndSet(true, false)) {
+            Log.d(TAG, "Tag detected but engagement is inactive or in-flight; swallowing")
             return@ReaderCallback
         }
         emit(Event.Exchanging)
         val isoDep = IsoDep.get(tag)
         if (isoDep == null) {
+            active.set(true)
             emit(Event.WaitingForTag)
             return@ReaderCallback
         }
@@ -194,15 +205,14 @@ class NfcReaderEngagement(
                         } catch (_: IOException) {
                             // Connection already gone; ignore.
                         }
-                        // Mark this engagement as done so subsequent taps are
-                        // silently swallowed even if the host hasn't yet
-                        // reacted to the Success event. We deliberately do NOT
-                        // call stop() here: empirically, fully disabling reader
+                        // Engagement complete. We deliberately do NOT call
+                        // stop() here: empirically, fully disabling reader
                         // mode at this point lets the OS wallet picker fire
                         // and puts the reader into weird latent states while
-                        // the BLE handoff is still in progress. Keeping reader
-                        // mode armed with active=false suppresses both.
-                        active = false
+                        // the BLE handoff is still in progress. Keeping
+                        // reader mode armed with active=false suppresses
+                        // both. (active is already false from compareAndSet
+                        // above; left here for clarity.)
                         val handover = progress.v1
                         mainHandler.post { onEvent(Event.Success(handover)) }
                         return@ReaderCallback
@@ -211,14 +221,17 @@ class NfcReaderEngagement(
             }
         } catch (e: TagLostException) {
             Log.i(TAG, "Tag lost during handover; awaiting next tap", e)
+            active.set(true)
             emit(Event.TransientError(e))
             emit(Event.WaitingForTag)
         } catch (e: IOException) {
             Log.w(TAG, "I/O during handover; awaiting next tap", e)
+            active.set(true)
             emit(Event.TransientError(e))
             emit(Event.WaitingForTag)
         } catch (e: ReaderApduHandoverException) {
             Log.e(TAG, "Handover protocol error", e)
+            active.set(true)
             emit(Event.ProtocolError(e))
         }
     }
@@ -256,7 +269,7 @@ class NfcReaderEngagement(
      * [Event.Success]; call `setActive(true)` to accept another handover.
      */
     fun setActive(active: Boolean) {
-        this.active = active
+        this.active.set(active)
     }
 
     /**

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NfcReaderEngagement.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NfcReaderEngagement.kt
@@ -197,11 +197,11 @@ class NfcReaderEngagement(
                         // Mark this engagement as done so subsequent taps are
                         // silently swallowed even if the host hasn't yet
                         // reacted to the Success event. We deliberately do NOT
-                        // call stop() here: callers typically want reader
-                        // mode to stay active through the post-handover BLE
-                        // phase so the device stays in initiator role and no
-                        // foreign HCE service / OS tag dispatcher gets fired
-                        // while the phones may still be in proximity.
+                        // call stop() here: empirically, fully disabling reader
+                        // mode at this point lets the OS wallet picker fire
+                        // and puts the reader into weird latent states while
+                        // the BLE handoff is still in progress. Keeping reader
+                        // mode armed with active=false suppresses both.
                         active = false
                         val handover = progress.v1
                         mainHandler.post { onEvent(Event.Success(handover)) }
@@ -326,28 +326,19 @@ class NfcReaderEngagement(
         private const val TAG = "NfcReaderEngagement"
         private const val TRANSCEIVE_TIMEOUT_MS = 20_000
         // ISO 18013-5 NFC engagement uses IsoDep (Type 4 Tag) over NFC-A;
-        // NFC-B is kept as a hedge. NFC-F/V/BARCODE were tried — they do
-        // not change the Samsung first-tap behaviour either way — so we
-        // omit them to match Multipaz's flag set.
+        // NFC-B is kept as a hedge.
+        //
+        // Do NOT add NFC_F / NFC_V / NFC_BARCODE here: empirically, on
+        // Samsung the wider tech set causes the "new tag scanned" / OS
+        // tag-dispatcher overlay to surface on first tap, even with the
+        // camera-availability re-arm active. The extra techs evidently
+        // route through a code path the re-arm doesn't catch. Mdoc only
+        // needs A; B is harmless.
         //
         // FLAG_READER_SKIP_NDEF_CHECK avoids the platform-level NDEF probe
         // (which is what foreign HCE / wallet pickers latch onto on most
         // OEMs). FLAG_READER_NO_PLATFORM_SOUNDS suppresses the system
         // tag-detected chime that otherwise plays on every tag we see.
-        //
-        // Samsung first-tap caveat (unresolved): when a holder advertises
-        // NDEF over HCE (e.g. Google Wallet), Samsung's modified NfcService
-        // runs its own NDEF read and dispatches the tag explicitly to
-        // com.android.apps.tag/.TagViewer, bypassing both this reader mode
-        // (despite FLAG_READER_SKIP_NDEF_CHECK) and any manifest
-        // TECH_DISCOVERED intent-filter. The dispatch uses an explicit
-        // component, so no app-side filter can intercept it. The first tap
-        // shows a brief "Unknown tag" overlay; subsequent taps within the
-        // same engagement go through reader mode normally. Multipaz does
-        // not reproduce this on the same hardware/holder, and the cause
-        // is not the reader flags — likely the lifecycle/timing of when
-        // reader mode is armed (Multipaz arms lazily on prompt show, we
-        // arm on Activity ON_RESUME).
         private const val READER_FLAGS =
             NfcAdapter.FLAG_READER_NFC_A or
                 NfcAdapter.FLAG_READER_NFC_B or

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NfcReaderEngagement.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NfcReaderEngagement.kt
@@ -173,9 +173,19 @@ class NfcReaderEngagement(
         // OEM "tag scanner" overlays, NDEF auto-launch, etc.). Observed in
         // the wild: Pixel + Google Wallet emits NFC-F during ISO 18013-5
         // engagement; without FLAG_READER_NFC_F our reader mode misses it
-        // and Samsung's OS launches com.android.apps.tag/.TagViewer.
+        // and the OS launches com.android.apps.tag/.TagViewer.
         // FLAG_READER_NO_PLATFORM_SOUNDS also kills the system tag-detected
         // chime, which otherwise plays even on tags we silently swallow.
+        //
+        // Known limitation on Samsung: when a holder advertises NDEF over
+        // HCE (Google Wallet does this), Samsung's modified NfcService runs
+        // its own NDEF read and dispatches the tag explicitly to
+        // com.android.apps.tag/.TagViewer, bypassing both this reader mode
+        // (despite FLAG_READER_SKIP_NDEF_CHECK) and any manifest
+        // TECH_DISCOVERED intent-filter. The dispatch uses an explicit
+        // component, so no app-side filter can intercept it. The first tap
+        // shows a brief "Unknown tag" overlay; subsequent taps within the
+        // same engagement go through reader mode normally.
         private const val READER_FLAGS =
             NfcAdapter.FLAG_READER_NFC_A or
                 NfcAdapter.FLAG_READER_NFC_B or

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NfcReaderEngagement.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NfcReaderEngagement.kt
@@ -1,0 +1,154 @@
+package com.spruceid.mobile.sdk.nfc
+
+import android.app.Activity
+import android.nfc.NfcAdapter
+import android.nfc.Tag
+import android.nfc.TagLostException
+import android.nfc.tech.IsoDep
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import com.spruceid.mobile.sdk.rs.ReaderApduHandoverException
+import com.spruceid.mobile.sdk.rs.ReaderApduProgress
+import com.spruceid.mobile.sdk.rs.ReaderHandover
+import com.spruceid.mobile.sdk.rs.newReaderApduHandoverDriver
+import java.io.IOException
+
+/**
+ * Drives the reader (verifier) side of ISO 18013-5 NFC engagement.
+ *
+ * Lifecycle (Activity-scoped):
+ *  1. Construct with the hosting [Activity] and an event handler.
+ *  2. Call [start] when the user is ready to tap (e.g. when a verifier
+ *     screen becomes active). [start] enables NFC reader mode and emits
+ *     [Event.WaitingForTag].
+ *  3. On tap, the APDU exchange runs on a binder thread; events are always
+ *     delivered to the consumer on the main thread.
+ *  4. Call [stop] when leaving the screen. Reader mode is also released
+ *     automatically after [Event.Success] is delivered.
+ *
+ * Transient failures (tag lost, I/O) are recovered automatically: reader
+ * mode stays on and the next tap starts a fresh handover. This handles
+ * holders that disconnect after the first APDU to show a wallet picker
+ * and reconnect (e.g. Samsung Wallet).
+ */
+class NfcReaderEngagement(
+    private val activity: Activity,
+    private val onEvent: (Event) -> Unit,
+) {
+    sealed class Event {
+        object WaitingForTag : Event()
+        object Exchanging : Event()
+        /** Recoverable failure (tag lost, I/O). Reader mode is still active. */
+        data class TransientError(val cause: Throwable) : Event()
+        /** Protocol-level failure. Caller should decide whether to [start] again. */
+        data class ProtocolError(val cause: Throwable) : Event()
+        data class Success(val handover: ReaderHandover) : Event()
+    }
+
+    val nfcAdapter: NfcAdapter? = NfcAdapter.getDefaultAdapter(activity)
+
+    val isSupported: Boolean get() = nfcAdapter != null
+    val isEnabled: Boolean get() = nfcAdapter?.isEnabled == true
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var running = false
+
+    private val readerCallback = NfcAdapter.ReaderCallback { tag: Tag ->
+        // Guard against stale invocations that the system may dispatch after
+        // disableReaderMode() returns.
+        if (!running) {
+            Log.d(TAG, "Ignoring tag detection after stop()")
+            return@ReaderCallback
+        }
+        emit(Event.Exchanging)
+        val isoDep = IsoDep.get(tag)
+        if (isoDep == null) {
+            emit(Event.WaitingForTag)
+            return@ReaderCallback
+        }
+        try {
+            isoDep.connect()
+            isoDep.timeout = TRANSCEIVE_TIMEOUT_MS
+            // Fresh driver per tap: holders that disconnect mid-handover
+            // (e.g. wallet picker) reconnect with a new SELECT, so resumption
+            // is not possible.
+            val init = newReaderApduHandoverDriver()
+            var rapdu = isoDep.transceive(init.initialApdu)
+            while (true) {
+                when (val progress = init.driver.processRapdu(rapdu)) {
+                    is ReaderApduProgress.InProgress -> {
+                        rapdu = isoDep.transceive(progress.v1)
+                    }
+                    is ReaderApduProgress.Done -> {
+                        try {
+                            isoDep.close()
+                        } catch (_: IOException) {
+                            // Connection already gone; ignore.
+                        }
+                        // Disable reader mode before delivering the handover so
+                        // the holder's HCE service does not get re-triggered
+                        // (e.g. wallet picker reappearing) while the caller
+                        // moves on to BLE.
+                        val handover = progress.v1
+                        mainHandler.post {
+                            stop()
+                            onEvent(Event.Success(handover))
+                        }
+                        return@ReaderCallback
+                    }
+                }
+            }
+        } catch (e: TagLostException) {
+            Log.i(TAG, "Tag lost during handover; awaiting next tap", e)
+            emit(Event.TransientError(e))
+            emit(Event.WaitingForTag)
+        } catch (e: IOException) {
+            Log.w(TAG, "I/O during handover; awaiting next tap", e)
+            emit(Event.TransientError(e))
+            emit(Event.WaitingForTag)
+        } catch (e: ReaderApduHandoverException) {
+            Log.e(TAG, "Handover protocol error", e)
+            emit(Event.ProtocolError(e))
+        }
+    }
+
+    /**
+     * Enable reader mode. Returns true if reader mode was activated.
+     * Returns false if NFC is unsupported or disabled — callers should
+     * check [isSupported] / [isEnabled] beforehand to give a useful UI.
+     */
+    fun start(): Boolean {
+        if (running) return true
+        val adapter = nfcAdapter ?: return false
+        if (!adapter.isEnabled) return false
+        running = true
+        adapter.enableReaderMode(activity, readerCallback, READER_FLAGS, null)
+        emit(Event.WaitingForTag)
+        return true
+    }
+
+    /** Disable reader mode. Idempotent. */
+    fun stop() {
+        if (!running) return
+        running = false
+        nfcAdapter?.disableReaderMode(activity)
+    }
+
+    private fun emit(event: Event) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            onEvent(event)
+        } else {
+            mainHandler.post { onEvent(event) }
+        }
+    }
+
+    companion object {
+        private const val TAG = "NfcReaderEngagement"
+        private const val TRANSCEIVE_TIMEOUT_MS = 20_000
+        private const val READER_FLAGS =
+            NfcAdapter.FLAG_READER_NFC_A or
+                NfcAdapter.FLAG_READER_NFC_B or
+                NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK
+    }
+}

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NfcReaderEngagement.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NfcReaderEngagement.kt
@@ -5,6 +5,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.hardware.camera2.CameraManager
 import android.nfc.NfcAdapter
 import android.nfc.Tag
 import android.nfc.TagLostException
@@ -86,6 +87,8 @@ class NfcReaderEngagement(
     }
 
     private val nfcAdapter: NfcAdapter? = NfcAdapter.getDefaultAdapter(activity)
+    private val cameraManager: CameraManager? =
+        activity.getSystemService(Context.CAMERA_SERVICE) as? CameraManager
 
     private val mainHandler = Handler(Looper.getMainLooper())
     @Volatile private var running = false
@@ -93,6 +96,8 @@ class NfcReaderEngagement(
     private var lifecycleObserver: LifecycleEventObserver? = null
     private var boundOwner: LifecycleOwner? = null
     private var receiverRegistered = false
+    private var cameraCallbackRegistered = false
+    private val unavailableCameras = mutableSetOf<String>()
 
     private val adapterStateReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -111,6 +116,36 @@ class NfcReaderEngagement(
         }
     }
 
+    // Samsung quirk: when the camera is open, NfcService forces NFC active
+    // polling off ("setReaderMode: active polling is forced to disable now").
+    // When the camera closes, NfcService internally clears the app's reader
+    // mode (logs `setReaderMode: uid=1000, packageName: android, flags: 0`
+    // followed by `restoreSavedTech`) and falls back to the default tag
+    // dispatcher. The next tap then hits the OS overlay (`new tag scanned` /
+    // `Unknown tag`) instead of our callback. Re-arm reader mode whenever a
+    // camera transitions from in-use back to available.
+    private val cameraAvailabilityCallback = object : CameraManager.AvailabilityCallback() {
+        override fun onCameraUnavailable(cameraId: String) {
+            unavailableCameras.add(cameraId)
+        }
+
+        override fun onCameraAvailable(cameraId: String) {
+            val wasUnavailable = unavailableCameras.remove(cameraId)
+            if (!wasUnavailable) return
+            if (!running) return
+            // NfcService has already finished its setReaderMode(uid=1000) +
+            // restoreSavedTech sequence by the time this callback fires; we
+            // just need to be on the main thread to re-arm.
+            mainHandler.post {
+                val adapter = nfcAdapter ?: return@post
+                if (running && adapter.isEnabled) {
+                    Log.d(TAG, "Camera released; re-arming reader mode")
+                    adapter.enableReaderMode(activity, readerCallback, READER_FLAGS, null)
+                }
+            }
+        }
+    }
+
     init {
         if (nfcAdapter != null) {
             activity.registerReceiver(
@@ -118,6 +153,8 @@ class NfcReaderEngagement(
                 IntentFilter(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED),
             )
             receiverRegistered = true
+            cameraManager?.registerAvailabilityCallback(cameraAvailabilityCallback, mainHandler)
+            cameraCallbackRegistered = cameraManager != null
         }
     }
 
@@ -265,6 +302,11 @@ class NfcReaderEngagement(
             }
             receiverRegistered = false
         }
+        if (cameraCallbackRegistered) {
+            cameraManager?.unregisterAvailabilityCallback(cameraAvailabilityCallback)
+            cameraCallbackRegistered = false
+        }
+        unavailableCameras.clear()
         boundOwner?.let { owner ->
             lifecycleObserver?.let { owner.lifecycle.removeObserver(it) }
         }
@@ -283,32 +325,32 @@ class NfcReaderEngagement(
     companion object {
         private const val TAG = "NfcReaderEngagement"
         private const val TRANSCEIVE_TIMEOUT_MS = 20_000
-        // Claim every NFC tech: tags we don't recognise are silently swallowed
-        // by the callback (when active=false or non-IsoDep), but we MUST
-        // claim them at the reader-mode level so the OS doesn't fall through
-        // to its default tag dispatcher (TECH_DISCOVERED → system TagViewer,
-        // OEM "tag scanner" overlays, NDEF auto-launch, etc.). Observed in
-        // the wild: Pixel + Google Wallet emits NFC-F during ISO 18013-5
-        // engagement; without FLAG_READER_NFC_F our reader mode misses it
-        // and the OS launches com.android.apps.tag/.TagViewer.
-        // FLAG_READER_NO_PLATFORM_SOUNDS also kills the system tag-detected
-        // chime, which otherwise plays even on tags we silently swallow.
+        // ISO 18013-5 NFC engagement uses IsoDep (Type 4 Tag) over NFC-A;
+        // NFC-B is kept as a hedge. NFC-F/V/BARCODE were tried — they do
+        // not change the Samsung first-tap behaviour either way — so we
+        // omit them to match Multipaz's flag set.
         //
-        // Known limitation on Samsung: when a holder advertises NDEF over
-        // HCE (Google Wallet does this), Samsung's modified NfcService runs
-        // its own NDEF read and dispatches the tag explicitly to
+        // FLAG_READER_SKIP_NDEF_CHECK avoids the platform-level NDEF probe
+        // (which is what foreign HCE / wallet pickers latch onto on most
+        // OEMs). FLAG_READER_NO_PLATFORM_SOUNDS suppresses the system
+        // tag-detected chime that otherwise plays on every tag we see.
+        //
+        // Samsung first-tap caveat (unresolved): when a holder advertises
+        // NDEF over HCE (e.g. Google Wallet), Samsung's modified NfcService
+        // runs its own NDEF read and dispatches the tag explicitly to
         // com.android.apps.tag/.TagViewer, bypassing both this reader mode
         // (despite FLAG_READER_SKIP_NDEF_CHECK) and any manifest
         // TECH_DISCOVERED intent-filter. The dispatch uses an explicit
         // component, so no app-side filter can intercept it. The first tap
         // shows a brief "Unknown tag" overlay; subsequent taps within the
-        // same engagement go through reader mode normally.
+        // same engagement go through reader mode normally. Multipaz does
+        // not reproduce this on the same hardware/holder, and the cause
+        // is not the reader flags — likely the lifecycle/timing of when
+        // reader mode is armed (Multipaz arms lazily on prompt show, we
+        // arm on Activity ON_RESUME).
         private const val READER_FLAGS =
             NfcAdapter.FLAG_READER_NFC_A or
                 NfcAdapter.FLAG_READER_NFC_B or
-                NfcAdapter.FLAG_READER_NFC_F or
-                NfcAdapter.FLAG_READER_NFC_V or
-                NfcAdapter.FLAG_READER_NFC_BARCODE or
                 NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK or
                 NfcAdapter.FLAG_READER_NO_PLATFORM_SOUNDS
     }

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NfcReaderEngagement.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NfcReaderEngagement.kt
@@ -51,14 +51,28 @@ class NfcReaderEngagement(
     val isSupported: Boolean get() = nfcAdapter != null
     val isEnabled: Boolean get() = nfcAdapter?.isEnabled == true
 
+    /**
+     * When false, detected tags are silently consumed without an APDU exchange
+     * or any [Event] emission. Reader mode itself stays enabled, which is
+     * useful for keeping the device in initiator role (so foreign HCE,
+     * system tag dispatch, OEM "tag scanner" overlays, etc. are suppressed)
+     * while the host UI is foreground but not actively soliciting a tap.
+     */
+    @Volatile
+    var engageOnTap: Boolean = true
+
     private val mainHandler = Handler(Looper.getMainLooper())
-    private var running = false
+    @Volatile private var running = false
 
     private val readerCallback = NfcAdapter.ReaderCallback { tag: Tag ->
         // Guard against stale invocations that the system may dispatch after
         // disableReaderMode() returns.
         if (!running) {
             Log.d(TAG, "Ignoring tag detection after stop()")
+            return@ReaderCallback
+        }
+        if (!engageOnTap) {
+            Log.d(TAG, "Tag detected but engagement is paused; swallowing")
             return@ReaderCallback
         }
         emit(Event.Exchanging)
@@ -86,15 +100,17 @@ class NfcReaderEngagement(
                         } catch (_: IOException) {
                             // Connection already gone; ignore.
                         }
-                        // Disable reader mode before delivering the handover so
-                        // the holder's HCE service does not get re-triggered
-                        // (e.g. wallet picker reappearing) while the caller
-                        // moves on to BLE.
+                        // Mark this engagement as done so subsequent taps are
+                        // silently swallowed even if the host hasn't yet
+                        // reacted to the Success event. We deliberately do NOT
+                        // call stop() here: callers typically want reader
+                        // mode to stay active through the post-handover BLE
+                        // phase so the device stays in initiator role and no
+                        // foreign HCE service / OS tag dispatcher gets fired
+                        // while the phones may still be in proximity.
+                        engageOnTap = false
                         val handover = progress.v1
-                        mainHandler.post {
-                            stop()
-                            onEvent(Event.Success(handover))
-                        }
+                        mainHandler.post { onEvent(Event.Success(handover)) }
                         return@ReaderCallback
                     }
                 }
@@ -146,9 +162,23 @@ class NfcReaderEngagement(
     companion object {
         private const val TAG = "NfcReaderEngagement"
         private const val TRANSCEIVE_TIMEOUT_MS = 20_000
+        // Claim every NFC tech: tags we don't recognise are silently swallowed
+        // by the callback (when engageOnTap=false or non-IsoDep), but we MUST
+        // claim them at the reader-mode level so the OS doesn't fall through
+        // to its default tag dispatcher (TECH_DISCOVERED → system TagViewer,
+        // OEM "tag scanner" overlays, NDEF auto-launch, etc.). Observed in
+        // the wild: Pixel + Google Wallet emits NFC-F during ISO 18013-5
+        // engagement; without FLAG_READER_NFC_F our reader mode misses it
+        // and Samsung's OS launches com.android.apps.tag/.TagViewer.
+        // FLAG_READER_NO_PLATFORM_SOUNDS also kills the system tag-detected
+        // chime, which otherwise plays even on tags we silently swallow.
         private const val READER_FLAGS =
             NfcAdapter.FLAG_READER_NFC_A or
                 NfcAdapter.FLAG_READER_NFC_B or
-                NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK
+                NfcAdapter.FLAG_READER_NFC_F or
+                NfcAdapter.FLAG_READER_NFC_V or
+                NfcAdapter.FLAG_READER_NFC_BARCODE or
+                NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK or
+                NfcAdapter.FLAG_READER_NO_PLATFORM_SOUNDS
     }
 }

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NfcReaderEngagement.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NfcReaderEngagement.kt
@@ -21,6 +21,7 @@ import com.spruceid.mobile.sdk.rs.ReaderApduProgress
 import com.spruceid.mobile.sdk.rs.ReaderHandover
 import com.spruceid.mobile.sdk.rs.newReaderApduHandoverDriver
 import java.io.IOException
+import java.lang.ref.WeakReference
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -129,25 +130,43 @@ class NfcReaderEngagement(
     // dispatcher. The next tap then hits the OS overlay (`new tag scanned` /
     // `Unknown tag`) instead of our callback. Re-arm reader mode whenever a
     // camera transitions from in-use back to available.
-    private val cameraAvailabilityCallback = object : CameraManager.AvailabilityCallback() {
-        override fun onCameraUnavailable(cameraId: String) {
-            unavailableCameras.add(cameraId)
-        }
+    //
+    // The callback is a static nested class holding the engagement weakly
+    // so that if `release()` is somehow skipped, the registered callback
+    // (which CameraManager keeps strongly) does not pin the engagement —
+    // and therefore the Activity — in memory. In normal usage release()
+    // unregisters it; this is belt-and-braces.
+    private val cameraAvailabilityCallback = WeakCameraAvailabilityCallback(this)
 
-        override fun onCameraAvailable(cameraId: String) {
-            val wasUnavailable = unavailableCameras.remove(cameraId)
-            if (!wasUnavailable) return
-            if (!running) return
-            // NfcService has already finished its setReaderMode(uid=1000) +
-            // restoreSavedTech sequence by the time this callback fires; we
-            // just need to be on the main thread to re-arm.
-            mainHandler.post {
-                val adapter = nfcAdapter ?: return@post
-                if (running && adapter.isEnabled) {
-                    Log.d(TAG, "Camera released; re-arming reader mode")
-                    adapter.enableReaderMode(activity, readerCallback, READER_FLAGS, null)
-                }
+    private fun onCameraUnavailableInternal(cameraId: String) {
+        unavailableCameras.add(cameraId)
+    }
+
+    private fun onCameraAvailableInternal(cameraId: String) {
+        val wasUnavailable = unavailableCameras.remove(cameraId)
+        if (!wasUnavailable) return
+        if (!running) return
+        // NfcService has already finished its setReaderMode(uid=1000) +
+        // restoreSavedTech sequence by the time this callback fires; we
+        // just need to be on the main thread to re-arm.
+        mainHandler.post {
+            val adapter = nfcAdapter ?: return@post
+            if (running && adapter.isEnabled) {
+                Log.d(TAG, "Camera released; re-arming reader mode")
+                adapter.enableReaderMode(activity, readerCallback, READER_FLAGS, null)
             }
+        }
+    }
+
+    private class WeakCameraAvailabilityCallback(
+        engagement: NfcReaderEngagement,
+    ) : CameraManager.AvailabilityCallback() {
+        private val ref = WeakReference(engagement)
+        override fun onCameraUnavailable(cameraId: String) {
+            ref.get()?.onCameraUnavailableInternal(cameraId)
+        }
+        override fun onCameraAvailable(cameraId: String) {
+            ref.get()?.onCameraAvailableInternal(cameraId)
         }
     }
 

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NfcReaderEngagement.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NfcReaderEngagement.kt
@@ -1,6 +1,10 @@
 package com.spruceid.mobile.sdk.nfc
 
 import android.app.Activity
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.nfc.NfcAdapter
 import android.nfc.Tag
 import android.nfc.TagLostException
@@ -8,6 +12,9 @@ import android.nfc.tech.IsoDep
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
 import com.spruceid.mobile.sdk.rs.ReaderApduHandoverException
 import com.spruceid.mobile.sdk.rs.ReaderApduProgress
 import com.spruceid.mobile.sdk.rs.ReaderHandover
@@ -17,56 +24,102 @@ import java.io.IOException
 /**
  * Drives the reader (verifier) side of ISO 18013-5 NFC engagement.
  *
- * Lifecycle (Activity-scoped):
- *  1. Construct with the hosting [Activity] and an event handler.
- *  2. Call [start] when the user is ready to tap (e.g. when a verifier
- *     screen becomes active). [start] enables NFC reader mode and emits
- *     [Event.WaitingForTag].
- *  3. On tap, the APDU exchange runs on a binder thread; events are always
- *     delivered to the consumer on the main thread.
- *  4. Call [stop] when leaving the screen. After [Event.Success] reader
- *     mode is intentionally NOT released — only [engageOnTap] is flipped
- *     to false. Callers typically keep the device in initiator role
- *     through the post-handover BLE phase so foreign HCE services,
- *     wallet pickers, and OS tag dispatchers stay suppressed while the
- *     phones may still be in proximity.
+ * Most integrators should prefer [rememberNfcReaderEngagement] from the
+ * Compose helper, which wraps this class with lifecycle binding, activity
+ * discovery, and event-to-state translation. This class is the lower-level
+ * primitive for non-Compose hosts.
  *
- * Transient failures (tag lost, I/O) are recovered automatically: reader
- * mode stays on and the next tap starts a fresh handover. This handles
- * holders that disconnect after the first APDU to show a wallet picker
- * and reconnect (e.g. Samsung Wallet).
+ * Typical lifecycle when used directly:
+ *  1. Construct with the hosting [Activity] and an event handler. The
+ *     constructor registers an internal receiver for NFC adapter state
+ *     changes so [Event.NfcDisabled] / [Event.WaitingForTag] are emitted
+ *     when the user toggles NFC in system settings.
+ *  2. Call [bindToLifecycle] with the activity's [LifecycleOwner] so
+ *     reader mode follows the activity's RESUMED/PAUSED state and the
+ *     instance is automatically [release]d on DESTROYED. Or, drive
+ *     [start] / [stop] / [release] manually.
+ *  3. Toggle [setActive] off when the UI is foreground but not actively
+ *     soliciting a tap (e.g. on a different tab). Reader mode stays on
+ *     to keep the device in initiator role (suppressing foreign HCE,
+ *     wallet pickers, and OS tag dispatchers) but detected taps are
+ *     silently swallowed.
+ *
+ * After [Event.Success] the SDK automatically calls `setActive(false)`
+ * so a stray second tap during the post-handover BLE phase does not
+ * re-fire the handover. To accept another handover, call `setActive(true)`.
+ *
+ * Transient failures (tag lost, I/O) are recovered automatically: a
+ * [Event.WaitingForTag] follows and the next tap starts a fresh handover.
+ * Protocol failures keep reader mode armed too — the next tap retries.
  */
 class NfcReaderEngagement(
     private val activity: Activity,
     private val onEvent: (Event) -> Unit,
 ) {
     sealed class Event {
+        /** NFC hardware is not present on this device. Terminal. */
+        object NfcUnsupported : Event()
+
+        /** NFC adapter exists but is turned off in system settings. */
+        object NfcDisabled : Event()
+
+        /** Reader mode is armed and waiting for a holder tap. */
         object WaitingForTag : Event()
+
+        /** A tap has been detected; the APDU exchange is in progress. */
         object Exchanging : Event()
-        /** Recoverable failure (tag lost, I/O). Reader mode is still active. */
+
+        /**
+         * Recoverable failure (tag lost, I/O). A [WaitingForTag] is
+         * emitted right after. Safe to ignore — only useful for logging.
+         */
         data class TransientError(val cause: Throwable) : Event()
-        /** Protocol-level failure. Caller should decide whether to [start] again. */
+
+        /**
+         * Protocol-level failure. Reader mode stays armed; the next tap
+         * starts a fresh handover automatically.
+         */
         data class ProtocolError(val cause: Throwable) : Event()
+
+        /** Engagement completed. */
         data class Success(val handover: ReaderHandover) : Event()
     }
 
-    val nfcAdapter: NfcAdapter? = NfcAdapter.getDefaultAdapter(activity)
-
-    val isSupported: Boolean get() = nfcAdapter != null
-    val isEnabled: Boolean get() = nfcAdapter?.isEnabled == true
-
-    /**
-     * When false, detected tags are silently consumed without an APDU exchange
-     * or any [Event] emission. Reader mode itself stays enabled, which is
-     * useful for keeping the device in initiator role (so foreign HCE,
-     * system tag dispatch, OEM "tag scanner" overlays, etc. are suppressed)
-     * while the host UI is foreground but not actively soliciting a tap.
-     */
-    @Volatile
-    var engageOnTap: Boolean = true
+    private val nfcAdapter: NfcAdapter? = NfcAdapter.getDefaultAdapter(activity)
 
     private val mainHandler = Handler(Looper.getMainLooper())
     @Volatile private var running = false
+    @Volatile private var active: Boolean = true
+    private var lifecycleObserver: LifecycleEventObserver? = null
+    private var boundOwner: LifecycleOwner? = null
+    private var receiverRegistered = false
+
+    private val adapterStateReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action != NfcAdapter.ACTION_ADAPTER_STATE_CHANGED) return
+            when (intent.getIntExtra(NfcAdapter.EXTRA_ADAPTER_STATE, NfcAdapter.STATE_OFF)) {
+                NfcAdapter.STATE_ON -> {
+                    // Re-arm reader mode if start() was called before the
+                    // user toggled NFC off.
+                    if (running) {
+                        nfcAdapter?.enableReaderMode(activity, readerCallback, READER_FLAGS, null)
+                        emit(Event.WaitingForTag)
+                    }
+                }
+                NfcAdapter.STATE_OFF -> emit(Event.NfcDisabled)
+            }
+        }
+    }
+
+    init {
+        if (nfcAdapter != null) {
+            activity.registerReceiver(
+                adapterStateReceiver,
+                IntentFilter(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED),
+            )
+            receiverRegistered = true
+        }
+    }
 
     private val readerCallback = NfcAdapter.ReaderCallback { tag: Tag ->
         // Guard against stale invocations that the system may dispatch after
@@ -75,8 +128,8 @@ class NfcReaderEngagement(
             Log.d(TAG, "Ignoring tag detection after stop()")
             return@ReaderCallback
         }
-        if (!engageOnTap) {
-            Log.d(TAG, "Tag detected but engagement is paused; swallowing")
+        if (!active) {
+            Log.d(TAG, "Tag detected but engagement is inactive; swallowing")
             return@ReaderCallback
         }
         emit(Event.Exchanging)
@@ -112,7 +165,7 @@ class NfcReaderEngagement(
                         // phase so the device stays in initiator role and no
                         // foreign HCE service / OS tag dispatcher gets fired
                         // while the phones may still be in proximity.
-                        engageOnTap = false
+                        active = false
                         val handover = progress.v1
                         mainHandler.post { onEvent(Event.Success(handover)) }
                         return@ReaderCallback
@@ -134,25 +187,89 @@ class NfcReaderEngagement(
     }
 
     /**
-     * Enable reader mode. Returns true if reader mode was activated.
-     * Returns false if NFC is unsupported or disabled — callers should
-     * check [isSupported] / [isEnabled] beforehand to give a useful UI.
+     * Bind reader mode to a [LifecycleOwner]. Maps RESUMED → [start],
+     * PAUSED → [stop], DESTROYED → [release]. Idempotent — calling again
+     * replaces any previous binding.
+     */
+    fun bindToLifecycle(owner: LifecycleOwner) {
+        boundOwner?.let { prev ->
+            lifecycleObserver?.let { prev.lifecycle.removeObserver(it) }
+        }
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_RESUME -> start()
+                Lifecycle.Event.ON_PAUSE -> stop()
+                Lifecycle.Event.ON_DESTROY -> release()
+                else -> {}
+            }
+        }
+        owner.lifecycle.addObserver(observer)
+        lifecycleObserver = observer
+        boundOwner = owner
+    }
+
+    /**
+     * Set whether detected taps should be processed. When false, taps are
+     * silently swallowed but reader mode stays on, keeping the device in
+     * initiator role (so foreign HCE services, wallet pickers, and OS
+     * tag dispatchers stay suppressed) while the host UI is not actively
+     * soliciting a tap.
+     *
+     * The SDK automatically sets active=false after delivering
+     * [Event.Success]; call `setActive(true)` to accept another handover.
+     */
+    fun setActive(active: Boolean) {
+        this.active = active
+    }
+
+    /**
+     * Enable reader mode. If NFC is unsupported or disabled, emits the
+     * corresponding event and returns false; callers don't need to check
+     * up-front. Idempotent.
      */
     fun start(): Boolean {
         if (running) return true
-        val adapter = nfcAdapter ?: return false
-        if (!adapter.isEnabled) return false
+        val adapter = nfcAdapter ?: run {
+            emit(Event.NfcUnsupported)
+            return false
+        }
+        if (!adapter.isEnabled) {
+            emit(Event.NfcDisabled)
+            return false
+        }
         running = true
         adapter.enableReaderMode(activity, readerCallback, READER_FLAGS, null)
         emit(Event.WaitingForTag)
         return true
     }
 
-    /** Disable reader mode. Idempotent. */
+    /** Disable reader mode. Idempotent. The instance remains usable. */
     fun stop() {
         if (!running) return
         running = false
         nfcAdapter?.disableReaderMode(activity)
+    }
+
+    /**
+     * Fully tear down: [stop] reader mode, unregister the adapter state
+     * receiver, and detach any lifecycle binding. After [release] the
+     * instance is unusable. Idempotent.
+     */
+    fun release() {
+        stop()
+        if (receiverRegistered) {
+            try {
+                activity.unregisterReceiver(adapterStateReceiver)
+            } catch (_: IllegalArgumentException) {
+                // Already unregistered.
+            }
+            receiverRegistered = false
+        }
+        boundOwner?.let { owner ->
+            lifecycleObserver?.let { owner.lifecycle.removeObserver(it) }
+        }
+        boundOwner = null
+        lifecycleObserver = null
     }
 
     private fun emit(event: Event) {
@@ -167,7 +284,7 @@ class NfcReaderEngagement(
         private const val TAG = "NfcReaderEngagement"
         private const val TRANSCEIVE_TIMEOUT_MS = 20_000
         // Claim every NFC tech: tags we don't recognise are silently swallowed
-        // by the callback (when engageOnTap=false or non-IsoDep), but we MUST
+        // by the callback (when active=false or non-IsoDep), but we MUST
         // claim them at the reader-mode level so the OS doesn't fall through
         // to its default tag dispatcher (TECH_DISCOVERED → system TagViewer,
         // OEM "tag scanner" overlays, NDEF auto-launch, etc.). Observed in

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NfcReaderEngagementCompose.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/nfc/NfcReaderEngagementCompose.kt
@@ -1,0 +1,126 @@
+package com.spruceid.mobile.sdk.nfc
+
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import com.spruceid.mobile.sdk.rs.ReaderHandover
+
+/** UI-facing phase for an NFC reader engagement. */
+sealed class NfcReaderPhase {
+    /** NFC hardware is not present on this device. */
+    object Unsupported : NfcReaderPhase()
+
+    /** NFC is turned off in system settings. */
+    object Disabled : NfcReaderPhase()
+
+    /** Reader mode is armed; waiting for a holder tap. */
+    object WaitingForTag : NfcReaderPhase()
+
+    /** A tap has been detected; the APDU exchange is in progress. */
+    object Exchanging : NfcReaderPhase()
+
+    /** Protocol-level failure. Reader mode stays armed; the next tap retries. */
+    data class ProtocolError(val cause: Throwable) : NfcReaderPhase()
+}
+
+/**
+ * One-stop Compose entry point for reader-side NFC engagement.
+ *
+ * Handles activity discovery, lifecycle binding, NFC adapter state, and
+ * event-to-phase translation. Typical use from a verifier screen:
+ *
+ * ```
+ * val phase by rememberNfcReaderEngagement(
+ *     onHandover = { handover -> startBleSession(handover) },
+ *     active = onNfcTab && state == State.SCANNING,
+ * )
+ * when (phase) {
+ *     NfcReaderPhase.Unsupported -> Text("No NFC on this device")
+ *     NfcReaderPhase.Disabled -> Text("Turn NFC on in settings")
+ *     NfcReaderPhase.WaitingForTag -> Text("Tap the holder's phone")
+ *     NfcReaderPhase.Exchanging -> CircularProgressIndicator()
+ *     is NfcReaderPhase.ProtocolError -> Text(phase.cause.message ?: "Error")
+ * }
+ * ```
+ *
+ * Flip [active] off whenever the UI is not actively soliciting a tap
+ * (different tab, transmitting over BLE, results screen). Reader mode
+ * stays on so the device keeps the NFC controller in initiator role
+ * (suppressing wallet pickers, foreign HCE services, and OS tag
+ * dispatchers from triggering on stray taps) but events are not emitted
+ * while inactive.
+ *
+ * If the hosting context is not a [ComponentActivity] (e.g. Compose
+ * previews) the returned state stays at [NfcReaderPhase.Unsupported].
+ */
+@Composable
+fun rememberNfcReaderEngagement(
+    onHandover: (ReaderHandover) -> Unit,
+    active: Boolean = true,
+): State<NfcReaderPhase> {
+    val context = LocalContext.current
+    val activity = remember(context) { context.findComponentActivity() }
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val onHandoverState = rememberUpdatedState(onHandover)
+
+    val phase = remember { mutableStateOf<NfcReaderPhase>(NfcReaderPhase.WaitingForTag) }
+
+    if (activity == null) {
+        phase.value = NfcReaderPhase.Unsupported
+        return phase
+    }
+
+    val engagement = remember(activity) {
+        NfcReaderEngagement(activity) { event ->
+            when (event) {
+                is NfcReaderEngagement.Event.NfcUnsupported ->
+                    phase.value = NfcReaderPhase.Unsupported
+                is NfcReaderEngagement.Event.NfcDisabled ->
+                    phase.value = NfcReaderPhase.Disabled
+                is NfcReaderEngagement.Event.WaitingForTag ->
+                    phase.value = NfcReaderPhase.WaitingForTag
+                is NfcReaderEngagement.Event.Exchanging ->
+                    phase.value = NfcReaderPhase.Exchanging
+                is NfcReaderEngagement.Event.TransientError -> {
+                    // WaitingForTag follows automatically; nothing to do.
+                }
+                is NfcReaderEngagement.Event.ProtocolError ->
+                    phase.value = NfcReaderPhase.ProtocolError(event.cause)
+                is NfcReaderEngagement.Event.Success ->
+                    onHandoverState.value(event.handover)
+            }
+        }
+    }
+
+    DisposableEffect(engagement, lifecycleOwner) {
+        // Apply the initial `active` value synchronously before binding to
+        // the lifecycle: bindToLifecycle may fire ON_RESUME immediately if
+        // the activity is already resumed, and we want the first tap (if
+        // any) to honor the caller's `active=false` rather than the SDK
+        // default of true.
+        engagement.setActive(active)
+        engagement.bindToLifecycle(lifecycleOwner)
+        onDispose { engagement.release() }
+    }
+
+    LaunchedEffect(engagement, active) {
+        engagement.setActive(active)
+    }
+
+    return phase
+}
+
+private tailrec fun Context.findComponentActivity(): ComponentActivity? = when (this) {
+    is ComponentActivity -> this
+    is ContextWrapper -> baseContext.findComponentActivity()
+    else -> null
+}

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/verifier/VerifyMDocNfcTab.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/verifier/VerifyMDocNfcTab.kt
@@ -2,7 +2,6 @@ package com.spruceid.mobilesdkexample.verifier
 
 import android.content.Intent
 import android.provider.Settings
-import androidx.activity.ComponentActivity
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -18,11 +17,6 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -31,15 +25,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.spruceid.mobile.sdk.nfc.NfcReaderEngagement
-import com.spruceid.mobile.sdk.rs.ReaderHandover
 import com.spruceid.mobilesdkexample.ui.theme.ColorBlue600
 import com.spruceid.mobilesdkexample.ui.theme.ColorStone300
 import com.spruceid.mobilesdkexample.ui.theme.ColorStone500
 import com.spruceid.mobilesdkexample.ui.theme.ColorStone950
 import com.spruceid.mobilesdkexample.ui.theme.Inter
 
-private sealed class NfcTabUi {
+internal sealed class NfcTabUi {
     object NfcUnsupported : NfcTabUi()
     object NfcDisabled : NfcTabUi()
     object WaitingForTag : NfcTabUi()
@@ -47,45 +39,19 @@ private sealed class NfcTabUi {
     data class ProtocolError(val message: String) : NfcTabUi()
 }
 
+/**
+ * Pure UI for the NFC verifier tab. Engagement lifecycle (reader mode,
+ * APDU exchange) is owned by the parent [VerifyMDocView] which lifts the
+ * [NfcReaderEngagement] to the screen scope so reader mode can stay on
+ * across all tabs and states.
+ */
 @Composable
-fun VerifyMDocNfcTab(
-    active: Boolean,
-    onHandover: (ReaderHandover) -> Unit,
+internal fun VerifyMDocNfcTab(
+    nfcUi: NfcTabUi,
+    onRetry: () -> Unit,
     onCancel: () -> Unit,
 ) {
     val context = LocalContext.current
-    val activity = context as ComponentActivity
-    var ui by remember { mutableStateOf<NfcTabUi>(NfcTabUi.WaitingForTag) }
-
-    val engagement = remember(activity) {
-        NfcReaderEngagement(activity) { event ->
-            ui = when (event) {
-                is NfcReaderEngagement.Event.WaitingForTag -> NfcTabUi.WaitingForTag
-                is NfcReaderEngagement.Event.Exchanging -> NfcTabUi.Exchanging
-                is NfcReaderEngagement.Event.TransientError -> ui // already handled by next WaitingForTag
-                is NfcReaderEngagement.Event.ProtocolError -> NfcTabUi.ProtocolError(
-                    event.cause.localizedMessage ?: event.cause.message ?: "Handover failed"
-                )
-                is NfcReaderEngagement.Event.Success -> {
-                    onHandover(event.handover)
-                    NfcTabUi.WaitingForTag
-                }
-            }
-        }
-    }
-
-    DisposableEffect(active, engagement.isSupported, engagement.isEnabled) {
-        ui = when {
-            !engagement.isSupported -> NfcTabUi.NfcUnsupported
-            !engagement.isEnabled -> NfcTabUi.NfcDisabled
-            active -> {
-                engagement.start()
-                NfcTabUi.WaitingForTag
-            }
-            else -> ui
-        }
-        onDispose { engagement.stop() }
-    }
 
     Column(
         modifier = Modifier
@@ -102,7 +68,7 @@ fun VerifyMDocNfcTab(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center,
             ) {
-                when (val s = ui) {
+                when (val s = nfcUi) {
                     is NfcTabUi.NfcUnsupported -> {
                         Text(
                             text = "This device does not support NFC.",
@@ -174,7 +140,7 @@ fun VerifyMDocNfcTab(
                         )
                         Spacer(modifier = Modifier.height(24.dp))
                         Button(
-                            onClick = { ui = NfcTabUi.WaitingForTag },
+                            onClick = onRetry,
                             colors = ButtonDefaults.buttonColors(containerColor = ColorBlue600),
                             shape = RoundedCornerShape(5.dp),
                         ) {

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/verifier/VerifyMDocNfcTab.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/verifier/VerifyMDocNfcTab.kt
@@ -1,0 +1,210 @@
+package com.spruceid.mobilesdkexample.verifier
+
+import android.content.Intent
+import android.provider.Settings
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.spruceid.mobile.sdk.nfc.NfcReaderEngagement
+import com.spruceid.mobile.sdk.rs.ReaderHandover
+import com.spruceid.mobilesdkexample.ui.theme.ColorBlue600
+import com.spruceid.mobilesdkexample.ui.theme.ColorStone300
+import com.spruceid.mobilesdkexample.ui.theme.ColorStone500
+import com.spruceid.mobilesdkexample.ui.theme.ColorStone950
+import com.spruceid.mobilesdkexample.ui.theme.Inter
+
+private sealed class NfcTabUi {
+    object NfcUnsupported : NfcTabUi()
+    object NfcDisabled : NfcTabUi()
+    object WaitingForTag : NfcTabUi()
+    object Exchanging : NfcTabUi()
+    data class ProtocolError(val message: String) : NfcTabUi()
+}
+
+@Composable
+fun VerifyMDocNfcTab(
+    active: Boolean,
+    onHandover: (ReaderHandover) -> Unit,
+    onCancel: () -> Unit,
+) {
+    val context = LocalContext.current
+    val activity = context as ComponentActivity
+    var ui by remember { mutableStateOf<NfcTabUi>(NfcTabUi.WaitingForTag) }
+
+    val engagement = remember(activity) {
+        NfcReaderEngagement(activity) { event ->
+            ui = when (event) {
+                is NfcReaderEngagement.Event.WaitingForTag -> NfcTabUi.WaitingForTag
+                is NfcReaderEngagement.Event.Exchanging -> NfcTabUi.Exchanging
+                is NfcReaderEngagement.Event.TransientError -> ui // already handled by next WaitingForTag
+                is NfcReaderEngagement.Event.ProtocolError -> NfcTabUi.ProtocolError(
+                    event.cause.localizedMessage ?: event.cause.message ?: "Handover failed"
+                )
+                is NfcReaderEngagement.Event.Success -> {
+                    onHandover(event.handover)
+                    NfcTabUi.WaitingForTag
+                }
+            }
+        }
+    }
+
+    DisposableEffect(active, engagement.isSupported, engagement.isEnabled) {
+        ui = when {
+            !engagement.isSupported -> NfcTabUi.NfcUnsupported
+            !engagement.isEnabled -> NfcTabUi.NfcDisabled
+            active -> {
+                engagement.start()
+                NfcTabUi.WaitingForTag
+            }
+            else -> ui
+        }
+        onDispose { engagement.stop() }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                when (val s = ui) {
+                    is NfcTabUi.NfcUnsupported -> {
+                        Text(
+                            text = "This device does not support NFC.",
+                            fontFamily = Inter,
+                            fontSize = 16.sp,
+                            color = ColorStone950,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                    is NfcTabUi.NfcDisabled -> {
+                        Text(
+                            text = "NFC is turned off. Enable NFC in system settings to continue.",
+                            fontFamily = Inter,
+                            fontSize = 16.sp,
+                            color = ColorStone950,
+                            textAlign = TextAlign.Center,
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Button(
+                            onClick = {
+                                context.startActivity(Intent(Settings.ACTION_NFC_SETTINGS))
+                            },
+                            colors = ButtonDefaults.buttonColors(containerColor = ColorBlue600),
+                            shape = RoundedCornerShape(5.dp),
+                        ) {
+                            Text(
+                                "Open NFC Settings",
+                                fontFamily = Inter,
+                                fontWeight = FontWeight.SemiBold,
+                                color = Color.White,
+                            )
+                        }
+                    }
+                    is NfcTabUi.WaitingForTag -> {
+                        Text(
+                            text = "Tap the holder's phone to share their credential.",
+                            fontFamily = Inter,
+                            fontSize = 18.sp,
+                            fontWeight = FontWeight.Medium,
+                            color = ColorStone950,
+                            textAlign = TextAlign.Center,
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Text(
+                            text = "Hold the phones back-to-back until the share completes.",
+                            fontFamily = Inter,
+                            fontSize = 14.sp,
+                            color = ColorStone500,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                    is NfcTabUi.Exchanging -> {
+                        CircularProgressIndicator(color = ColorBlue600)
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text(
+                            text = "Negotiating handover…",
+                            fontFamily = Inter,
+                            fontSize = 16.sp,
+                            color = ColorStone500,
+                        )
+                    }
+                    is NfcTabUi.ProtocolError -> {
+                        Text(
+                            text = s.message,
+                            fontFamily = Inter,
+                            fontSize = 16.sp,
+                            color = Color.Red,
+                            textAlign = TextAlign.Center,
+                        )
+                        Spacer(modifier = Modifier.height(24.dp))
+                        Button(
+                            onClick = { ui = NfcTabUi.WaitingForTag },
+                            colors = ButtonDefaults.buttonColors(containerColor = ColorBlue600),
+                            shape = RoundedCornerShape(5.dp),
+                        ) {
+                            Text(
+                                "Try again",
+                                fontFamily = Inter,
+                                fontWeight = FontWeight.SemiBold,
+                                color = Color.White,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        Button(
+            onClick = onCancel,
+            modifier = Modifier.fillMaxWidth(),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color.Transparent,
+                contentColor = Color.Black,
+            ),
+            border = BorderStroke(1.dp, ColorStone300),
+            shape = RoundedCornerShape(5.dp),
+        ) {
+            Text(
+                "Cancel",
+                fontFamily = Inter,
+                fontWeight = FontWeight.SemiBold,
+                color = Color.Black,
+            )
+        }
+    }
+}

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/verifier/VerifyMDocNfcTab.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/verifier/VerifyMDocNfcTab.kt
@@ -25,30 +25,21 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.spruceid.mobile.sdk.nfc.NfcReaderPhase
 import com.spruceid.mobilesdkexample.ui.theme.ColorBlue600
 import com.spruceid.mobilesdkexample.ui.theme.ColorStone300
 import com.spruceid.mobilesdkexample.ui.theme.ColorStone500
 import com.spruceid.mobilesdkexample.ui.theme.ColorStone950
 import com.spruceid.mobilesdkexample.ui.theme.Inter
 
-internal sealed class NfcTabUi {
-    object NfcUnsupported : NfcTabUi()
-    object NfcDisabled : NfcTabUi()
-    object WaitingForTag : NfcTabUi()
-    object Exchanging : NfcTabUi()
-    data class ProtocolError(val message: String) : NfcTabUi()
-}
-
 /**
  * Pure UI for the NFC verifier tab. Engagement lifecycle (reader mode,
- * APDU exchange) is owned by the parent [VerifyMDocView] which lifts the
- * [NfcReaderEngagement] to the screen scope so reader mode can stay on
- * across all tabs and states.
+ * APDU exchange, NFC adapter state) is owned by the parent [VerifyMDocView]
+ * via [com.spruceid.mobile.sdk.nfc.rememberNfcReaderEngagement].
  */
 @Composable
 internal fun VerifyMDocNfcTab(
-    nfcUi: NfcTabUi,
-    onRetry: () -> Unit,
+    phase: NfcReaderPhase,
     onCancel: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -68,8 +59,8 @@ internal fun VerifyMDocNfcTab(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center,
             ) {
-                when (val s = nfcUi) {
-                    is NfcTabUi.NfcUnsupported -> {
+                when (phase) {
+                    NfcReaderPhase.Unsupported -> {
                         Text(
                             text = "This device does not support NFC.",
                             fontFamily = Inter,
@@ -78,7 +69,7 @@ internal fun VerifyMDocNfcTab(
                             textAlign = TextAlign.Center,
                         )
                     }
-                    is NfcTabUi.NfcDisabled -> {
+                    NfcReaderPhase.Disabled -> {
                         Text(
                             text = "NFC is turned off. Enable NFC in system settings to continue.",
                             fontFamily = Inter,
@@ -102,7 +93,7 @@ internal fun VerifyMDocNfcTab(
                             )
                         }
                     }
-                    is NfcTabUi.WaitingForTag -> {
+                    NfcReaderPhase.WaitingForTag -> {
                         Text(
                             text = "Tap the holder's phone to share their credential.",
                             fontFamily = Inter,
@@ -120,7 +111,7 @@ internal fun VerifyMDocNfcTab(
                             textAlign = TextAlign.Center,
                         )
                     }
-                    is NfcTabUi.Exchanging -> {
+                    NfcReaderPhase.Exchanging -> {
                         CircularProgressIndicator(color = ColorBlue600)
                         Spacer(modifier = Modifier.height(16.dp))
                         Text(
@@ -130,27 +121,24 @@ internal fun VerifyMDocNfcTab(
                             color = ColorStone500,
                         )
                     }
-                    is NfcTabUi.ProtocolError -> {
+                    is NfcReaderPhase.ProtocolError -> {
                         Text(
-                            text = s.message,
+                            text = phase.cause.localizedMessage
+                                ?: phase.cause.message
+                                ?: "Handover failed",
                             fontFamily = Inter,
                             fontSize = 16.sp,
                             color = Color.Red,
                             textAlign = TextAlign.Center,
                         )
                         Spacer(modifier = Modifier.height(24.dp))
-                        Button(
-                            onClick = onRetry,
-                            colors = ButtonDefaults.buttonColors(containerColor = ColorBlue600),
-                            shape = RoundedCornerShape(5.dp),
-                        ) {
-                            Text(
-                                "Try again",
-                                fontFamily = Inter,
-                                fontWeight = FontWeight.SemiBold,
-                                color = Color.White,
-                            )
-                        }
+                        Text(
+                            text = "Tap again to retry.",
+                            fontFamily = Inter,
+                            fontSize = 14.sp,
+                            color = ColorStone500,
+                            textAlign = TextAlign.Center,
+                        )
                     }
                 }
             }

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/verifier/VerifyMDocView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/verifier/VerifyMDocView.kt
@@ -5,6 +5,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.nfc.NfcAdapter
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -290,36 +291,70 @@ fun VerifyMDocView(
 
     val pagerState = rememberPagerState(initialPage = 0, pageCount = { 2 })
 
-    val activity = context as ComponentActivity
+    val activity = context as? ComponentActivity
     var nfcUi by remember { mutableStateOf<NfcTabUi>(NfcTabUi.WaitingForTag) }
     val engagement = remember(activity) {
-        NfcReaderEngagement(activity) { event ->
-            when (event) {
-                is NfcReaderEngagement.Event.WaitingForTag ->
-                    nfcUi = NfcTabUi.WaitingForTag
-                is NfcReaderEngagement.Event.Exchanging ->
-                    nfcUi = NfcTabUi.Exchanging
-                is NfcReaderEngagement.Event.TransientError -> {
-                    // Recoverable; the SDK emits WaitingForTag right after.
+        activity?.let { act ->
+            NfcReaderEngagement(act) { event ->
+                when (event) {
+                    is NfcReaderEngagement.Event.WaitingForTag ->
+                        nfcUi = NfcTabUi.WaitingForTag
+                    is NfcReaderEngagement.Event.Exchanging ->
+                        nfcUi = NfcTabUi.Exchanging
+                    is NfcReaderEngagement.Event.TransientError -> {
+                        // Recoverable; the SDK emits WaitingForTag right after.
+                    }
+                    is NfcReaderEngagement.Event.ProtocolError ->
+                        nfcUi = NfcTabUi.ProtocolError(
+                            event.cause.localizedMessage
+                                ?: event.cause.message
+                                ?: "Handover failed"
+                        )
+                    is NfcReaderEngagement.Event.Success ->
+                        onHandover(event.handover)
                 }
-                is NfcReaderEngagement.Event.ProtocolError ->
-                    nfcUi = NfcTabUi.ProtocolError(
-                        event.cause.localizedMessage
-                            ?: event.cause.message
-                            ?: "Handover failed"
-                    )
-                is NfcReaderEngagement.Event.Success ->
-                    onHandover(event.handover)
             }
         }
     }
 
-    LaunchedEffect(Unit) {
+    fun refreshNfcUi() {
+        val eng = engagement
         nfcUi = when {
-            !engagement.isSupported -> NfcTabUi.NfcUnsupported
-            !engagement.isEnabled -> NfcTabUi.NfcDisabled
+            eng == null || !eng.isSupported -> NfcTabUi.NfcUnsupported
+            !eng.isEnabled -> NfcTabUi.NfcDisabled
             else -> NfcTabUi.WaitingForTag
         }
+    }
+
+    LaunchedEffect(Unit) {
+        refreshNfcUi()
+    }
+
+    // Track NFC adapter state changes so the UI recovers when the user
+    // enables NFC via system settings (e.g. through the "Open NFC Settings"
+    // button on the disabled-state screen).
+    DisposableEffect(Unit) {
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                if (intent?.action == NfcAdapter.ACTION_ADAPTER_STATE_CHANGED) {
+                    val state = intent.getIntExtra(
+                        NfcAdapter.EXTRA_ADAPTER_STATE,
+                        NfcAdapter.STATE_OFF
+                    )
+                    when (state) {
+                        NfcAdapter.STATE_ON -> {
+                            engagement?.start()
+                            refreshNfcUi()
+                        }
+                        NfcAdapter.STATE_OFF ->
+                            nfcUi = NfcTabUi.NfcDisabled
+                    }
+                }
+            }
+        }
+        val filter = IntentFilter(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED)
+        context.registerReceiver(receiver, filter)
+        onDispose { context.unregisterReceiver(receiver) }
     }
 
     // Reader mode is on for the entire VerifyMDocView lifecycle. While on,
@@ -328,15 +363,15 @@ fun VerifyMDocView(
     // wallet pickers, and OS-level tag dispatchers (e.g. Samsung's "tag
     // scanner" overlay) all stay quiet for the duration of the verifier flow.
     DisposableEffect(Unit) {
-        engagement.start()
-        onDispose { engagement.stop() }
+        engagement?.start()
+        onDispose { engagement?.stop() }
     }
 
     // Only actually run the APDU exchange while the user is on the NFC tab
     // and we're still in SCANNING. In every other case (QR tab, BT prompt,
     // BLE transmission, results screen) detected tags are silently swallowed.
     LaunchedEffect(scanProcessState, pagerState.settledPage) {
-        engagement.engageOnTap = scanProcessState == State.SCANNING &&
+        engagement?.engageOnTap = scanProcessState == State.SCANNING &&
             pagerState.settledPage == 1
     }
 

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/verifier/VerifyMDocView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/verifier/VerifyMDocView.kt
@@ -3,6 +3,7 @@ package com.spruceid.mobilesdkexample.verifier
 import android.bluetooth.BluetoothAdapter
 import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.Intent
 import android.content.IntentFilter
 import android.nfc.NfcAdapter
@@ -45,6 +46,9 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -291,7 +295,11 @@ fun VerifyMDocView(
 
     val pagerState = rememberPagerState(initialPage = 0, pageCount = { 2 })
 
-    val activity = context as? ComponentActivity
+    // Walk the ContextWrapper chain to find the owning ComponentActivity.
+    // A direct `context as? ComponentActivity` cast happens to work today
+    // (LocalContext.current is the Activity), but stays robust if a wrapper
+    // is ever inserted between the composition and the Activity.
+    val activity = remember(context) { context.findComponentActivity() }
     var nfcUi by remember { mutableStateOf<NfcTabUi>(NfcTabUi.WaitingForTag) }
     val engagement = remember(activity) {
         activity?.let { act ->
@@ -357,14 +365,29 @@ fun VerifyMDocView(
         onDispose { context.unregisterReceiver(receiver) }
     }
 
-    // Reader mode is on for the entire VerifyMDocView lifecycle. While on,
-    // the device is in initiator role only — its HCE controller is dormant,
-    // so foreign HCE services (payment apps, our own NfcPresentationService),
-    // wallet pickers, and OS-level tag dispatchers (e.g. Samsung's "tag
-    // scanner" overlay) all stay quiet for the duration of the verifier flow.
-    DisposableEffect(Unit) {
-        engagement?.start()
-        onDispose { engagement?.stop() }
+    // Reader mode is bound to the Activity's RESUMED/PAUSED lifecycle, not
+    // to first composition. The OS auto-disables reader mode whenever our
+    // Activity loses top-resumed (e.g. when the post-tap OS overlay
+    // launches), and a one-shot DisposableEffect(Unit) would never
+    // re-enable it. Reader mode keeps the device in initiator role: its
+    // HCE controller is dormant, so foreign HCE services (payment apps,
+    // our own NfcPresentationService), wallet pickers, and OS-level tag
+    // dispatchers stay quiet — except on Samsung, see note in
+    // NfcReaderEngagement.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner, engagement) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_RESUME -> engagement?.start()
+                Lifecycle.Event.ON_PAUSE -> engagement?.stop()
+                else -> {}
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            engagement?.stop()
+        }
     }
 
     // Only actually run the APDU exchange while the user is on the NFC tab
@@ -517,4 +540,10 @@ private fun VerifyMDocEngagementTabs(
             }
         }
     }
+}
+
+private tailrec fun Context.findComponentActivity(): ComponentActivity? = when (this) {
+    is ComponentActivity -> this
+    is ContextWrapper -> baseContext.findComponentActivity()
+    else -> null
 }

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/verifier/VerifyMDocView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/verifier/VerifyMDocView.kt
@@ -8,14 +8,23 @@ import android.content.IntentFilter
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -30,8 +39,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -43,11 +55,16 @@ import com.spruceid.mobile.sdk.getBluetoothManager
 import com.spruceid.mobile.sdk.getPermissions
 import com.spruceid.mobile.sdk.rs.AuthenticationStatus
 import com.spruceid.mobile.sdk.rs.MDocItem
+import com.spruceid.mobile.sdk.rs.ReaderHandover
 import com.spruceid.mobilesdkexample.LoadingView
+import com.spruceid.mobilesdkexample.R
 import com.spruceid.mobilesdkexample.ScanningComponent
 import com.spruceid.mobilesdkexample.ScanningType
 import com.spruceid.mobilesdkexample.db.VerificationActivityLogs
 import com.spruceid.mobilesdkexample.navigation.Screen
+import com.spruceid.mobilesdkexample.ui.theme.ColorBase50
+import com.spruceid.mobilesdkexample.ui.theme.ColorBase600
+import com.spruceid.mobilesdkexample.ui.theme.ColorBlue600
 import com.spruceid.mobilesdkexample.ui.theme.ColorStone300
 import com.spruceid.mobilesdkexample.ui.theme.Inter
 import com.spruceid.mobilesdkexample.utils.Toast
@@ -237,7 +254,7 @@ fun VerifyMDocView(
         }
     }
 
-    fun onRead(content: String) {
+    fun onHandover(handover: ReaderHandover) {
         scanProcessState = State.TRANSMITTING
         checkAndRequestBluetoothPermissions(
             context.applicationContext,
@@ -249,7 +266,7 @@ fun VerifyMDocView(
             try {
                 reader = IsoMdlReader(
                     bleCallback,
-                    content,
+                    handover,
                     if (checkAgeOver18) {
                         ageOver18Elements
                     } else {
@@ -268,6 +285,8 @@ fun VerifyMDocView(
 
         }
     }
+
+    val pagerState = rememberPagerState(initialPage = 0, pageCount = { 2 })
 
     when (scanProcessState) {
         State.ENABLE_BLUETOOTH -> if (!isBluetoothEnabled) {
@@ -317,13 +336,29 @@ fun VerifyMDocView(
             }
         }
 
-        State.SCANNING -> ScanningComponent(
-            ScanningType.QRCODE,
-            title = "",
-            subtitle = "",
-            onRead = ::onRead,
-            onCancel = ::back
-        )
+        State.SCANNING -> Column(modifier = Modifier.fillMaxSize()) {
+            Box(modifier = Modifier.weight(1f)) {
+                HorizontalPager(state = pagerState) { page ->
+                    when (page) {
+                        0 -> ScanningComponent(
+                            ScanningType.QRCODE,
+                            title = "",
+                            subtitle = "",
+                            onRead = { uri -> onHandover(ReaderHandover.newQr(uri)) },
+                            onCancel = ::back,
+                        )
+                        1 -> VerifyMDocNfcTab(
+                            active = pagerState.settledPage == 1,
+                            onHandover = ::onHandover,
+                            onCancel = ::back,
+                        )
+                    }
+                }
+            }
+            VerifyMDocEngagementTabs(pagerState) { index ->
+                scope.launch { pagerState.animateScrollToPage(index) }
+            }
+        }
 
         State.TRANSMITTING -> LoadingView("Verifying...", "Cancel", ::back)
         State.DONE -> VerifierMDocResultView(
@@ -347,5 +382,52 @@ fun VerifyMDocView(
                 }
             }
         )
+    }
+}
+
+@Composable
+private fun VerifyMDocEngagementTabs(
+    pagerState: PagerState,
+    changeTab: (Int) -> Unit,
+) {
+    val icons = listOf(
+        R.drawable.qrcode_scanner to "QR code engagement",
+        R.drawable.wallet to "NFC engagement",
+    )
+    BottomAppBar(containerColor = ColorBase50) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+        ) {
+            icons.forEachIndexed { index, (drawable, alt) ->
+                Button(
+                    onClick = { changeTab(index) },
+                    modifier = Modifier.weight(1f),
+                    contentPadding = PaddingValues(0.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
+                ) {
+                    val active = pagerState.currentPage == index
+                    Image(
+                        painter = painterResource(id = drawable),
+                        contentDescription = alt,
+                        colorFilter = ColorFilter.tint(
+                            if (active) ColorBlue600 else ColorBase600,
+                        ),
+                        modifier = Modifier
+                            .width(32.dp)
+                            .height(32.dp)
+                            .padding(end = 3.dp)
+                            .drawBehind {
+                                drawLine(
+                                    color = if (active) ColorBlue600 else Color.Transparent,
+                                    start = androidx.compose.ui.geometry.Offset(0f, 0f),
+                                    end = androidx.compose.ui.geometry.Offset(size.width, 0f),
+                                    strokeWidth = 4.dp.toPx(),
+                                )
+                            },
+                    )
+                }
+            }
+        }
     }
 }

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/verifier/VerifyMDocView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/verifier/VerifyMDocView.kt
@@ -3,11 +3,8 @@ package com.spruceid.mobilesdkexample.verifier
 import android.bluetooth.BluetoothAdapter
 import android.content.BroadcastReceiver
 import android.content.Context
-import android.content.ContextWrapper
 import android.content.Intent
 import android.content.IntentFilter
-import android.nfc.NfcAdapter
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
@@ -46,9 +43,6 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -59,7 +53,7 @@ import com.spruceid.mobile.sdk.BLESessionStateDelegate
 import com.spruceid.mobile.sdk.IsoMdlReader
 import com.spruceid.mobile.sdk.getBluetoothManager
 import com.spruceid.mobile.sdk.getPermissions
-import com.spruceid.mobile.sdk.nfc.NfcReaderEngagement
+import com.spruceid.mobile.sdk.nfc.rememberNfcReaderEngagement
 import com.spruceid.mobile.sdk.rs.AuthenticationStatus
 import com.spruceid.mobile.sdk.rs.MDocItem
 import com.spruceid.mobile.sdk.rs.ReaderHandover
@@ -176,7 +170,7 @@ fun VerifyMDocView(
     val trustedCertificatesViewModel: TrustedCertificatesViewModel = activityHiltViewModel()
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    var reader: IsoMdlReader? = null
+    var reader by remember { mutableStateOf<IsoMdlReader?>(null) }
 
     var scanProcessState by remember {
         mutableStateOf(State.ENABLE_BLUETOOTH)
@@ -295,108 +289,15 @@ fun VerifyMDocView(
 
     val pagerState = rememberPagerState(initialPage = 0, pageCount = { 2 })
 
-    // Walk the ContextWrapper chain to find the owning ComponentActivity.
-    // A direct `context as? ComponentActivity` cast happens to work today
-    // (LocalContext.current is the Activity), but stays robust if a wrapper
-    // is ever inserted between the composition and the Activity.
-    val activity = remember(context) { context.findComponentActivity() }
-    var nfcUi by remember { mutableStateOf<NfcTabUi>(NfcTabUi.WaitingForTag) }
-    val engagement = remember(activity) {
-        activity?.let { act ->
-            NfcReaderEngagement(act) { event ->
-                when (event) {
-                    is NfcReaderEngagement.Event.WaitingForTag ->
-                        nfcUi = NfcTabUi.WaitingForTag
-                    is NfcReaderEngagement.Event.Exchanging ->
-                        nfcUi = NfcTabUi.Exchanging
-                    is NfcReaderEngagement.Event.TransientError -> {
-                        // Recoverable; the SDK emits WaitingForTag right after.
-                    }
-                    is NfcReaderEngagement.Event.ProtocolError ->
-                        nfcUi = NfcTabUi.ProtocolError(
-                            event.cause.localizedMessage
-                                ?: event.cause.message
-                                ?: "Handover failed"
-                        )
-                    is NfcReaderEngagement.Event.Success ->
-                        onHandover(event.handover)
-                }
-            }
-        }
-    }
-
-    fun refreshNfcUi() {
-        val eng = engagement
-        nfcUi = when {
-            eng == null || !eng.isSupported -> NfcTabUi.NfcUnsupported
-            !eng.isEnabled -> NfcTabUi.NfcDisabled
-            else -> NfcTabUi.WaitingForTag
-        }
-    }
-
-    LaunchedEffect(Unit) {
-        refreshNfcUi()
-    }
-
-    // Track NFC adapter state changes so the UI recovers when the user
-    // enables NFC via system settings (e.g. through the "Open NFC Settings"
-    // button on the disabled-state screen).
-    DisposableEffect(Unit) {
-        val receiver = object : BroadcastReceiver() {
-            override fun onReceive(context: Context?, intent: Intent?) {
-                if (intent?.action == NfcAdapter.ACTION_ADAPTER_STATE_CHANGED) {
-                    val state = intent.getIntExtra(
-                        NfcAdapter.EXTRA_ADAPTER_STATE,
-                        NfcAdapter.STATE_OFF
-                    )
-                    when (state) {
-                        NfcAdapter.STATE_ON -> {
-                            engagement?.start()
-                            refreshNfcUi()
-                        }
-                        NfcAdapter.STATE_OFF ->
-                            nfcUi = NfcTabUi.NfcDisabled
-                    }
-                }
-            }
-        }
-        val filter = IntentFilter(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED)
-        context.registerReceiver(receiver, filter)
-        onDispose { context.unregisterReceiver(receiver) }
-    }
-
-    // Reader mode is bound to the Activity's RESUMED/PAUSED lifecycle, not
-    // to first composition. The OS auto-disables reader mode whenever our
-    // Activity loses top-resumed (e.g. when the post-tap OS overlay
-    // launches), and a one-shot DisposableEffect(Unit) would never
-    // re-enable it. Reader mode keeps the device in initiator role: its
-    // HCE controller is dormant, so foreign HCE services (payment apps,
-    // our own NfcPresentationService), wallet pickers, and OS-level tag
-    // dispatchers stay quiet — except on Samsung, see note in
-    // NfcReaderEngagement.
-    val lifecycleOwner = LocalLifecycleOwner.current
-    DisposableEffect(lifecycleOwner, engagement) {
-        val observer = LifecycleEventObserver { _, event ->
-            when (event) {
-                Lifecycle.Event.ON_RESUME -> engagement?.start()
-                Lifecycle.Event.ON_PAUSE -> engagement?.stop()
-                else -> {}
-            }
-        }
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose {
-            lifecycleOwner.lifecycle.removeObserver(observer)
-            engagement?.stop()
-        }
-    }
-
-    // Only actually run the APDU exchange while the user is on the NFC tab
-    // and we're still in SCANNING. In every other case (QR tab, BT prompt,
-    // BLE transmission, results screen) detected tags are silently swallowed.
-    LaunchedEffect(scanProcessState, pagerState.settledPage) {
-        engagement?.engageOnTap = scanProcessState == State.SCANNING &&
-            pagerState.settledPage == 1
-    }
+    // Only engage NFC taps while the user is actively on the NFC tab and
+    // we're still in SCANNING. The SDK keeps reader mode on regardless so
+    // the device stays in initiator role (suppressing wallet pickers,
+    // foreign HCE, and OS tag dispatchers).
+    val nfcActive = scanProcessState == State.SCANNING && pagerState.settledPage == 1
+    val nfcPhase by rememberNfcReaderEngagement(
+        onHandover = ::onHandover,
+        active = nfcActive,
+    )
 
     when (scanProcessState) {
         State.ENABLE_BLUETOOTH -> if (!isBluetoothEnabled) {
@@ -458,8 +359,7 @@ fun VerifyMDocView(
                             onCancel = ::back,
                         )
                         1 -> VerifyMDocNfcTab(
-                            nfcUi = nfcUi,
-                            onRetry = { nfcUi = NfcTabUi.WaitingForTag },
+                            phase = nfcPhase,
                             onCancel = ::back,
                         )
                     }
@@ -540,10 +440,4 @@ private fun VerifyMDocEngagementTabs(
             }
         }
     }
-}
-
-private tailrec fun Context.findComponentActivity(): ComponentActivity? = when (this) {
-    is ComponentActivity -> this
-    is ContextWrapper -> baseContext.findComponentActivity()
-    else -> null
 }

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/verifier/VerifyMDocView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/verifier/VerifyMDocView.kt
@@ -5,6 +5,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
@@ -53,6 +54,7 @@ import com.spruceid.mobile.sdk.BLESessionStateDelegate
 import com.spruceid.mobile.sdk.IsoMdlReader
 import com.spruceid.mobile.sdk.getBluetoothManager
 import com.spruceid.mobile.sdk.getPermissions
+import com.spruceid.mobile.sdk.nfc.NfcReaderEngagement
 import com.spruceid.mobile.sdk.rs.AuthenticationStatus
 import com.spruceid.mobile.sdk.rs.MDocItem
 import com.spruceid.mobile.sdk.rs.ReaderHandover
@@ -288,6 +290,56 @@ fun VerifyMDocView(
 
     val pagerState = rememberPagerState(initialPage = 0, pageCount = { 2 })
 
+    val activity = context as ComponentActivity
+    var nfcUi by remember { mutableStateOf<NfcTabUi>(NfcTabUi.WaitingForTag) }
+    val engagement = remember(activity) {
+        NfcReaderEngagement(activity) { event ->
+            when (event) {
+                is NfcReaderEngagement.Event.WaitingForTag ->
+                    nfcUi = NfcTabUi.WaitingForTag
+                is NfcReaderEngagement.Event.Exchanging ->
+                    nfcUi = NfcTabUi.Exchanging
+                is NfcReaderEngagement.Event.TransientError -> {
+                    // Recoverable; the SDK emits WaitingForTag right after.
+                }
+                is NfcReaderEngagement.Event.ProtocolError ->
+                    nfcUi = NfcTabUi.ProtocolError(
+                        event.cause.localizedMessage
+                            ?: event.cause.message
+                            ?: "Handover failed"
+                    )
+                is NfcReaderEngagement.Event.Success ->
+                    onHandover(event.handover)
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        nfcUi = when {
+            !engagement.isSupported -> NfcTabUi.NfcUnsupported
+            !engagement.isEnabled -> NfcTabUi.NfcDisabled
+            else -> NfcTabUi.WaitingForTag
+        }
+    }
+
+    // Reader mode is on for the entire VerifyMDocView lifecycle. While on,
+    // the device is in initiator role only — its HCE controller is dormant,
+    // so foreign HCE services (payment apps, our own NfcPresentationService),
+    // wallet pickers, and OS-level tag dispatchers (e.g. Samsung's "tag
+    // scanner" overlay) all stay quiet for the duration of the verifier flow.
+    DisposableEffect(Unit) {
+        engagement.start()
+        onDispose { engagement.stop() }
+    }
+
+    // Only actually run the APDU exchange while the user is on the NFC tab
+    // and we're still in SCANNING. In every other case (QR tab, BT prompt,
+    // BLE transmission, results screen) detected tags are silently swallowed.
+    LaunchedEffect(scanProcessState, pagerState.settledPage) {
+        engagement.engageOnTap = scanProcessState == State.SCANNING &&
+            pagerState.settledPage == 1
+    }
+
     when (scanProcessState) {
         State.ENABLE_BLUETOOTH -> if (!isBluetoothEnabled) {
             Box(
@@ -348,8 +400,8 @@ fun VerifyMDocView(
                             onCancel = ::back,
                         )
                         1 -> VerifyMDocNfcTab(
-                            active = pagerState.settledPage == 1,
-                            onHandover = ::onHandover,
+                            nfcUi = nfcUi,
+                            onRetry = { nfcUi = NfcTabUi.WaitingForTag },
                             onCancel = ::back,
                         )
                     }

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -12916,124 +12916,6 @@ public func FfiConverterTypeReaderApduHandoverDriver_lower(_ value: ReaderApduHa
 
 
 
-public protocol ReaderApduHandoverDriverInitProtocol: AnyObject, Sendable {
-    
-}
-open class ReaderApduHandoverDriverInit: ReaderApduHandoverDriverInitProtocol, @unchecked Sendable {
-    fileprivate let handle: UInt64
-
-    /// Used to instantiate a [FFIObject] without an actual handle, for fakes in tests, mostly.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
-    public struct NoHandle {
-        public init() {}
-    }
-
-    // TODO: We'd like this to be `private` but for Swifty reasons,
-    // we can't implement `FfiConverter` without making this `required` and we can't
-    // make it `required` without making it `public`.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
-    required public init(unsafeFromHandle handle: UInt64) {
-        self.handle = handle
-    }
-
-    // This constructor can be used to instantiate a fake object.
-    // - Parameter noHandle: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
-    //
-    // - Warning:
-    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing handle the FFI lower functions will crash.
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
-    public init(noHandle: NoHandle) {
-        self.handle = 0
-    }
-
-#if swift(>=5.8)
-    @_documentation(visibility: private)
-#endif
-    public func uniffiCloneHandle() -> UInt64 {
-        return try! rustCall { uniffi_mobile_sdk_rs_fn_clone_readerapduhandoverdriverinit(self.handle, $0) }
-    }
-    /**
-     * Create a new APDU handover driver for a reader.
-     *
-     * Returns: the driver along with the initial APDU.
-     */
-public convenience init() {
-    let handle =
-        try! rustCall() {
-    uniffi_mobile_sdk_rs_fn_constructor_readerapduhandoverdriverinit_new($0
-    )
-}
-    self.init(unsafeFromHandle: handle)
-}
-
-    deinit {
-        if handle == 0 {
-            // Mock objects have handle=0 don't try to free them
-            return
-        }
-
-        try! rustCall { uniffi_mobile_sdk_rs_fn_free_readerapduhandoverdriverinit(handle, $0) }
-    }
-
-    
-
-    
-
-    
-}
-
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public struct FfiConverterTypeReaderApduHandoverDriverInit: FfiConverter {
-    typealias FfiType = UInt64
-    typealias SwiftType = ReaderApduHandoverDriverInit
-
-    public static func lift(_ handle: UInt64) throws -> ReaderApduHandoverDriverInit {
-        return ReaderApduHandoverDriverInit(unsafeFromHandle: handle)
-    }
-
-    public static func lower(_ value: ReaderApduHandoverDriverInit) -> UInt64 {
-        return value.uniffiCloneHandle()
-    }
-
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ReaderApduHandoverDriverInit {
-        let handle: UInt64 = try readInt(&buf)
-        return try lift(handle)
-    }
-
-    public static func write(_ value: ReaderApduHandoverDriverInit, into buf: inout [UInt8]) {
-        writeInt(&buf, lower(value))
-    }
-}
-
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public func FfiConverterTypeReaderApduHandoverDriverInit_lift(_ handle: UInt64) throws -> ReaderApduHandoverDriverInit {
-    return try FfiConverterTypeReaderApduHandoverDriverInit.lift(handle)
-}
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public func FfiConverterTypeReaderApduHandoverDriverInit_lower(_ value: ReaderApduHandoverDriverInit) -> UInt64 {
-    return FfiConverterTypeReaderApduHandoverDriverInit.lower(value)
-}
-
-
-
-
-
-
 public protocol ReaderHandoverProtocol: AnyObject, Sendable {
     
 }
@@ -18463,6 +18345,60 @@ public func FfiConverterTypeRawCredential_lift(_ buf: RustBuffer) throws -> RawC
 #endif
 public func FfiConverterTypeRawCredential_lower(_ value: RawCredential) -> RustBuffer {
     return FfiConverterTypeRawCredential.lower(value)
+}
+
+
+public struct ReaderApduHandoverDriverInit {
+    public var driver: ReaderApduHandoverDriver
+    public var initialApdu: Data
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(driver: ReaderApduHandoverDriver, initialApdu: Data) {
+        self.driver = driver
+        self.initialApdu = initialApdu
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension ReaderApduHandoverDriverInit: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeReaderApduHandoverDriverInit: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ReaderApduHandoverDriverInit {
+        return
+            try ReaderApduHandoverDriverInit(
+                driver: FfiConverterTypeReaderApduHandoverDriver.read(from: &buf), 
+                initialApdu: FfiConverterData.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: ReaderApduHandoverDriverInit, into buf: inout [UInt8]) {
+        FfiConverterTypeReaderApduHandoverDriver.write(value.driver, into: &buf)
+        FfiConverterData.write(value.initialApdu, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeReaderApduHandoverDriverInit_lift(_ buf: RustBuffer) throws -> ReaderApduHandoverDriverInit {
+    return try FfiConverterTypeReaderApduHandoverDriverInit.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeReaderApduHandoverDriverInit_lower(_ value: ReaderApduHandoverDriverInit) -> RustBuffer {
+    return FfiConverterTypeReaderApduHandoverDriverInit.lower(value)
 }
 
 
@@ -32469,6 +32405,17 @@ public func handleResponse(state: MdlSessionManager, response: Data)throws  -> M
     )
 })
 }
+/**
+ * Create a new APDU handover driver for a reader.
+ *
+ * Returns: the driver along with the initial APDU to send to the holder.
+ */
+public func newReaderApduHandoverDriver() -> ReaderApduHandoverDriverInit  {
+    return try!  FfiConverterTypeReaderApduHandoverDriverInit_lift(try! rustCall() {
+    uniffi_mobile_sdk_rs_fn_func_new_reader_apdu_handover_driver($0
+    )
+})
+}
 public func verifiedResponseAsJsonString(response: MdlReaderResponseData)throws  -> String  {
     return try  FfiConverterString.lift(try rustCallWithError(FfiConverterTypeMDLReaderResponseSerializeError_lift) {
     uniffi_mobile_sdk_rs_fn_func_verified_response_as_json_string(
@@ -32701,6 +32648,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_func_handle_response() != 9521) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mobile_sdk_rs_checksum_func_new_reader_apdu_handover_driver() != 54309) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_func_verified_response_as_json_string() != 44695) {
@@ -33727,9 +33677,6 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_constructor_saattestationobjectvaluebuilder_new() != 13328) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_mobile_sdk_rs_checksum_constructor_readerapduhandoverdriverinit_new() != 36929) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_constructor_readerhandover_new_qr() != 43836) {

--- a/rust/src/mdl/reader.rs
+++ b/rust/src/mdl/reader.rs
@@ -17,21 +17,22 @@ use isomdl::{
 };
 use uuid::Uuid;
 
-#[derive(uniffi::Object, Debug)]
-pub struct ReaderApduHandoverDriverInit(pub ReaderApduHandoverDriver, pub Vec<u8>);
+#[derive(uniffi::Record)]
+pub struct ReaderApduHandoverDriverInit {
+    pub driver: Arc<ReaderApduHandoverDriver>,
+    pub initial_apdu: Vec<u8>,
+}
 
+/// Create a new APDU handover driver for a reader.
+///
+/// Returns: the driver along with the initial APDU to send to the holder.
 #[uniffi::export]
-impl ReaderApduHandoverDriverInit {
-    #[uniffi::constructor]
-    #[allow(clippy::new_without_default)]
-    #[allow(clippy::new_ret_no_self)]
-    /// Create a new APDU handover driver for a reader.
-    ///
-    /// Returns: the driver along with the initial APDU.
-    pub fn new() -> Self {
-        let (driver, apdu) =
-            isomdl::definitions::device_engagement::nfc::ReaderApduHandoverDriver::new();
-        Self(ReaderApduHandoverDriver(Mutex::new(driver)), apdu)
+pub fn new_reader_apdu_handover_driver() -> ReaderApduHandoverDriverInit {
+    let (driver, apdu) =
+        isomdl::definitions::device_engagement::nfc::ReaderApduHandoverDriver::new();
+    ReaderApduHandoverDriverInit {
+        driver: Arc::new(ReaderApduHandoverDriver(Mutex::new(driver))),
+        initial_apdu: apdu,
     }
 }
 


### PR DESCRIPTION
Tested with:
- Samsung Wallet
- Google Wallet
- Showcase

Remaining issues:
- [X] the reader seems to keep sending the initial APDU after the engagement is complete, so e.g. on a Samsung phone the wallet picker will pop up again when reviewing the presentation reques
- [X] the NFC engagement is very finicky, but I don't think it's about the engagement:
    * between the google pixel and the samsung phone, I believe there are conflicts with the payment protocols and the mDL presentation doesn't seem to suppress them. If you discard warnings about tag types, you will find that the presentation is still ongoing underneath
- [x] Samsung reader: the first tap with Google Pixel still has "unknown tag" screen but it doesn't happen on the second tap anymore
- [x] Google Pixel reader: Samsung still complains about payment NFC conflicts on the first tap, but then it's all good
    * Turns out it isn't about payment apps, it's just the OS saying the wallet picker can be avoided if the user disables wallets they're not using. And anyway it's for the wallet side, it's not caused by the reader.
<img width="1023" height="437" alt="Screenshot_20260512_141938_One UI Home" src="https://github.com/user-attachments/assets/a07c1050-ded1-4427-a855-eeee36cb568a" />

- [x] The code (and UI) was fully AI generated, and hasn't yet been reviewed.
