### PR TITLE
fix(rust): use Option::zip to satisfy clippy::manual_option_zip

### DIFF
--- a/rust/CLAUDE.md
+++ b/rust/CLAUDE.md
@@ -9,6 +9,10 @@ UniFFI library (`mobile-sdk-rs`) that generates Swift and Kotlin bindings for th
 ## Commands
 
 ```bash
+# Keep your toolchain up to date so local clippy/build matches CI's version
+# (CI may run a newer toolchain that flags lints your local version misses)
+rustup update
+
 # Build
 cargo build
 
@@ -17,10 +21,6 @@ cargo test
 
 # Lint (CI runs with RUSTFLAGS="-Dwarnings")
 cargo clippy
-
-# Keep your toolchain up to date so local clippy matches CI's version
-# (CI may run a newer clippy that flags lints your local version misses)
-rustup update
 
 # Format check
 cargo fmt -- --check

--- a/rust/CLAUDE.md
+++ b/rust/CLAUDE.md
@@ -18,6 +18,10 @@ cargo test
 # Lint (CI runs with RUSTFLAGS="-Dwarnings")
 cargo clippy
 
+# Keep your toolchain up to date so local clippy matches CI's version
+# (CI may run a newer clippy that flags lints your local version misses)
+rustup update
+
 # Format check
 cargo fmt -- --check
 

--- a/rust/src/oid4vp/iso_18013_7/requested_values.rs
+++ b/rust/src/oid4vp/iso_18013_7/requested_values.rs
@@ -271,7 +271,7 @@ pub fn calculate_age_over_mapping(
         .filter_map(|(id, elem)| {
             id.strip_prefix("age_over_")
                 .and_then(age_from_str)
-                .and_then(|age| elem.as_ref().element_value.as_bool().map(|b| (age, b)))
+                .zip(elem.as_ref().element_value.as_bool())
         })
         .collect();
 


### PR DESCRIPTION
CI on main runs a newer clippy (1.96) than local/PR (1.94), which flags `manual_option_zip` as an error under `-Dwarnings`. This rewrites the age_over mapping to use `Option::zip`, and notes in rust/CLAUDE.md to run `rustup update` so local clippy matches CI.

https://github.com/spruceid/sprucekit-mobile/actions/runs/27292396888/job/80624204941