### PR TITLE
Fixes CD tag ordering and publish iOS pods to CocoaPods

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -81,7 +81,7 @@ jobs:
 
   ios:
     runs-on: macos-latest
-    needs: validation
+    needs: flutter
     permissions:
       contents: write
     steps:
@@ -105,6 +105,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
+          ref: main
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: "aarch64-apple-ios-sim,aarch64-apple-ios,x86_64-apple-ios"
@@ -141,15 +142,13 @@ jobs:
           sed -i '' "s/spec.version.*=.*/spec.version      = '${{ github.event.inputs.version }}'/" SpruceIDMobileSdkRs.podspec
           sed -i '' "s/spec.version.*=.*/spec.version          = '${{ github.event.inputs.version }}'/" SpruceIDMobileSdk.podspec
           sed -i '' "s/spec.dependency 'SpruceIDMobileSdkRs'.*/spec.dependency 'SpruceIDMobileSdkRs', '~> ${{ github.event.inputs.version }}'/" SpruceIDMobileSdk.podspec
-          sed -i '' "s/s.version.*/s.version          = '${{ github.event.inputs.version }}'/" flutter/ios/sprucekit_mobile.podspec
-          sed -i '' "s/s.dependency 'SpruceIDMobileSdk'.*/s.dependency 'SpruceIDMobileSdk', '~> ${{ github.event.inputs.version }}'/" flutter/ios/sprucekit_mobile.podspec
 
       # If this fails due to a new commit on the main branch, it's a feature not a bug!
       # This way, there will be no confusion around what was included in the release.
       - name: Push changes and tag
         id: commit
         run: |
-          git add Package.swift SpruceIDMobileSdk.podspec SpruceIDMobileSdkRs.podspec SpruceIDMobileSdkRsRustFramework.podspec flutter/ios/sprucekit_mobile.podspec
+          git add Package.swift SpruceIDMobileSdk.podspec SpruceIDMobileSdkRs.podspec SpruceIDMobileSdkRsRustFramework.podspec
           git commit -m "Release ${{ github.event.inputs.version }}"
           git push
           git tag ${{ github.event.inputs.version }} -m "${{ github.event.inputs.version }}"
@@ -162,6 +161,19 @@ jobs:
           tag: ${{ github.event.inputs.version }}
           name: ${{ github.event.inputs.version }}
 
+      - uses: webfactory/ssh-agent@v0.9.0
+        if: steps.commit.outcome == 'success'
+        with:
+          ssh-private-key: ${{ secrets.COCOAPODS_SPECS_DEPLOY_KEY }}
+
+      - name: Publish podspecs to private Specs repo
+        if: steps.commit.outcome == 'success'
+        run: |
+          pod repo add spruce-specs git@github.com:spruceid/cocoapods-specs.git
+          pod repo push spruce-specs SpruceIDMobileSdkRsRustFramework.podspec --allow-warnings --skip-import-validation
+          pod repo push spruce-specs SpruceIDMobileSdkRs.podspec --allow-warnings --skip-import-validation
+          pod repo push spruce-specs SpruceIDMobileSdk.podspec --allow-warnings --skip-import-validation
+
       - name: Revert Package.swift for local development
         if: steps.commit.outcome == 'success'
         run: |
@@ -171,7 +183,7 @@ jobs:
 
   flutter:
     runs-on: macos-latest
-    needs: [ios, android]
+    needs: android
     permissions:
       contents: write
     steps:
@@ -205,6 +217,8 @@ jobs:
           sed -i '' "s/com.spruceid.mobile.sdk:mobilesdk:[0-9.]*/com.spruceid.mobile.sdk:mobilesdk:${{ github.event.inputs.version }}/" flutter/android/build.gradle
           sed -i '' "s/com.spruceid.mobile.sdk.rs:mobilesdkrs:[0-9.]*/com.spruceid.mobile.sdk.rs:mobilesdkrs:${{ github.event.inputs.version }}/" flutter/android/build.gradle
           sed -i '' "s/^version:.*/version: ${{ github.event.inputs.version }}/" flutter/pubspec.yaml
+          sed -i '' "s/s.version.*/s.version          = '${{ github.event.inputs.version }}'/" flutter/ios/sprucekit_mobile.podspec
+          sed -i '' "s/s.dependency 'SpruceIDMobileSdk'.*/s.dependency 'SpruceIDMobileSdk', '~> ${{ github.event.inputs.version }}'/" flutter/ios/sprucekit_mobile.podspec
 
       - name: Push Flutter version updates
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -81,7 +81,42 @@ jobs:
 
   ios:
     runs-on: macos-latest
-    needs: flutter
+    needs: validation
+    outputs:
+      checksum: ${{ steps.checksum.outputs.value }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: "aarch64-apple-ios-sim,aarch64-apple-ios,x86_64-apple-ios"
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: "true"
+          workspaces: "rust -> target"
+
+      - name: Install static version of cargo-swift
+        run: cargo install cargo-swift@^0.11
+
+      - name: Generate Swift package
+        run: cargo swift package -p ios -n MobileSdkRs --release
+        working-directory: rust
+
+      - name: Compress XCFramework
+        run: zip -9 -r RustFramework.xcframework.zip rust/MobileSdkRs/RustFramework.xcframework
+
+      - name: Compute checksum
+        id: checksum
+        run: echo "value=$(swift package compute-checksum RustFramework.xcframework.zip)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rust-xcframework
+          path: RustFramework.xcframework.zip
+
+  release:
+    runs-on: macos-latest
+    needs: [android, ios]
     permissions:
       contents: write
     steps:
@@ -106,35 +141,23 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: main
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: "aarch64-apple-ios-sim,aarch64-apple-ios,x86_64-apple-ios"
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: "true"
-          workspaces: "rust -> target"
 
-      # - uses: taiki-e/install-action@v2
-      #   with:
-      #     tool: cargo-swift
-      # - name: Install unreleased version of cargo-swift
-      #   run: cargo install --git https://github.com/antoniusnaumann/cargo-swift
-      - name: Install static version of cargo-swift
-        run: cargo install cargo-swift@^0.11
-
-      - name: Generate Swift package
-        run: cargo swift package -p ios -n MobileSdkRs --release
-        working-directory: rust
-
-      - name: Compress XCFramework
+      # If this fails due to a new commit on the main branch, it's a feature not a bug!
+      # This way, there will be no confusion around what was included in the release.
+      - name: Ensure main has not moved since dispatch
         run: |
-          zip -9 -r RustFramework.xcframework.zip rust/MobileSdkRs/RustFramework.xcframework
-          echo "XCF_CHECKSUM=`swift package compute-checksum RustFramework.xcframework.zip`" >> $GITHUB_ENV
+          if [ "$(git rev-parse HEAD)" != "${{ github.sha }}" ]; then
+            echo "main advanced since dispatch (HEAD=$(git rev-parse HEAD), dispatch=${{ github.sha }})"
+            exit 1
+          fi
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: rust-xcframework
 
       - name: Update Swift Package definition
         run: |
-          sed -i '' 's/binaryTarget.*/binaryTarget(name: "RustFramework", url: "https:\/\/github.com\/spruceid\/sprucekit-mobile\/releases\/download\/${{ github.event.inputs.version }}\/RustFramework.xcframework.zip", checksum: "${{ env.XCF_CHECKSUM }}"),/' Package.swift
+          sed -i '' 's/binaryTarget.*/binaryTarget(name: "RustFramework", url: "https:\/\/github.com\/spruceid\/sprucekit-mobile\/releases\/download\/${{ github.event.inputs.version }}\/RustFramework.xcframework.zip", checksum: "${{ needs.ios.outputs.checksum }}"),/' Package.swift
 
       - name: Update CocoaPods podspecs
         run: |
@@ -143,12 +166,18 @@ jobs:
           sed -i '' "s/spec.version.*=.*/spec.version          = '${{ github.event.inputs.version }}'/" SpruceIDMobileSdk.podspec
           sed -i '' "s/spec.dependency 'SpruceIDMobileSdkRs'.*/spec.dependency 'SpruceIDMobileSdkRs', '~> ${{ github.event.inputs.version }}'/" SpruceIDMobileSdk.podspec
 
-      # If this fails due to a new commit on the main branch, it's a feature not a bug!
-      # This way, there will be no confusion around what was included in the release.
+      - name: Update Flutter plugin versions
+        run: |
+          sed -i '' "s/com.spruceid.mobile.sdk:mobilesdk:[0-9.]*/com.spruceid.mobile.sdk:mobilesdk:${{ github.event.inputs.version }}/" flutter/android/build.gradle
+          sed -i '' "s/com.spruceid.mobile.sdk.rs:mobilesdkrs:[0-9.]*/com.spruceid.mobile.sdk.rs:mobilesdkrs:${{ github.event.inputs.version }}/" flutter/android/build.gradle
+          sed -i '' "s/^version:.*/version: ${{ github.event.inputs.version }}/" flutter/pubspec.yaml
+          sed -i '' "s/s.version.*/s.version          = '${{ github.event.inputs.version }}'/" flutter/ios/sprucekit_mobile.podspec
+          sed -i '' "s/s.dependency 'SpruceIDMobileSdk'.*/s.dependency 'SpruceIDMobileSdk', '~> ${{ github.event.inputs.version }}'/" flutter/ios/sprucekit_mobile.podspec
+
       - name: Push changes and tag
         id: commit
         run: |
-          git add Package.swift SpruceIDMobileSdk.podspec SpruceIDMobileSdkRs.podspec SpruceIDMobileSdkRsRustFramework.podspec
+          git add Package.swift SpruceIDMobileSdk.podspec SpruceIDMobileSdkRs.podspec SpruceIDMobileSdkRsRustFramework.podspec flutter/
           git commit -m "Release ${{ github.event.inputs.version }}"
           git push
           git tag ${{ github.event.inputs.version }} -m "${{ github.event.inputs.version }}"
@@ -175,57 +204,9 @@ jobs:
           pod repo push spruce-specs SpruceIDMobileSdk.podspec --allow-warnings --skip-import-validation
 
       - name: Revert Package.swift for local development
-        if: steps.commit.outcome == 'success'
+        if: ${{ !cancelled() && steps.commit.outcome == 'success' }}
         run: |
-          git checkout HEAD~1 -- Package.swift
+          sed -i '' 's/binaryTarget.*/binaryTarget(name: "RustFramework", path: "rust\/MobileSdkRs\/RustFramework.xcframework"),/' Package.swift
+          git add Package.swift
           git commit -m "Revert Package.swift for local development"
           git push
-
-  flutter:
-    runs-on: macos-latest
-    needs: android
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.MONOREPO_GH_APP_ID }}
-          private-key: ${{ secrets.MONOREPO_GH_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: |
-            sprucekit-mobile
-      - name: Get GitHub App User ID
-        id: get-user-id
-        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-      - run: |
-          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
-
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          ref: main
-
-      - name: Pull latest changes
-        run: git pull --rebase
-
-      - name: Update Flutter plugin versions
-        run: |
-          sed -i '' "s/com.spruceid.mobile.sdk:mobilesdk:[0-9.]*/com.spruceid.mobile.sdk:mobilesdk:${{ github.event.inputs.version }}/" flutter/android/build.gradle
-          sed -i '' "s/com.spruceid.mobile.sdk.rs:mobilesdkrs:[0-9.]*/com.spruceid.mobile.sdk.rs:mobilesdkrs:${{ github.event.inputs.version }}/" flutter/android/build.gradle
-          sed -i '' "s/^version:.*/version: ${{ github.event.inputs.version }}/" flutter/pubspec.yaml
-          sed -i '' "s/s.version.*/s.version          = '${{ github.event.inputs.version }}'/" flutter/ios/sprucekit_mobile.podspec
-          sed -i '' "s/s.dependency 'SpruceIDMobileSdk'.*/s.dependency 'SpruceIDMobileSdk', '~> ${{ github.event.inputs.version }}'/" flutter/ios/sprucekit_mobile.podspec
-
-      - name: Push Flutter version updates
-        run: |
-          git add flutter/
-          if git diff --cached --quiet; then
-            echo "No Flutter version changes to commit (already up to date)"
-          else
-            git commit -m "Update Flutter plugin to ${{ github.event.inputs.version }}"
-            git push
-          fi

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Validate main branch
         if: github.ref_name != github.event.repository.default_branch
         run: |
-          echo "Branch is not main"
-          exit 0
+          echo "CD must run from '${{ github.event.repository.default_branch }}', not '${{ github.ref_name }}'"
+          exit 1
       - name: Validate tag
         run: |
           echo "${{ github.event.inputs.version }}" | grep -P '^[0-9]+\.[0-9]+\.[0-9]+'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,6 +170,16 @@ touch local.properties  # if missing
 ### SDKs
 Use the [`cd` Github Action](https://github.com/spruceid/sprucekit-mobile/actions/workflows/cd.yml) which is a manually triggered action, and provide the version is the `x.y.z` format.
 
+The Android SDK is published to Maven Central. The iOS pods are published to the private [`spruceid/cocoapods-specs`](https://github.com/spruceid/cocoapods-specs) Specs repo via `pod repo push`, authenticated with an SSH deploy key stored in the `COCOAPODS_SPECS_DEPLOY_KEY` secret.
+
+### Consuming the iOS SDK via CocoaPods
+The pods source their code from the release git tag, so add the private Specs repo alongside the CDN at the top of your `Podfile`:
+
+```ruby
+source 'https://github.com/spruceid/cocoapods-specs.git'
+source 'https://cdn.cocoapods.org'
+```
+
 ### Showcase Apps
 This is currently done manually and locally.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,9 +168,9 @@ touch local.properties  # if missing
 ## Releases
 
 ### SDKs
-Use the [`cd` Github Action](https://github.com/spruceid/sprucekit-mobile/actions/workflows/cd.yml) which is a manually triggered action, and provide the version is the `x.y.z` format.
+Use the [`cd` Github Action](https://github.com/spruceid/sprucekit-mobile/actions/workflows/cd.yml) which is a manually triggered action, and provide the version in the `x.y.z` format.
 
-The Android SDK is published to Maven Central. The iOS pods are published to the private [`spruceid/cocoapods-specs`](https://github.com/spruceid/cocoapods-specs) Specs repo via `pod repo push`, authenticated with an SSH deploy key stored in the `COCOAPODS_SPECS_DEPLOY_KEY` secret.
+The Android SDK is published to Maven Central. The iOS pods are published to the private [`spruceid/cocoapods-specs`](https://github.com/spruceid/cocoapods-specs) Specs repo.
 
 ### Consuming the iOS SDK via CocoaPods
 The pods source their code from the release git tag, so add the private Specs repo alongside the CDN at the top of your `Podfile`:


### PR DESCRIPTION
## Description
 The release is tagged inside the ios job, which is just where `git tag` runs. The Flutter version bump ran in a job that executed after that, so the bump was not in the tagged commit: checking out the release tag returned stale Flutter versions (`pubspec.yaml`, `build.gradle`). Move the flutter job before ios so the bump is part of the tagged commit.

### Other changes

Also publish the iOS SDK pods to the private [spruceid/cocoapods-specs](https://github.com/spruceid/cocoapods-specs) repo after tagging, and move the `flutter/ios podspec` bump into the flutter job so all Flutter version edits live in one place. 

To publish to cocoapods, I followed: https://guides.cocoapods.org/making/private-cocoapods.html

### Optional section

- [x] Need to setup COCOAPODS_SPECS_DEPLOY_KEY so this repo can publish to: [spruceid/cocoapods-specs](https://github.com/spruceid/cocoapods-specs)

## Tested

- [x] Need to publish a test tag and test locally
