### PR TITLE
Fix GattServer rejecting the final BLE data chunk; add reader diagnostics

### DIFF
--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/IsoMdlReader.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/IsoMdlReader.kt
@@ -111,8 +111,21 @@ class IsoMdlReader(
 
     fun handleMdlReaderResponseData(response: ByteArray): MdlReaderResponseData {
         try {
-            return com.spruceid.mobile.sdk.rs.handleResponse(session, response)
+            val data = com.spruceid.mobile.sdk.rs.handleResponse(session, response)
+            // Diagnostic: surface what handleResponse produced so a capture can
+            // tell "empty/failed parse" from "parsed but unverified". `errors`
+            // is the JSON-encoded per-category error map from isomdl.
+            Log.d(
+                "IsoMdlReader",
+                "handleResponse: docTypes=${data.docTypes}, " +
+                    "issuerAuth=${data.issuerAuthentication}, " +
+                    "deviceAuth=${data.deviceAuthentication}, " +
+                    "namespaces=${data.verifiedResponse.keys}, " +
+                    "errors=${data.errors}"
+            )
+            return data
         } catch (e: MdlReaderResponseException) {
+            Log.e("IsoMdlReader", "handleResponse failed", e)
             throw e
         }
     }

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/GattServer.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/GattServer.kt
@@ -324,32 +324,39 @@ class GattServer(
                         }
                     } // End synchronized block
 
-                    if (value[0].toInt() == 0x01) {
-                        if (value.size > mtu - 3) {
-                            callback.onError(
-                                Error(
+                    when (value[0].toInt()) {
+                        // 0x00 = final chunk; the message was already assembled
+                        // and delivered in the synchronized block above.
+                        0x00 -> {}
+                        // 0x01 = intermediate chunk; must fit within the MTU.
+                        0x01 -> {
+                            if (value.size > mtu - 3) {
+                                callback.onError(
+                                    Error(
+                                        "Invalid size ${value.size} of data written Client2Server " +
+                                                "characteristic, expected maximum size ${mtu - 3}"
+                                    )
+                                )
+                                logger.e(
                                     "Invalid size ${value.size} of data written Client2Server " +
                                             "characteristic, expected maximum size ${mtu - 3}"
                                 )
+                                return
+                            }
+                        }
+                        else -> {
+                            callback.onError(
+                                Error(
+                                    "Invalid first byte ${value[0].toInt()} in Client2Server " +
+                                            "data chunk, expected 0 or 1"
+                                )
                             )
                             logger.e(
-                                "Invalid size ${value.size} of data written Client2Server " +
-                                        "characteristic, expected maximum size ${mtu - 3}"
-                            )
-                            return
-                        }
-                    } else {
-                        callback.onError(
-                            Error(
                                 "Invalid first byte ${value[0].toInt()} in Client2Server " +
                                         "data chunk, expected 0 or 1"
                             )
-                        )
-                        logger.e(
-                            "Invalid first byte ${value[0].toInt()} in Client2Server " +
-                                    "data chunk, expected 0 or 1"
-                        )
-                        return
+                            return
+                        }
                     }
                     if (responseNeeded) {
                         try {

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/GattServer.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/GattServer.kt
@@ -324,37 +324,14 @@ class GattServer(
                         }
                     } // End synchronized block
 
-                    when (value[0].toInt()) {
-                        // 0x00 = final chunk; the message was already assembled
-                        // and delivered in the synchronized block above.
-                        0x00 -> {}
-                        // 0x01 = intermediate chunk; must fit within the MTU.
-                        0x01 -> {
-                            if (value.size > mtu - 3) {
-                                callback.onError(
-                                    Error(
-                                        "Invalid size ${value.size} of data written Client2Server " +
-                                                "characteristic, expected maximum size ${mtu - 3}"
-                                    )
-                                )
-                                logger.e(
-                                    "Invalid size ${value.size} of data written Client2Server " +
-                                            "characteristic, expected maximum size ${mtu - 3}"
-                                )
-                                return
-                            }
-                        }
-                        else -> {
-                            callback.onError(
-                                Error(
-                                    "Invalid first byte ${value[0].toInt()} in Client2Server " +
-                                            "data chunk, expected 0 or 1"
-                                )
-                            )
-                            logger.e(
-                                "Invalid first byte ${value[0].toInt()} in Client2Server " +
-                                        "data chunk, expected 0 or 1"
-                            )
+                    // The final chunk's message was already assembled and delivered above; a
+                    // within-MTU intermediate chunk simply proceeds. Only a malformed chunk is an
+                    // error. See [classifyClient2ServerChunk] for the framing rules (unit-tested).
+                    when (val chunk = classifyClient2ServerChunk(value[0].toInt(), value.size, mtu)) {
+                        Client2ServerChunk.Final, Client2ServerChunk.Intermediate -> {}
+                        is Client2ServerChunk.Invalid -> {
+                            callback.onError(Error(chunk.message))
+                            logger.e(chunk.message)
                             return
                         }
                     }
@@ -1147,3 +1124,49 @@ class GattServer(
         }
     }
 }
+
+/**
+ * Classification of a chunk written to the Client2Server characteristic by its leading status
+ * byte. Extracted as a pure function so the framing rules can be unit-tested without an Android
+ * BLE stack.
+ */
+internal sealed class Client2ServerChunk {
+    /** `0x00` — final chunk; the assembled message is complete. */
+    object Final : Client2ServerChunk()
+
+    /** `0x01` — intermediate chunk that fits within the negotiated MTU. */
+    object Intermediate : Client2ServerChunk()
+
+    /** Malformed: an unknown leading byte, or an intermediate chunk exceeding the MTU. */
+    data class Invalid(val message: String) : Client2ServerChunk()
+}
+
+/**
+ * Classify a Client2Server chunk by its leading byte (`0x00` final, `0x01` intermediate).
+ *
+ * `0x00` is valid regardless of `chunkSize`; rejecting it as a self-contradictory "expected 0 or 1"
+ * error was the GattServer final-chunk bug, which tore the session down after the message had
+ * already been delivered.
+ */
+internal fun classifyClient2ServerChunk(
+    firstByte: Int,
+    chunkSize: Int,
+    mtu: Int,
+): Client2ServerChunk =
+    when (firstByte) {
+        0x00 -> Client2ServerChunk.Final
+        0x01 ->
+            if (chunkSize > mtu - 3) {
+                Client2ServerChunk.Invalid(
+                    "Invalid size $chunkSize of data written Client2Server " +
+                        "characteristic, expected maximum size ${mtu - 3}"
+                )
+            } else {
+                Client2ServerChunk.Intermediate
+            }
+
+        else ->
+            Client2ServerChunk.Invalid(
+                "Invalid first byte $firstByte in Client2Server data chunk, expected 0 or 1"
+            )
+    }

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBlePeripheralServerReader.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBlePeripheralServerReader.kt
@@ -111,7 +111,14 @@ class TransportBlePeripheralServerReader(
 
             override fun onMessageSendProgress(progress: Int, max: Int) {}
             override fun onMessageReceived(data: ByteArray) {
-                logger.d(data.toString())
+                // Diagnostic: byte[] .toString() only yields an object hash.
+                // Log size + a short hex prefix so a capture can distinguish
+                // "no/short response over BLE" from "full response that failed
+                // to decrypt/parse downstream".
+                logger.d(
+                    "onMessageReceived: ${data.size} bytes, prefix=" +
+                        data.take(16).joinToString("") { "%02x".format(it) }
+                )
 
                 try {
                     gattServer.sendTransportSpecificTermination()

--- a/android/MobileSdk/src/test/java/com/spruceid/mobile/sdk/ble/GattServerTest.kt
+++ b/android/MobileSdk/src/test/java/com/spruceid/mobile/sdk/ble/GattServerTest.kt
@@ -1,0 +1,46 @@
+package com.spruceid.mobile.sdk.ble
+
+import org.junit.Test
+
+import org.junit.Assert.*
+
+/**
+ * Tests for [classifyClient2ServerChunk], the framing rules for chunks written to the
+ * Client2Server GATT characteristic.
+ */
+class GattServerTest {
+    private val mtu = 512
+
+    /**
+     * Regression: a final chunk's `0x00` leading byte must classify as [Client2ServerChunk.Final],
+     * not be rejected as a self-contradictory "invalid first byte 0, expected 0 or 1". That spurious
+     * error drove the session to ERROR after the message had already been delivered.
+     */
+    @Test
+    fun finalChunkByteIsAccepted() {
+        assertEquals(Client2ServerChunk.Final, classifyClient2ServerChunk(0x00, 5, mtu))
+    }
+
+    @Test
+    fun finalChunkIsAcceptedRegardlessOfSize() {
+        assertEquals(Client2ServerChunk.Final, classifyClient2ServerChunk(0x00, mtu * 4, mtu))
+    }
+
+    @Test
+    fun intermediateChunkWithinMtuIsAccepted() {
+        assertEquals(
+            Client2ServerChunk.Intermediate,
+            classifyClient2ServerChunk(0x01, mtu - 3, mtu)
+        )
+    }
+
+    @Test
+    fun intermediateChunkExceedingMtuIsInvalid() {
+        assertTrue(classifyClient2ServerChunk(0x01, mtu - 2, mtu) is Client2ServerChunk.Invalid)
+    }
+
+    @Test
+    fun unknownLeadingByteIsInvalid() {
+        assertTrue(classifyClient2ServerChunk(0x02, 5, mtu) is Client2ServerChunk.Invalid)
+    }
+}

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2416,7 +2416,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -2743,7 +2743,7 @@ dependencies = [
 [[package]]
 name = "isomdl"
 version = "0.2.0"
-source = "git+https://github.com/spruceid/isomdl?rev=fb19e7b#fb19e7bea3cd8ee087ee9c033e5357698c11ccec"
+source = "git+https://github.com/spruceid/isomdl?rev=9d53cf9#9d53cf94da3d5e6517dae726e8665a025e662344"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2763,7 +2763,7 @@ dependencies = [
  "hex",
  "hkdf",
  "hmac",
- "isomdl-macros 0.1.0 (git+https://github.com/spruceid/isomdl?rev=fb19e7b)",
+ "isomdl-macros 0.1.0 (git+https://github.com/spruceid/isomdl?rev=9d53cf9)",
  "ndef-rs",
  "p256",
  "p384",
@@ -2799,7 +2799,7 @@ dependencies = [
 [[package]]
 name = "isomdl-macros"
 version = "0.1.0"
-source = "git+https://github.com/spruceid/isomdl?rev=fb19e7b#fb19e7bea3cd8ee087ee9c033e5357698c11ccec"
+source = "git+https://github.com/spruceid/isomdl?rev=9d53cf9#9d53cf94da3d5e6517dae726e8665a025e662344"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4453,7 +4453,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4490,7 +4490,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2416,7 +2416,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -2743,7 +2743,7 @@ dependencies = [
 [[package]]
 name = "isomdl"
 version = "0.2.0"
-source = "git+https://github.com/spruceid/isomdl?rev=9d53cf9#9d53cf94da3d5e6517dae726e8665a025e662344"
+source = "git+https://github.com/spruceid/isomdl?rev=3ad4471#3ad4471337cc203515c0a8572af7a57612633475"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2763,7 +2763,7 @@ dependencies = [
  "hex",
  "hkdf",
  "hmac",
- "isomdl-macros 0.1.0 (git+https://github.com/spruceid/isomdl?rev=9d53cf9)",
+ "isomdl-macros 0.1.0 (git+https://github.com/spruceid/isomdl?rev=3ad4471)",
  "ndef-rs",
  "p256",
  "p384",
@@ -2789,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "isomdl-macros"
 version = "0.1.0"
-source = "git+https://github.com/spruceid/isomdl?rev=7608053#76080536badc867d2d674acfca9e5bae6809a54c"
+source = "git+https://github.com/spruceid/isomdl?rev=3ad4471#3ad4471337cc203515c0a8572af7a57612633475"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2799,7 +2799,7 @@ dependencies = [
 [[package]]
 name = "isomdl-macros"
 version = "0.1.0"
-source = "git+https://github.com/spruceid/isomdl?rev=9d53cf9#9d53cf94da3d5e6517dae726e8665a025e662344"
+source = "git+https://github.com/spruceid/isomdl?rev=7608053#76080536badc867d2d674acfca9e5bae6809a54c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4453,7 +4453,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4490,7 +4490,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,7 +19,7 @@ path = "uniffi-bindgen.rs"
 cose-rs = { git = "https://github.com/spruceid/cose-rs", rev = "0018c9b", features = [
     "time",
 ] }
-isomdl = { git = "https://github.com/spruceid/isomdl", rev = "9d53cf9" }
+isomdl = { git = "https://github.com/spruceid/isomdl", rev = "3ad4471" }
 oid4vci = { git = "https://github.com/spruceid/oid4vci-rs", rev = "e64ae8d", features = ["ssi", "integer-ts"] }
 oid4vci_legacy = { package = "oid4vci", git = "https://github.com/spruceid/oid4vci-rs", rev = "490c135" }
 openid4vp = { git = "https://github.com/spruceid/openid4vp", rev = "6127287" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,7 +19,7 @@ path = "uniffi-bindgen.rs"
 cose-rs = { git = "https://github.com/spruceid/cose-rs", rev = "0018c9b", features = [
     "time",
 ] }
-isomdl = { git = "https://github.com/spruceid/isomdl", rev = "fb19e7b" }
+isomdl = { git = "https://github.com/spruceid/isomdl", rev = "9d53cf9" }
 oid4vci = { git = "https://github.com/spruceid/oid4vci-rs", rev = "e64ae8d", features = ["ssi", "integer-ts"] }
 oid4vci_legacy = { package = "oid4vci", git = "https://github.com/spruceid/oid4vci-rs", rev = "490c135" }
 openid4vp = { git = "https://github.com/spruceid/openid4vp", rev = "6127287" }


### PR DESCRIPTION
## Summary

Found while testing the NFC mDL reader against an Apple Wallet holder (Google/Samsung work). Two commits:

1. **Fix** a logic bug in `GattServer` that flagged the final Client2Server data chunk as invalid.
2. **Diagnostics** to pin down a still-open Apple-specific empty-result issue (see "What this does NOT fix" below).

## Commit 1 — final-chunk handling

Per ISO 18013-5 the data characteristics chunk messages with a leading byte: `0x00` = final chunk, `0x01` = intermediate. The handler assembled and delivered the message correctly on `0x00`, but the validation right after was shaped as:

```kotlin
if (value[0] == 0x01) { /* size check */ } else { onError("Invalid first byte … expected 0 or 1") }
```

so a `0x00` byte fell into the `else` and raised **"Invalid first byte 0 … expected 0 or 1"** — self-contradictory, since `0` is one of the expected values. That spurious `onError` drove the session to `ERROR` and tripped a teardown-race `NullPointerException` in `onNotificationSent` (the GATT server was already nulled). All of this fired *after* the message had been delivered, so it was latent for holders whose response was captured first, but it's a real bug.

Replaced with a three-way `when`: `0x00` is a no-op (message already delivered), `0x01` keeps its MTU size check, only other bytes error.

Observed in a real Pixel-reader → Apple-Wallet log:
```
TransportBlePeripheralServerReader: Invalid first byte 0 in Client2Server data chunk, expected 0 or 1
BluetoothGattServer: Unhandled exception: java.lang.NullPointerException: … onNotificationSent … on a null object reference
```

## Commit 2 — diagnostics

The same log showed the NFC handover + isomdl fixes working end to end (polling, TNEP pacing, MLe negotiation, DeviceEngagement 1.1), the BLE session connecting, and the reader's request going out — but the Apple result screen showed no fields with both issuer and device auth `Unchecked`. The response *was* received (`onMessageReceived` fired), so the empty result is **not** explained by commit 1.

To localize that, this commit logs:
- the received BLE message size + hex prefix (the previous `data.toString()` only printed an object hash), and
- `handleResponse`'s outcome — doc types, issuer/device auth status, namespace keys, and the isomdl error map.

That will distinguish "short/empty response over BLE" from "full response that failed to decrypt or parse" (leading hypothesis: NFC-handover SessionTranscript mismatch between reader and Apple).

## What this does NOT fix

The Apple Wallet empty-result issue itself is **not** resolved here — commit 1 removes a spurious error + NPE, commit 2 adds the logging needed to root-cause it. Next step is a fresh capture from the Apple holder with these diagnostics.

## Verification

- `:mobilesdk:compileReleaseKotlin` — BUILD SUCCESSFUL.
- Real-device regression (Google/Samsung still read cleanly; Apple capture with new diagnostics) — to follow on this PR.