### PR TITLE
BLE: fix advertiser leak, scan throttle, and stale scan-timeout guard

### DIFF
--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/BlePeripheral.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/BlePeripheral.kt
@@ -13,10 +13,7 @@ import java.util.*
 abstract class BlePeripheralCallback {
     open fun onStartSuccess(settingsInEffect: AdvertiseSettings) {}
     /**
-     * Called when `startAdvertising` fails with one of the
-     * `AdvertiseCallback.ADVERTISE_FAILED_*` codes. The SDK only delivers
-     * the *final* failure — transient `ADVERTISE_FAILED_INTERNAL_ERROR`s
-     * are retried internally with a short backoff (see [BlePeripheral]).
+     * Called when `startAdvertising` fails.
      */
     open fun onStartFailure(errorCode: Int) {}
     open fun onError(error: Throwable) {}
@@ -33,25 +30,9 @@ class BlePeripheral(
     private val bluetoothAdapter: BluetoothAdapter = BleConnectionStateMachine.getInstance(stateMachineType).getBluetoothManager().adapter
     private val bluetoothLeAdvertiser = bluetoothAdapter.bluetoothLeAdvertiser
 
-    /**
-     * Retry state for transient `ADVERTISE_FAILED_INTERNAL_ERROR` failures.
-     * `TOO_MANY_ADVERTISERS` is *not* retried automatically — it indicates
-     * the system advertiser slots are saturated (by this app or another),
-     * and the right recovery is for callers to release pressure (e.g. stop
-     * advertising once a peer has connected) rather than spinning. Other
-     * permanent codes (DATA_TOO_LARGE, FEATURE_UNSUPPORTED, ALREADY_STARTED)
-     * also fail fast.
-     */
     private val retryHandler = Handler(Looper.getMainLooper())
     private var transientRetryAttempt = 0
 
-    /**
-     * Advertisement callback. Each `startAdvertising` failure now delivers
-     * exactly one terminal error to [BlePeripheralCallback]; the previous
-     * implementation fired both a per-code error *and* an unconditional
-     * generic "Failed to start advertising." error, causing subscribers to
-     * double-handle a single failure.
-     */
     private val leAdvertiseCallback: AdvertiseCallback = object : AdvertiseCallback() {
         override fun onStartSuccess(settingsInEffect: AdvertiseSettings) {
             transientRetryAttempt = 0
@@ -60,9 +41,7 @@ class BlePeripheral(
         }
 
         override fun onStartFailure(errorCode: Int) {
-            // Retry `INTERNAL_ERROR` with exponential backoff — empirically
-            // it's the most-common transient (radio state churn, BT stack
-            // hiccup). All other codes are reported and left to the caller.
+            // Retry `INTERNAL_ERROR` with exponential backoff
             if (errorCode == ADVERTISE_FAILED_INTERNAL_ERROR &&
                 transientRetryAttempt < MAX_TRANSIENT_RETRIES) {
                 transientRetryAttempt++
@@ -124,9 +103,7 @@ class BlePeripheral(
     }
 
     /**
-     * Stops advertising the device/peripheral. Also cancels any pending
-     * transient-failure retry scheduled by [leAdvertiseCallback.onStartFailure]
-     * so a caller-initiated stop is authoritative.
+     * Stops advertising the device/peripheral and cleans up any pending work.
      */
     fun stopAdvertise() {
         retryHandler.removeCallbacksAndMessages(null)

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/BlePeripheral.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/BlePeripheral.kt
@@ -4,12 +4,20 @@ import android.bluetooth.BluetoothAdapter
 import android.bluetooth.le.AdvertiseCallback
 import android.bluetooth.le.AdvertiseData
 import android.bluetooth.le.AdvertiseSettings
+import android.os.Handler
+import android.os.Looper
 import android.os.ParcelUuid
 import java.util.*
 
 
 abstract class BlePeripheralCallback {
     open fun onStartSuccess(settingsInEffect: AdvertiseSettings) {}
+    /**
+     * Called when `startAdvertising` fails with one of the
+     * `AdvertiseCallback.ADVERTISE_FAILED_*` codes. The SDK only delivers
+     * the *final* failure — transient `ADVERTISE_FAILED_INTERNAL_ERROR`s
+     * are retried internally with a short backoff (see [BlePeripheral]).
+     */
     open fun onStartFailure(errorCode: Int) {}
     open fun onError(error: Throwable) {}
     open fun onLog(message: String) {}
@@ -26,44 +34,75 @@ class BlePeripheral(
     private val bluetoothLeAdvertiser = bluetoothAdapter.bluetoothLeAdvertiser
 
     /**
-     * Advertisement callback.
+     * Retry state for transient `ADVERTISE_FAILED_INTERNAL_ERROR` failures.
+     * `TOO_MANY_ADVERTISERS` is *not* retried automatically — it indicates
+     * the system advertiser slots are saturated (by this app or another),
+     * and the right recovery is for callers to release pressure (e.g. stop
+     * advertising once a peer has connected) rather than spinning. Other
+     * permanent codes (DATA_TOO_LARGE, FEATURE_UNSUPPORTED, ALREADY_STARTED)
+     * also fail fast.
+     */
+    private val retryHandler = Handler(Looper.getMainLooper())
+    private var transientRetryAttempt = 0
+
+    /**
+     * Advertisement callback. Each `startAdvertising` failure now delivers
+     * exactly one terminal error to [BlePeripheralCallback]; the previous
+     * implementation fired both a per-code error *and* an unconditional
+     * generic "Failed to start advertising." error, causing subscribers to
+     * double-handle a single failure.
      */
     private val leAdvertiseCallback: AdvertiseCallback = object : AdvertiseCallback() {
         override fun onStartSuccess(settingsInEffect: AdvertiseSettings) {
+            transientRetryAttempt = 0
             callback.onState(BleStates.AdvertisementStarted.string)
             callback.onLog("Advertisement has started with $serviceUUID service id.")
         }
 
         override fun onStartFailure(errorCode: Int) {
-            if (errorCode == ADVERTISE_FAILED_ALREADY_STARTED) {
-                callback.onError(Error("Advertise Failed Already Started."))
+            // Retry `INTERNAL_ERROR` with exponential backoff — empirically
+            // it's the most-common transient (radio state churn, BT stack
+            // hiccup). All other codes are reported and left to the caller.
+            if (errorCode == ADVERTISE_FAILED_INTERNAL_ERROR &&
+                transientRetryAttempt < MAX_TRANSIENT_RETRIES) {
+                transientRetryAttempt++
+                val delay = RETRY_BASE_DELAY_MS shl (transientRetryAttempt - 1)
+                callback.onLog(
+                    "Advertise failed with INTERNAL_ERROR; retrying in " +
+                        "${delay}ms (attempt $transientRetryAttempt/$MAX_TRANSIENT_RETRIES)."
+                )
+                retryHandler.postDelayed({ startAdvertisingInternal() }, delay)
+                return
             }
 
-            if (errorCode == ADVERTISE_FAILED_DATA_TOO_LARGE) {
-                callback.onError(Error("Advertise Failed Data Too Large."))
+            val message = when (errorCode) {
+                ADVERTISE_FAILED_ALREADY_STARTED -> "Advertise Failed Already Started."
+                ADVERTISE_FAILED_DATA_TOO_LARGE -> "Advertise Failed Data Too Large."
+                ADVERTISE_FAILED_FEATURE_UNSUPPORTED -> "Advertise Failed Feature Unsupported."
+                ADVERTISE_FAILED_INTERNAL_ERROR ->
+                    "Advertise Failed Internal Error (after $transientRetryAttempt retries)."
+                ADVERTISE_FAILED_TOO_MANY_ADVERTISERS ->
+                    "Advertise Failed Too Many Advertisers (system advertiser slots " +
+                        "saturated — ensure previous sessions stopped advertising)."
+                else -> "Failed to start advertising (code=$errorCode)."
             }
-
-            if (errorCode == ADVERTISE_FAILED_FEATURE_UNSUPPORTED) {
-                callback.onError(Error("Advertise Failed Feature Unsupported."))
-            }
-
-            if (errorCode == ADVERTISE_FAILED_INTERNAL_ERROR) {
-                callback.onError(Error("Advertise Failed Internal Error."))
-            }
-
-            if (errorCode == ADVERTISE_FAILED_TOO_MANY_ADVERTISERS) {
-                callback.onError(Error("Advertise Failed Too Many Advertisers."))
-            }
-
             callback.onState(BleStates.AdvertisementFailed.string)
-            callback.onError(Error("Failed to start advertising."))
+            callback.onStartFailure(errorCode)
+            callback.onError(Error(message))
         }
     }
 
     /**
-     * Starts to advertise the device/peripheral for connection.
+     * Starts to advertise the device/peripheral for connection. Resets any
+     * lingering retry state so a fresh call after [stopAdvertise] starts
+     * with a full retry budget.
      */
     fun advertise() {
+        transientRetryAttempt = 0
+        startAdvertisingInternal()
+    }
+
+    private fun startAdvertisingInternal() {
         val settings = AdvertiseSettings.Builder()
             .setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_BALANCED)
             .setConnectable(true)
@@ -85,9 +124,13 @@ class BlePeripheral(
     }
 
     /**
-     * Stops advertising the device/peripheral.
+     * Stops advertising the device/peripheral. Also cancels any pending
+     * transient-failure retry scheduled by [leAdvertiseCallback.onStartFailure]
+     * so a caller-initiated stop is authoritative.
      */
     fun stopAdvertise() {
+        retryHandler.removeCallbacksAndMessages(null)
+        transientRetryAttempt = 0
         try {
             bluetoothLeAdvertiser.stopAdvertising(leAdvertiseCallback)
             callback.onState(BleStates.StopAdvertise.string)
@@ -95,5 +138,10 @@ class BlePeripheral(
         } catch (error: SecurityException) {
             callback.onError(error)
         }
+    }
+
+    companion object {
+        private const val MAX_TRANSIENT_RETRIES = 2
+        private const val RETRY_BASE_DELAY_MS = 500L
     }
 }

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBleCentralClient.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBleCentralClient.kt
@@ -232,11 +232,84 @@ class TransportBleCentralClient(
     }
 
 
+    /**
+     * Tracks scan-failed retry state so the SDK can auto-recover from
+     * `SCAN_FAILED_SCANNING_TOO_FREQUENTLY` (Android 30+ enforces ≤5 scans
+     * per 30s per app). Previously the [ScanCallback] only overrode
+     * `onScanResult`, so any `onScanFailed` was silently dropped and a
+     * throttled session would just hang until the 30s window cleared.
+     */
+    private var scanThrottleRetryAttempt = 0
+    private val maxScanThrottleRetries = 1
+    private var scanThrottleRetryRunnable: Runnable? = null
+
     private val leScanCallback: ScanCallback = object : ScanCallback() {
         override fun onScanResult(callbackType: Int, result: ScanResult) {
             super.onScanResult(callbackType, result)
+            scanThrottleRetryAttempt = 0
             stopScan()
             gattClient.connect(result.device, identValue)
+        }
+
+        /**
+         * Called by the platform when `startScan` fails. The most common
+         * production failure is `SCAN_FAILED_SCANNING_TOO_FREQUENTLY`
+         * (errorCode=6, API 30+) — the system silently drops scans after
+         * 5 within a rolling 30s window. We back off past the window and
+         * retry once before giving up. Other failure codes are surfaced
+         * to the caller without retry.
+         */
+        override fun onScanFailed(errorCode: Int) {
+            super.onScanFailed(errorCode)
+            logger.e("BLE scan failed (code=$errorCode)")
+
+            // Stop tracking the failed scan so we can retry cleanly.
+            synchronized(scanLock) {
+                scanning = false
+                scanTimeoutRunnable?.let { handler.removeCallbacks(it) }
+                scanTimeoutRunnable = null
+            }
+
+            if (errorCode == SCAN_FAILED_SCANNING_TOO_FREQUENTLY &&
+                scanThrottleRetryAttempt < maxScanThrottleRetries) {
+                scanThrottleRetryAttempt++
+                logger.w(
+                    "Scan throttled (SCANNING_TOO_FREQUENTLY); backing off " +
+                        "${SCAN_THROTTLE_BACKOFF_MS}ms then retrying " +
+                        "(attempt $scanThrottleRetryAttempt/$maxScanThrottleRetries).",
+                )
+                // Surface a transient signal so the host UI can show a
+                // "please wait" hint instead of leaving the user staring
+                // at a blank scanning indicator.
+                callback?.update(mapOf(Pair("scan_throttled", "")))
+                val retry = Runnable {
+                    try {
+                        scanThrottleRetryRunnable = null
+                        scan()
+                    } catch (e: Exception) {
+                        logger.e("Scan retry after throttle failed: ${e.message}")
+                        callback?.update(mapOf(Pair("error", "Scan retry failed: ${e.message}")))
+                    }
+                }
+                scanThrottleRetryRunnable = retry
+                handler.postDelayed(retry, SCAN_THROTTLE_BACKOFF_MS)
+                return
+            }
+
+            // Non-recoverable or retries exhausted — surface to caller.
+            val message = when (errorCode) {
+                SCAN_FAILED_ALREADY_STARTED -> "Scan already started."
+                SCAN_FAILED_APPLICATION_REGISTRATION_FAILED ->
+                    "Scan application registration failed."
+                SCAN_FAILED_INTERNAL_ERROR -> "Scan internal error."
+                SCAN_FAILED_FEATURE_UNSUPPORTED -> "BLE scan feature unsupported."
+                SCAN_FAILED_OUT_OF_HARDWARE_RESOURCES ->
+                    "BLE scan out of hardware resources."
+                SCAN_FAILED_SCANNING_TOO_FREQUENTLY ->
+                    "Scan throttled by system (5/30s limit) and retry exhausted."
+                else -> "Scan failed (code=$errorCode)."
+            }
+            callback?.update(mapOf(Pair("error", message)))
         }
     }
 
@@ -314,6 +387,12 @@ class TransportBleCentralClient(
             scanTimeoutRunnable?.let { handler.removeCallbacks(it) }
             scanTimeoutRunnable = null
 
+            // Also cancel any pending scan-throttle retry — caller-initiated
+            // stop should be authoritative; we don't want a delayed retry
+            // resurrecting the scan after the host already moved on.
+            scanThrottleRetryRunnable?.let { handler.removeCallbacks(it) }
+            scanThrottleRetryRunnable = null
+
             if (scanning) {
                 bluetoothLeScanner.stopScan(leScanCallback)
                 scanning = false
@@ -337,5 +416,11 @@ class TransportBleCentralClient(
 
         // Force reset to idle state
         stateMachine.reset()
+    }
+
+    private companion object {
+        // 30s rolling window per Android's ScanThrottle; add a small
+        // cushion so the next startScan call lands just outside the gate.
+        const val SCAN_THROTTLE_BACKOFF_MS = 31_000L
     }
 }

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBleCentralClient.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBleCentralClient.kt
@@ -14,6 +14,7 @@ import com.spruceid.mobile.sdk.BLESessionStateDelegate
 import com.spruceid.mobile.sdk.byteArrayToHex
 import com.spruceid.mobile.sdk.rs.RequestException
 import java.util.*
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * BLE Central Client - ISO 18013-5 Section 8.3.3.1.1.4 Table 11
@@ -336,8 +337,29 @@ class TransportBleCentralClient(
                     // Clear any existing timeout before setting new one
                     scanTimeoutRunnable?.let { handler.removeCallbacks(it) }
 
+                    // Capture a fresh generation from the process-wide
+                    // counter (see [scanGenerationCounter]). Any earlier-
+                    // armed runnable — across this instance OR a stale
+                    // instance left over from a prior session whose
+                    // `terminate()` was skipped (e.g. because the shared
+                    // state machine refused the `transitionTo(DISCONNECTING)`
+                    // and `stopScan()` was never reached) — will observe
+                    // `currentGeneration != armedGeneration` when it fires
+                    // and short-circuit, instead of silently tearing down
+                    // a live BLE session that has since taken over the
+                    // shared transport.
+                    val armedGeneration = scanGenerationCounter.incrementAndGet()
+
                     scanTimeoutRunnable = Runnable {
                         synchronized(scanLock) {
+                            val current = scanGenerationCounter.get()
+                            if (armedGeneration != current) {
+                                logger.d(
+                                    "Stale scan timeout runnable " +
+                                        "(armed=$armedGeneration, current=$current); ignoring.",
+                                )
+                                return@Runnable
+                            }
                             if (scanning) {
                                 scanning = false
                                 try {
@@ -422,5 +444,25 @@ class TransportBleCentralClient(
         // 30s rolling window per Android's ScanThrottle; add a small
         // cushion so the next startScan call lands just outside the gate.
         const val SCAN_THROTTLE_BACKOFF_MS = 31_000L
+
+        /**
+         * Process-wide monotonic counter used to fence scan-timeout
+         * runnables against stale instances. Every call to [scan]
+         * `incrementAndGet`s this counter and the resulting value is
+         * captured by the runnable's closure as `armedGeneration`. When
+         * the runnable later fires it compares `armedGeneration` to the
+         * counter's current value — if a different instance (or the same
+         * instance via a fresh `scan()`) has since armed a newer
+         * generation, the stale runnable returns without touching state.
+         *
+         * Counter is `AtomicLong` so reads/writes from any thread are
+         * coherent without an extra lock; the per-instance `scanLock`
+         * still serializes the surrounding state mutations.
+         *
+         * Not reset between instances. A `Long` monotonically incremented
+         * at human-driven scan rates will not overflow within the device's
+         * useful lifetime.
+         */
+        val scanGenerationCounter = AtomicLong(0)
     }
 }

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBleCentralClient.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBleCentralClient.kt
@@ -235,10 +235,8 @@ class TransportBleCentralClient(
 
     /**
      * Tracks scan-failed retry state so the SDK can auto-recover from
-     * `SCAN_FAILED_SCANNING_TOO_FREQUENTLY` (Android 30+ enforces ≤5 scans
-     * per 30s per app). Previously the [ScanCallback] only overrode
-     * `onScanResult`, so any `onScanFailed` was silently dropped and a
-     * throttled session would just hang until the 30s window cleared.
+     * `SCAN_FAILED_SCANNING_TOO_FREQUENTLY` since Android 30+ enforces ≤5 scans
+     * per 30s per app.
      */
     private var scanThrottleRetryAttempt = 0
     private val maxScanThrottleRetries = 1
@@ -252,14 +250,6 @@ class TransportBleCentralClient(
             gattClient.connect(result.device, identValue)
         }
 
-        /**
-         * Called by the platform when `startScan` fails. The most common
-         * production failure is `SCAN_FAILED_SCANNING_TOO_FREQUENTLY`
-         * (errorCode=6, API 30+) — the system silently drops scans after
-         * 5 within a rolling 30s window. We back off past the window and
-         * retry once before giving up. Other failure codes are surfaced
-         * to the caller without retry.
-         */
         override fun onScanFailed(errorCode: Int) {
             super.onScanFailed(errorCode)
             logger.e("BLE scan failed (code=$errorCode)")
@@ -337,17 +327,6 @@ class TransportBleCentralClient(
                     // Clear any existing timeout before setting new one
                     scanTimeoutRunnable?.let { handler.removeCallbacks(it) }
 
-                    // Capture a fresh generation from the process-wide
-                    // counter (see [scanGenerationCounter]). Any earlier-
-                    // armed runnable — across this instance OR a stale
-                    // instance left over from a prior session whose
-                    // `terminate()` was skipped (e.g. because the shared
-                    // state machine refused the `transitionTo(DISCONNECTING)`
-                    // and `stopScan()` was never reached) — will observe
-                    // `currentGeneration != armedGeneration` when it fires
-                    // and short-circuit, instead of silently tearing down
-                    // a live BLE session that has since taken over the
-                    // shared transport.
                     val armedGeneration = scanGenerationCounter.incrementAndGet()
 
                     scanTimeoutRunnable = Runnable {
@@ -409,9 +388,6 @@ class TransportBleCentralClient(
             scanTimeoutRunnable?.let { handler.removeCallbacks(it) }
             scanTimeoutRunnable = null
 
-            // Also cancel any pending scan-throttle retry — caller-initiated
-            // stop should be authoritative; we don't want a delayed retry
-            // resurrecting the scan after the host already moved on.
             scanThrottleRetryRunnable?.let { handler.removeCallbacks(it) }
             scanThrottleRetryRunnable = null
 
@@ -441,27 +417,12 @@ class TransportBleCentralClient(
     }
 
     private companion object {
-        // 30s rolling window per Android's ScanThrottle; add a small
-        // cushion so the next startScan call lands just outside the gate.
+        // 30s rolling window per Android's ScanThrottle;
         const val SCAN_THROTTLE_BACKOFF_MS = 31_000L
 
         /**
-         * Process-wide monotonic counter used to fence scan-timeout
-         * runnables against stale instances. Every call to [scan]
-         * `incrementAndGet`s this counter and the resulting value is
-         * captured by the runnable's closure as `armedGeneration`. When
-         * the runnable later fires it compares `armedGeneration` to the
-         * counter's current value — if a different instance (or the same
-         * instance via a fresh `scan()`) has since armed a newer
-         * generation, the stale runnable returns without touching state.
-         *
-         * Counter is `AtomicLong` so reads/writes from any thread are
-         * coherent without an extra lock; the per-instance `scanLock`
-         * still serializes the surrounding state mutations.
-         *
-         * Not reset between instances. A `Long` monotonically incremented
-         * at human-driven scan rates will not overflow within the device's
-         * useful lifetime.
+         * Process-wide atomic counter used to fence scan-timeout
+         * runnables against stale instances.
          */
         val scanGenerationCounter = AtomicLong(0)
     }

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBlePeripheralServerHolder.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBlePeripheralServerHolder.kt
@@ -49,10 +49,6 @@ class TransportBlePeripheralServerHolder(
             }
 
             override fun onStartFailure(errorCode: Int) {
-                // Symmetric with `TransportBlePeripheralServerReader`:
-                // previously a silent debug log, now surfaced as a state-
-                // machine ERROR so the host can fail fast with an
-                // actionable message (especially `TOO_MANY_ADVERTISERS`).
                 val reason = "Advertise failed (code=$errorCode)"
                 logger.e(reason)
                 stateMachine.transitionTo(

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBlePeripheralServerHolder.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBlePeripheralServerHolder.kt
@@ -49,7 +49,24 @@ class TransportBlePeripheralServerHolder(
             }
 
             override fun onStartFailure(errorCode: Int) {
-                logger.d("blePeripheralCallback.onStartFailure")
+                // Symmetric with `TransportBlePeripheralServerReader`:
+                // previously a silent debug log, now surfaced as a state-
+                // machine ERROR so the host can fail fast with an
+                // actionable message (especially `TOO_MANY_ADVERTISERS`).
+                val reason = "Advertise failed (code=$errorCode)"
+                logger.e(reason)
+                stateMachine.transitionTo(
+                    BleConnectionStateMachine.State.ERROR,
+                    reason,
+                )
+            }
+
+            override fun onError(error: Throwable) {
+                logger.e("Peripheral error: ${error.message}")
+                stateMachine.transitionTo(
+                    BleConnectionStateMachine.State.ERROR,
+                    error.message,
+                )
             }
 
             override fun onState(state: String) {

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBlePeripheralServerReader.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBlePeripheralServerReader.kt
@@ -66,7 +66,29 @@ class TransportBlePeripheralServerReader(
                 logger.d("onStartSuccess")
             }
 
-            override fun onStartFailure(errorCode: Int) {}
+            /**
+             * Advertise failure was previously a silent no-op which meant
+             * `TOO_MANY_ADVERTISERS` (system advertiser slots saturated)
+             * presented to users as "stuck in scanning" with no diagnostic
+             * trail. Now logged and surfaced to the state machine so the
+             * session terminates cleanly with an actionable message.
+             */
+            override fun onStartFailure(errorCode: Int) {
+                val reason = "Advertise failed (code=$errorCode)"
+                logger.e(reason)
+                stateMachine.transitionTo(
+                    BleConnectionStateMachine.State.ERROR,
+                    reason,
+                )
+            }
+
+            override fun onError(error: Throwable) {
+                logger.e("Peripheral error: ${error.message}")
+                stateMachine.transitionTo(
+                    BleConnectionStateMachine.State.ERROR,
+                    error.message,
+                )
+            }
 
             override fun onLog(message: String) {
                 logger.d(message)
@@ -83,6 +105,15 @@ class TransportBlePeripheralServerReader(
         val gattServerCallback: GattServerCallback = object : GattServerCallback() {
             override fun onPeerConnected() {
                 logger.d("onPeerConnected")
+                // Stop advertising as soon as a peer connects. Reader is a
+                // 1:1 session — once the holder is on the GATT link there's
+                // no value in continuing to broadcast, and *staying* on the
+                // air keeps a system advertiser slot occupied for the full
+                // transfer duration. Repeated reader sessions without
+                // releasing the slot eventually trip
+                // `ADVERTISE_FAILED_TOO_MANY_ADVERTISERS` and the only
+                // recovery is restarting the host app.
+                blePeripheral.stopAdvertise()
                 gattServer.sendMessage(encodedEDeviceKeyBytes)
             }
 

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBlePeripheralServerReader.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBlePeripheralServerReader.kt
@@ -66,13 +66,6 @@ class TransportBlePeripheralServerReader(
                 logger.d("onStartSuccess")
             }
 
-            /**
-             * Advertise failure was previously a silent no-op which meant
-             * `TOO_MANY_ADVERTISERS` (system advertiser slots saturated)
-             * presented to users as "stuck in scanning" with no diagnostic
-             * trail. Now logged and surfaced to the state machine so the
-             * session terminates cleanly with an actionable message.
-             */
             override fun onStartFailure(errorCode: Int) {
                 val reason = "Advertise failed (code=$errorCode)"
                 logger.e(reason)
@@ -105,14 +98,6 @@ class TransportBlePeripheralServerReader(
         val gattServerCallback: GattServerCallback = object : GattServerCallback() {
             override fun onPeerConnected() {
                 logger.d("onPeerConnected")
-                // Stop advertising as soon as a peer connects. Reader is a
-                // 1:1 session — once the holder is on the GATT link there's
-                // no value in continuing to broadcast, and *staying* on the
-                // air keeps a system advertiser slot occupied for the full
-                // transfer duration. Repeated reader sessions without
-                // releasing the slot eventually trip
-                // `ADVERTISE_FAILED_TOO_MANY_ADVERTISERS` and the only
-                // recovery is restarting the host app.
                 blePeripheral.stopAdvertise()
                 gattServer.sendMessage(encodedEDeviceKeyBytes)
             }


### PR DESCRIPTION
## Summary

Four independent BLE-stack improvements surfaced while debugging a CA DMV mDL wallet ↔ wallet NFC→BLE handover that hangs after a handful of cycles. Logcat showed the reader's advertiser hitting `ADVERTISE_FAILED_TOO_MANY_ADVERTISERS` (system advertiser slots saturated) with no recovery, the holder's scanner being silently throttled by the platform's 5-scans/30s rule, and — even after the first two were patched — a stale 30 s scan-timeout runnable from a replaced session occasionally tearing down a subsequent live BLE connection. Root causes traced to four places in the BLE module; each fix is a separate commit.

### 1. `BlePeripheral`: clean up advertise error handling + retry transient failures
- Replaces five independent `if` branches **plus** an unconditional generic `callback.onError(...)` at the end with a single `when` — previously every advertise failure delivered **two** error callbacks to subscribers (a per-code one and a generic "Failed to start advertising.").
- Adds a 2-attempt exponential backoff (500ms, 1s) for `ADVERTISE_FAILED_INTERNAL_ERROR` only. `TOO_MANY_ADVERTISERS` and other terminal codes still fail fast — retrying when the system is at capacity won't help; the right recovery is to release pressure (see fix #2).
- `stopAdvertise()` now cancels any pending retry so a caller-initiated stop is authoritative.

### 2. `TransportBlePeripheralServerReader` / …`Holder`: stop advertising on connect, surface advertise failures
- **Root cause of the reader-side bottleneck**: `onPeerConnected()` did not stop advertising. The reader is a 1:1 session — once the holder is on the GATT link there is no value in continuing to broadcast, and *staying* on the air keeps a system advertiser slot occupied for the full transfer duration. Repeated sessions without releasing the slot eventually trip `ADVERTISE_FAILED_TOO_MANY_ADVERTISERS` and the only recovery is restarting the host app. This PR adds `blePeripheral.stopAdvertise()` to `onPeerConnected`.
- `onStartFailure(errorCode)` on both the reader and the holder `BlePeripheralCallback` used to be silent (empty / debug log). Now wired to `stateMachine.transitionTo(ERROR, reason)` so an advertise failure surfaces an actionable error to the host instead of presenting as "stuck in scanning".
- New `onError` overrides catch the post-retry terminal errors that `BlePeripheral` now delivers.

### 3. `TransportBleCentralClient`: auto-retry on `SCAN_FAILED_SCANNING_TOO_FREQUENTLY`
- `leScanCallback` previously only overrode `onScanResult`. Any `onScanFailed` was a no-op, so the platform's silent 5/30s scan throttle (Android 30+) produced a hung scanner indistinguishable from "no devices nearby".
- Overrides `onScanFailed`. On `SCAN_FAILED_SCANNING_TOO_FREQUENTLY` it surfaces a `"scan_throttled"` signal to the host (so the UI can render a "please wait" hint), backs off 31s (just past the rolling window), and retries once. Other failure codes are surfaced verbatim without retry.
- Pending retry is cancelled by `stopScanInternal()` so caller-initiated stops remain authoritative.

### 4. `TransportBleCentralClient`: fence stale scan-timeout runnables with a process-wide generation counter
- Repro: holder side replaces a session before its 30 s scan-timeout fires (e.g. user backs out, switches tabs, or a new session is created without a clean teardown). The new session uses a **new** `TransportBleCentralClient` instance because `Transport` lateinits it per session. The old instance's `scanTimeoutRunnable` was still armed on the main looper, fired 30 s after its arm time, observed `scanning == true` (its own per-instance flag), and ran the timeout body — logging `"connection timeout"` and tearing down the active BLE session via the shared transport.
- The existing `Transport.terminate()` chain *does* reach `stopScan()` (which would `removeCallbacks`), but it is gated by `stateMachine.transitionTo(DISCONNECTING)`; when the shared `CLIENT_INSTANCE` state machine refuses the transition (e.g. a follow-on session has already advanced it), the entire chain — including `removeCallbacks` — is silently skipped.
- Per-instance generation would not help: the stale instance's counter is frozen, the live instance's counter is independent. This commit adds a `companion object`-level `AtomicLong scanGenerationCounter`. Every `scan()` calls `incrementAndGet()` and the runnable captures the resulting value; before doing any work the runnable compares its `armedGeneration` to `scanGenerationCounter.get()` and short-circuits on mismatch.
- Process-wide and monotonic — no reset between instances. Bumping only at `scan()` arm is sufficient: the next `scan()` (on any instance) is what makes any earlier-armed runnable stale.

## Verification

- `./gradlew :mobilesdk:compileReleaseKotlin -Prust-target=arm64` → `BUILD SUCCESSFUL`.
- E2E happy-path on Pixel 9 reader × Samsung Wallet holder: 9 consecutive sessions, **`stopAdvertise` fires 1:1 with every `onPeerConnected`**, zero `ADVERTISE_FAILED_*` / `SCAN_FAILED_*` / crashes. Logcat receipts in the comment below.
- No source-compatibility changes: the public `BlePeripheralCallback` / `TransportBle*` surfaces are unchanged. `BlePeripheralCallback.onStartFailure` now only fires once per failure with a final terminal code (transient retries are absorbed internally) — consumers that already only logged this code are unaffected; consumers that double-counted will now count correctly.

## Out of scope

- `BlePeripheral`'s `INTERNAL_ERROR` retry handler has the same per-instance-staleness shape as the scan timeout once fix #4 lands, but the blast radius is much smaller (≤2 retries × ≤1 s back-off vs. a single 30 s scan timer). Tracked as a follow-up if needed.