### PR TITLE
WIP: support retaining expired credentials for DC-API

### DIFF
--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/dcapi/Registry.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/dcapi/Registry.kt
@@ -116,16 +116,6 @@ class Registry(
             ?.value?.replace("\"", "")
         val baseTitle = if (givenName != null) "Driver's License ($givenName)" else "Driver's License"
 
-        // TODO: Do we want this?
-        // Annotate the selector entry when the credential is not currently valid.
-        // The credential remains selectable; the consent UI is responsible for
-        // warning the user before sharing. Validity enforcement is the verifier's.
-        val title = when (mdoc.validityStatus()) {
-            MdocValidityStatus.EXPIRED -> "$baseTitle — Expired"
-            MdocValidityStatus.NOT_YET_VALID -> "$baseTitle — Not yet valid"
-            MdocValidityStatus.VALID -> baseTitle
-        }
-
         // Build the list of MdocFields
         val fields = mutableListOf<MdocField>()
         mdoc.details().forEach { (namespace, elements) ->

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/dcapi/Registry.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/dcapi/Registry.kt
@@ -14,7 +14,6 @@ import androidx.credentials.registry.provider.digitalcredentials.VerificationEnt
 import androidx.credentials.registry.provider.digitalcredentials.VerificationFieldDisplayProperties
 import com.spruceid.mobile.sdk.CredentialPack
 import com.spruceid.mobile.sdk.rs.Mdoc
-import com.spruceid.mobile.sdk.rs.MdocValidityStatus
 import com.spruceid.mobile.sdk.rs.ParsedCredential
 import java.util.UUID
 

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/dcapi/Registry.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/dcapi/Registry.kt
@@ -14,6 +14,7 @@ import androidx.credentials.registry.provider.digitalcredentials.VerificationEnt
 import androidx.credentials.registry.provider.digitalcredentials.VerificationFieldDisplayProperties
 import com.spruceid.mobile.sdk.CredentialPack
 import com.spruceid.mobile.sdk.rs.Mdoc
+import com.spruceid.mobile.sdk.rs.MdocValidityStatus
 import com.spruceid.mobile.sdk.rs.ParsedCredential
 import java.util.UUID
 
@@ -113,7 +114,17 @@ class Registry(
         val givenName = mdoc.details()["org.iso.18013.5.1"]
             ?.firstOrNull { it.identifier == "given_name" }
             ?.value?.replace("\"", "")
-        val title = if (givenName != null) "Driver's License ($givenName)" else "Driver's License"
+        val baseTitle = if (givenName != null) "Driver's License ($givenName)" else "Driver's License"
+
+        // TODO: Do we want this?
+        // Annotate the selector entry when the credential is not currently valid.
+        // The credential remains selectable; the consent UI is responsible for
+        // warning the user before sharing. Validity enforcement is the verifier's.
+        val title = when (mdoc.validityStatus()) {
+            MdocValidityStatus.EXPIRED -> "$baseTitle — Expired"
+            MdocValidityStatus.NOT_YET_VALID -> "$baseTitle — Not yet valid"
+            MdocValidityStatus.VALID -> baseTitle
+        }
 
         // Build the list of MdocFields
         val fields = mutableListOf<MdocField>()

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/dcapi/Registry.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/dcapi/Registry.kt
@@ -114,7 +114,7 @@ class Registry(
         val givenName = mdoc.details()["org.iso.18013.5.1"]
             ?.firstOrNull { it.identifier == "given_name" }
             ?.value?.replace("\"", "")
-        val baseTitle = if (givenName != null) "Driver's License ($givenName)" else "Driver's License"
+        val title = if (givenName != null) "Driver's License ($givenName)" else "Driver's License"
 
         // Build the list of MdocFields
         val fields = mutableListOf<MdocField>()

--- a/ios/MobileSdk/Sources/MobileSdk/CredentialPack.swift
+++ b/ios/MobileSdk/Sources/MobileSdk/CredentialPack.swift
@@ -216,14 +216,6 @@ public class CredentialPack {
                         documentIdentifier: mdoc.id(),
                         invalidationDate: invalidationDate
                     )
-                    print("""
-                    🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
-                    🚨 GOT HERE: addMDocToIDProvider → addRegistration   🚨
-                    🚨 mdoc.id() = \(mdoc.id())
-                    🚨 policy = \(invalidationPolicy)
-                    🚨 invalidationDate FORCED TO nil (TEMPORARY TEST HACK) 🚨
-                    🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
-                    """)
                     try await store.addRegistration(registration)
                 } catch IdentityDocumentProviderRegistrationStore.RegistrationError.notAuthorized {
                     print(

--- a/ios/MobileSdk/Sources/MobileSdk/CredentialPack.swift
+++ b/ios/MobileSdk/Sources/MobileSdk/CredentialPack.swift
@@ -8,24 +8,15 @@ import IdentityDocumentServices
 
 /// Controls the `invalidationDate` supplied to iOS IdentityDocumentServices when
 /// an mdoc is registered for presentation over the Digital Credentials API.
-///
-/// `invalidationDate` is an OS-eviction hint: once it has passed, the system stops
-/// offering the document in the credential picker (and, for a single-credential
-/// wallet, hides the wallet entirely). It is independent of the credential's own
-/// signed validity window (MSO `validityInfo`), which always travels in the
-/// presented response for the verifier to evaluate.
 public enum MdocInvalidationPolicy: Sendable {
     /// Set `invalidationDate` to the credential's MSO `validUntil`. Expired
     /// credentials are evicted by the OS and disappear from the picker. This is
-    /// the default in order to preserve existing behavior for current SDK users.
+    /// the default, and is backwards-compatible with previous SDK versions.
     case credentialExpiry
     /// Do not set an `invalidationDate` (`nil`). The credential remains in the
-    /// picker after its natural expiry; the wallet is responsible for flagging
-    /// and gating use of expired credentials in its own request UI.
+    /// picker after its natural expiry; the wallet is responsible for managing credential
+    /// lifecycle.
     case never
-    /// Set an explicit `invalidationDate` for a known future OS eviction
-    /// (e.g. a scheduled rotation).
-    case date(Date)
 }
 
 /// A collection of ParsedCredentials with methods to interact with all instances.
@@ -176,9 +167,6 @@ public class CredentialPack {
 
     #if canImport(IdentityDocumentServices)
         /// Resolve the `invalidationDate` to register for an mdoc, given a policy.
-        ///
-        /// Returns `nil` for `.never`, the supplied date for `.date`, and the parsed
-        /// MSO `validUntil` for `.credentialExpiry`.
         @available(iOS 26.0, *)
         private static func resolveInvalidationDate(
             for mdoc: Mdoc,
@@ -187,8 +175,6 @@ public class CredentialPack {
             switch policy {
             case .never:
                 return nil
-            case .date(let date):
-                return date
             case .credentialExpiry:
                 let dateFormatter = ISO8601DateFormatter()
                 let isoDateString = try mdoc.invalidationDate()
@@ -230,6 +216,14 @@ public class CredentialPack {
                         documentIdentifier: mdoc.id(),
                         invalidationDate: invalidationDate
                     )
+                    print("""
+                    🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
+                    🚨 GOT HERE: addMDocToIDProvider → addRegistration   🚨
+                    🚨 mdoc.id() = \(mdoc.id())
+                    🚨 policy = \(invalidationPolicy)
+                    🚨 invalidationDate FORCED TO nil (TEMPORARY TEST HACK) 🚨
+                    🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
+                    """)
                     try await store.addRegistration(registration)
                 } catch IdentityDocumentProviderRegistrationStore.RegistrationError.notAuthorized {
                     print(
@@ -248,63 +242,57 @@ public class CredentialPack {
         invalidationPolicy: MdocInvalidationPolicy = .credentialExpiry
     ) async throws {
         #if canImport(IdentityDocumentServices)
-            if #available(iOS 26.0, *) {
-                // checking first that there are any potential mdocs to add to the id provider
-                // to avoid the authorization popup if not necessary
-                var mdocs: [Mdoc] = []
-                for credential in self.credentials {
-                    guard let mdoc = credential.asMsoMdoc() else { continue }
-                    if mdoc.doctype() == "org.iso.18013.5.1.mDL" {
-                        mdocs.append(mdoc)
-                    }
-                }
-                if mdocs.isEmpty {
-                    return
-                }
-                let store = IdentityDocumentProviderRegistrationStore()
-                var storedRegistrations: [any IdentityDocumentRegistration]
-                do {
-                    storedRegistrations = try await store.registrations
-                } catch IdentityDocumentProviderRegistrationStore.RegistrationError.notAuthorized {
-                    // fetching registrations before the app has been authorized by user to use the id provider
-                    // (which happens at the time of registration of a credential) results in this error
-                    storedRegistrations = []
-                } catch {
-                    throw CredentialPackError.idService(
-                        reason: error
-                    )
-                }
-                for mdoc in mdocs {
-                    let matchingRegistration = storedRegistrations.first { storedRegistration in
-                        storedRegistration.documentIdentifier == mdoc.id()
-                    }
-                    if matchingRegistration == nil {
-                        try await self.addMDocToIDProvider(
-                            mdoc: mdoc,
-                            invalidationPolicy: invalidationPolicy
-                        )
-                    }
+        if #available(iOS 26.0, *) {
+            // checking first that there are any potential mdocs to add to the id provider
+            // to avoid the authorization popup if not necessary
+            var mdocs: [Mdoc] = []
+            for credential in self.credentials {
+                guard let mdoc = credential.asMsoMdoc() else { continue }
+                if mdoc.doctype() == "org.iso.18013.5.1.mDL" {
+                    mdocs.append(mdoc)
                 }
             }
+            if mdocs.isEmpty {
+                return
+            }
+            let store = IdentityDocumentProviderRegistrationStore()
+            var storedRegistrations: [any IdentityDocumentRegistration]
+            do {
+                storedRegistrations = try await store.registrations
+            } catch IdentityDocumentProviderRegistrationStore.RegistrationError.notAuthorized {
+                // fetching registrations before the app has been authorized by user to use the id provider
+                // (which happens at the time of registration of a credential) results in this error
+                storedRegistrations = []
+            } catch {
+                throw CredentialPackError.idService(
+                    reason: error
+                )
+            }
+            for mdoc in mdocs {
+                let matchingRegistration = storedRegistrations.first { storedRegistration in
+                    storedRegistration.documentIdentifier == mdoc.id()
+                }
+                if matchingRegistration == nil {
+                    try await self.addMDocToIDProvider(
+                        mdoc: mdoc,
+                        invalidationPolicy: invalidationPolicy
+                    )
+                }
+            }
+        }
         #endif
     }
 
     /// Add an Mdoc to the CredentialPack.
-    ///
-    /// - Parameter invalidationPolicy: Controls the `invalidationDate` registered
-    ///   with iOS IdentityDocumentServices. Defaults to `.credentialExpiry`, which
-    ///   preserves prior behavior (the OS hides the document once it expires). Pass
-    ///   `.never` to keep an expired credential visible in the picker and handle the
-    ///   expired state in your own request UI.
     public func addMDoc(
         mdoc: Mdoc,
         invalidationPolicy: MdocInvalidationPolicy = .credentialExpiry
     ) async throws -> [ParsedCredential] {
         #if canImport(IdentityDocumentServices)
-            if #available(iOS 26.0, *) {
-                try await self.addMDocToIDProvider(
-                    mdoc: mdoc, invalidationPolicy: invalidationPolicy)
-            }
+        if #available(iOS 26.0, *) {
+            try await self.addMDocToIDProvider(
+                mdoc: mdoc, invalidationPolicy: invalidationPolicy)
+        }
         #endif
         credentials.append(ParsedCredential.newMsoMdoc(mdoc: mdoc))
         return credentials

--- a/ios/MobileSdk/Sources/MobileSdk/CredentialPack.swift
+++ b/ios/MobileSdk/Sources/MobileSdk/CredentialPack.swift
@@ -6,6 +6,28 @@ import SpruceIDMobileSdkRs
 import IdentityDocumentServices
 #endif
 
+/// Controls the `invalidationDate` supplied to iOS IdentityDocumentServices when
+/// an mdoc is registered for presentation over the Digital Credentials API.
+///
+/// `invalidationDate` is an OS-eviction hint: once it has passed, the system stops
+/// offering the document in the credential picker (and, for a single-credential
+/// wallet, hides the wallet entirely). It is independent of the credential's own
+/// signed validity window (MSO `validityInfo`), which always travels in the
+/// presented response for the verifier to evaluate.
+public enum MdocInvalidationPolicy: Sendable {
+    /// Set `invalidationDate` to the credential's MSO `validUntil`. Expired
+    /// credentials are evicted by the OS and disappear from the picker. This is
+    /// the default in order to preserve existing behavior for current SDK users.
+    case credentialExpiry
+    /// Do not set an `invalidationDate` (`nil`). The credential remains in the
+    /// picker after its natural expiry; the wallet is responsible for flagging
+    /// and gating use of expired credentials in its own request UI.
+    case never
+    /// Set an explicit `invalidationDate` for a known future OS eviction
+    /// (e.g. a scheduled rotation).
+    case date(Date)
+}
+
 /// A collection of ParsedCredentials with methods to interact with all instances.
 ///
 /// A CredentialPack is a semantic grouping of Credentials for display in the wallet. For example,
@@ -148,90 +170,136 @@ public class CredentialPack {
     }
 
     #if canImport(IdentityDocumentServices)
-    @available(iOS 26.0, *)
-    private func addMDocToIDProvider(mdoc: Mdoc) async throws {
-        if mdoc.doctype() == "org.iso.18013.5.1.mDL" {
-            let store = IdentityDocumentProviderRegistrationStore()
-            do {
+        /// Resolve the `invalidationDate` to register for an mdoc, given a policy.
+        ///
+        /// Returns `nil` for `.never`, the supplied date for `.date`, and the parsed
+        /// MSO `validUntil` for `.credentialExpiry`.
+        @available(iOS 26.0, *)
+        private static func resolveInvalidationDate(
+            for mdoc: Mdoc,
+            policy: MdocInvalidationPolicy
+        ) throws -> Date? {
+            switch policy {
+            case .never:
+                return nil
+            case .date(let date):
+                return date
+            case .credentialExpiry:
                 let dateFormatter = ISO8601DateFormatter()
                 let isoDateString = try mdoc.invalidationDate()
                 // remove unsupported milliseconds
-                let trimmedIsoString = isoDateString.replacingOccurrences(of: "\\.\\d+",
-                                                                          with: "",
-                                                                          options: .regularExpression)
+                let trimmedIsoString = isoDateString.replacingOccurrences(
+                    of: "\\.\\d+",
+                    with: "",
+                    options: .regularExpression)
                 guard let dateUntil = dateFormatter.date(from: trimmedIsoString) else {
                     throw CredentialPackError.idService(
                         reason: NSError(
                             domain: "CredentialPack",
                             code: -1,
-                            userInfo: [NSLocalizedDescriptionKey: "Failed to parse invalidation date"]
+                            userInfo: [
+                                NSLocalizedDescriptionKey: "Failed to parse invalidation date"
+                            ]
                         )
                     )
                 }
-                let registration = MobileDocumentRegistration(
-                    mobileDocumentType: "org.iso.18013.5.1.mDL",
-                    supportedAuthorityKeyIdentifiers: [],  // TODO
-                    documentIdentifier: mdoc.id(),
-                    invalidationDate: dateUntil
-                )
-                try await store.addRegistration(registration)
-            } catch IdentityDocumentProviderRegistrationStore.RegistrationError.notAuthorized {
-                print("Device not authorized to use id document store, did the user disable document registration?")
-            } catch {
-                throw CredentialPackError.idService(
-                    reason: error
-                )
+                return dateUntil
             }
         }
-    }
+
+        @available(iOS 26.0, *)
+        private func addMDocToIDProvider(
+            mdoc: Mdoc,
+            invalidationPolicy: MdocInvalidationPolicy
+        ) async throws {
+            if mdoc.doctype() == "org.iso.18013.5.1.mDL" {
+                let store = IdentityDocumentProviderRegistrationStore()
+                do {
+                    let invalidationDate = try Self.resolveInvalidationDate(
+                        for: mdoc,
+                        policy: invalidationPolicy
+                    )
+                    let registration = MobileDocumentRegistration(
+                        mobileDocumentType: "org.iso.18013.5.1.mDL",
+                        supportedAuthorityKeyIdentifiers: [],  // TODO
+                        documentIdentifier: mdoc.id(),
+                        invalidationDate: invalidationDate
+                    )
+                    try await store.addRegistration(registration)
+                } catch IdentityDocumentProviderRegistrationStore.RegistrationError.notAuthorized {
+                    print(
+                        "Device not authorized to use id document store, did the user disable document registration?"
+                    )
+                } catch {
+                    throw CredentialPackError.idService(
+                        reason: error
+                    )
+                }
+            }
+        }
     #endif
 
-    public func registerUnregisteredIDProviderDocuments() async throws {
+    public func registerUnregisteredIDProviderDocuments(
+        invalidationPolicy: MdocInvalidationPolicy = .credentialExpiry
+    ) async throws {
         #if canImport(IdentityDocumentServices)
-        if #available(iOS 26.0, *) {
-            // checking first that there are any potential mdocs to add to the id provider
-            // to avoid the authorization popup if not necessary
-            var mdocs: [Mdoc] = []
-            for credential in self.credentials {
-                guard let mdoc = credential.asMsoMdoc() else { continue }
-                if mdoc.doctype() == "org.iso.18013.5.1.mDL" {
-                    mdocs.append(mdoc)
+            if #available(iOS 26.0, *) {
+                // checking first that there are any potential mdocs to add to the id provider
+                // to avoid the authorization popup if not necessary
+                var mdocs: [Mdoc] = []
+                for credential in self.credentials {
+                    guard let mdoc = credential.asMsoMdoc() else { continue }
+                    if mdoc.doctype() == "org.iso.18013.5.1.mDL" {
+                        mdocs.append(mdoc)
+                    }
+                }
+                if mdocs.isEmpty {
+                    return
+                }
+                let store = IdentityDocumentProviderRegistrationStore()
+                var storedRegistrations: [any IdentityDocumentRegistration]
+                do {
+                    storedRegistrations = try await store.registrations
+                } catch IdentityDocumentProviderRegistrationStore.RegistrationError.notAuthorized {
+                    // fetching registrations before the app has been authorized by user to use the id provider
+                    // (which happens at the time of registration of a credential) results in this error
+                    storedRegistrations = []
+                } catch {
+                    throw CredentialPackError.idService(
+                        reason: error
+                    )
+                }
+                for mdoc in mdocs {
+                    let matchingRegistration = storedRegistrations.first { storedRegistration in
+                        storedRegistration.documentIdentifier == mdoc.id()
+                    }
+                    if matchingRegistration == nil {
+                        try await self.addMDocToIDProvider(
+                            mdoc: mdoc,
+                            invalidationPolicy: invalidationPolicy
+                        )
+                    }
                 }
             }
-            if mdocs.isEmpty {
-                return
-            }
-            let store = IdentityDocumentProviderRegistrationStore()
-            var storedRegistrations: [any IdentityDocumentRegistration]
-            do {
-                storedRegistrations = try await store.registrations
-            } catch IdentityDocumentProviderRegistrationStore.RegistrationError.notAuthorized {
-                // fetching registrations before the app has been authorized by user to use the id provider
-                // (which happens at the time of registration of a credential) results in this error
-                storedRegistrations = []
-            } catch {
-                throw CredentialPackError.idService(
-                    reason: error
-                )
-            }
-            for mdoc in mdocs {
-                let matchingRegistration = storedRegistrations.first { storedRegistration in
-                    storedRegistration.documentIdentifier == mdoc.id()
-                }
-                if matchingRegistration == nil {
-                    try await self.addMDocToIDProvider(mdoc: mdoc)
-                }
-            }
-        }
         #endif
     }
 
     /// Add an Mdoc to the CredentialPack.
-    public func addMDoc(mdoc: Mdoc) async throws -> [ParsedCredential] {
+    ///
+    /// - Parameter invalidationPolicy: Controls the `invalidationDate` registered
+    ///   with iOS IdentityDocumentServices. Defaults to `.credentialExpiry`, which
+    ///   preserves prior behavior (the OS hides the document once it expires). Pass
+    ///   `.never` to keep an expired credential visible in the picker and handle the
+    ///   expired state in your own request UI.
+    public func addMDoc(
+        mdoc: Mdoc,
+        invalidationPolicy: MdocInvalidationPolicy = .credentialExpiry
+    ) async throws -> [ParsedCredential] {
         #if canImport(IdentityDocumentServices)
-        if #available(iOS 26.0, *) {
-            try await self.addMDocToIDProvider(mdoc: mdoc)
-        }
+            if #available(iOS 26.0, *) {
+                try await self.addMDocToIDProvider(
+                    mdoc: mdoc, invalidationPolicy: invalidationPolicy)
+            }
         #endif
         credentials.append(ParsedCredential.newMsoMdoc(mdoc: mdoc))
         return credentials

--- a/ios/MobileSdk/Sources/MobileSdk/CredentialPack.swift
+++ b/ios/MobileSdk/Sources/MobileSdk/CredentialPack.swift
@@ -92,20 +92,25 @@ public class CredentialPack {
     /**
      * Try to add a raw mDoc with specified keyAlias
      */
-    public func tryAddRawMdoc(rawCredential: String, keyAlias: String) async throws
-        -> [ParsedCredential] {
+    public func tryAddRawMdoc(
+        rawCredential: String,
+        keyAlias: String,
+        invalidationPolicy: MdocInvalidationPolicy = .credentialExpiry
+    ) async throws -> [ParsedCredential] {
         if let credentials = try? await addMDoc(
             mdoc: Mdoc.fromStringifiedDocument(
                 stringifiedDocument: rawCredential,
                 keyAlias: keyAlias
-            )
+            ),
+            invalidationPolicy: invalidationPolicy
         ) {
             return credentials
         } else if let credentials = try? await addMDoc(
             mdoc: Mdoc.newFromBase64urlEncodedIssuerSigned(
                 base64urlEncodedIssuerSigned: rawCredential,
                 keyAlias: keyAlias
-            )
+            ),
+            invalidationPolicy: invalidationPolicy
         ) {
             return credentials
         } else {

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleMdocOID4VPView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleMdocOID4VPView.swift
@@ -160,6 +160,7 @@ struct HandleMdocOID4VPView: View {
                     back()
                 }
             )
+            .id(selectedMatch?.credentialId())
         case .loading:
             LoadingView(loadingText: "Loading...")
         case .none:

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleMdocOID4VPView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleMdocOID4VPView.swift
@@ -27,7 +27,7 @@ struct HandleMdocOID4VPView: View {
     @EnvironmentObject private var keyManager: KeyManager
     @Binding var path: NavigationPath
     var credentialPackId: String?
-    
+
     var url: String
 
     @State private var handler: Oid4vp180137?
@@ -63,7 +63,7 @@ struct HandleMdocOID4VPView: View {
                 )
                 handler = handlerRef
                 request = try await handlerRef.processRequest(url: url)
-                
+
                 if credentials.count > 1 {
                     state = .selectCredential
                 } else {
@@ -179,6 +179,9 @@ struct MdocFieldSelector: View {
     @State private var selectedFields: [String]
     let requiredFields: [String]
 
+    /// Set by the user to share a credential that is expired / not yet valid.
+    @State private var acknowledgedInvalid = false
+
     init(
         match: RequestMatch180137,
         onContinue: @escaping (ApprovedResponse180137) -> Void,
@@ -191,6 +194,28 @@ struct MdocFieldSelector: View {
             .filter { $0.required || $0.selectivelyDisclosable }
             .map { $0.id }
         self.selectedFields = self.requiredFields
+    }
+
+    /// Warning copy shown when the credential is not currently valid; `nil` when valid.
+    private var invalidWarningText: String? {
+        switch match.validityStatus() {
+        case .valid:
+            return nil
+        case .expired:
+            return "This credential has expired. The verifier is likely to reject "
+                + "it, but you can choose to share it anyway."
+        case .notYetValid:
+            return "This credential is not yet valid. The verifier is likely to "
+                + "reject it, but you can choose to share it anyway."
+        @unknown default:
+            return nil
+        }
+    }
+
+    /// Whether the Approve button may proceed: always for valid credentials,
+    /// otherwise only after the user explicitly opts in.
+    private var canApprove: Bool {
+        invalidWarningText == nil || acknowledgedInvalid
     }
 
     func toggleBinding(for field: RequestedField180137) -> Binding<Bool> {
@@ -216,6 +241,27 @@ struct MdocFieldSelector: View {
                     .foregroundColor(Color("ColorStone950"))
             }
             .multilineTextAlignment(.center)
+
+            // NOTE: placeholder styling (system `.orange`, default fonts).
+            if let warning = invalidWarningText {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(warning)
+                        .font(.customFont(font: .inter, style: .medium, size: .h4))
+                        .foregroundStyle(.white)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Toggle(isOn: $acknowledgedInvalid) {
+                        Text("Share anyway")
+                            .font(.customFont(font: .inter, style: .medium, size: .h4))
+                            .foregroundStyle(.white)
+                    }
+                    .toggleStyle(iOSCheckboxToggleStyle())
+                }
+                .padding(16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.orange)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .padding(.vertical, 8)
+            }
 
             ScrollView {
                 ForEach(match.requestedFields(), id: \.self) { field in
@@ -260,6 +306,8 @@ struct MdocFieldSelector: View {
                 .padding(.vertical, 13)
                 .background(Color("ColorEmerald900"))
                 .clipShape(RoundedRectangle(cornerRadius: 8))
+                .disabled(!canApprove)
+                .opacity(canApprove ? 1 : 0.6)
             }
             .fixedSize(horizontal: false, vertical: true)
         }
@@ -380,6 +428,19 @@ struct MdocSelector: View {
     }
 }
 
+/// A short badge shown when a matched credential is not currently valid.
+/// Returns `nil` when the credential is valid.
+// NOTE (UI): copy and styling below use system colors (`.red`/`.orange`) as
+// placeholders — adjust to the app's design system / asset-catalog colors.
+func mdocValidityBadgeText(_ status: MdocValidityStatus) -> String? {
+    switch status {
+    case .valid: return nil
+    case .expired: return "Expired"
+    case .notYetValid: return "Not yet valid"
+    @unknown default: return nil
+    }
+}
+
 struct MdocSelectorItem: View {
     let match: RequestMatch180137
     let doctype: String?
@@ -413,6 +474,15 @@ struct MdocSelectorItem: View {
                         .foregroundStyle(Color("ColorStone950"))
                 }
                 .toggleStyle(iOSCheckboxToggleStyle())
+                if let badge = mdocValidityBadgeText(match.validityStatus()) {
+                    Text(badge)
+                        .font(.customFont(font: .inter, style: .medium, size: .h4))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 2)
+                        .background(Color.red)
+                        .clipShape(Capsule())
+                }
                 Spacer()
                 if expanded {
                     Image("Collapse")

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -8871,17 +8871,10 @@ public protocol MdocProtocol: AnyObject, Sendable {
     
     func invalidationDate() throws  -> String
     
-    /**
-     * Whether this mdoc is currently within its validity window.
-     */
-    func isCurrentlyValid()  -> Bool
-    
     func keyAlias()  -> KeyAlias
     
     /**
-     * The validity of this mdoc relative to the current time, derived from the
-     * MSO `validityInfo`. Intended for display; the verifier remains
-     * responsible for enforcing validity at presentation time.
+     * The validity of this mdoc relative to the current time, derived from `validityInfo`.
      */
     func validityStatus()  -> MdocValidityStatus
     
@@ -9070,17 +9063,6 @@ open func invalidationDate()throws  -> String  {
 })
 }
     
-    /**
-     * Whether this mdoc is currently within its validity window.
-     */
-open func isCurrentlyValid() -> Bool  {
-    return try!  FfiConverterBool.lift(try! rustCall() {
-    uniffi_mobile_sdk_rs_fn_method_mdoc_is_currently_valid(
-            self.uniffiCloneHandle(),$0
-    )
-})
-}
-    
 open func keyAlias() -> KeyAlias  {
     return try!  FfiConverterTypeKeyAlias_lift(try! rustCall() {
     uniffi_mobile_sdk_rs_fn_method_mdoc_key_alias(
@@ -9090,9 +9072,7 @@ open func keyAlias() -> KeyAlias  {
 }
     
     /**
-     * The validity of this mdoc relative to the current time, derived from the
-     * MSO `validityInfo`. Intended for display; the verifier remains
-     * responsible for enforcing validity at presentation time.
+     * The validity of this mdoc relative to the current time, derived from `validityInfo`.
      */
 open func validityStatus() -> MdocValidityStatus  {
     return try!  FfiConverterTypeMdocValidityStatus_lift(try! rustCall() {
@@ -13395,10 +13375,6 @@ public protocol RequestMatch180137Protocol: AnyObject, Sendable {
     
     func requestedFields()  -> [RequestedField180137]
     
-    /**
-     * Validity of the matched credential relative to the current time.
-     * Selection UI can use this to flag expired / not-yet-valid credentials.
-     */
     func validityStatus()  -> MdocValidityStatus
     
 }
@@ -13474,10 +13450,6 @@ open func requestedFields() -> [RequestedField180137]  {
 })
 }
     
-    /**
-     * Validity of the matched credential relative to the current time.
-     * Selection UI can use this to flag expired / not-yet-valid credentials.
-     */
 open func validityStatus() -> MdocValidityStatus  {
     return try!  FfiConverterTypeMdocValidityStatus_lift(try! rustCall() {
     uniffi_mobile_sdk_rs_fn_method_requestmatch180137_validity_status(
@@ -26848,10 +26820,6 @@ public func FfiConverterTypeMdocInitError_lower(_ value: MdocInitError) -> RustB
 /**
  * The validity of an mdoc relative to the current time, derived from the MSO
  * `validityInfo` (`validFrom`/`validUntil`).
- *
- * This is informational metadata for display purposes. Validity enforcement is
- * a verifier responsibility per ISO/IEC 18013-5; a holder may still present an
- * expired or not-yet-valid credential and let the verifier decide.
  */
 
 public enum MdocValidityStatus: Equatable, Hashable {
@@ -36877,13 +36845,10 @@ private let initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_method_mdoc_invalidation_date() != 52225) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mobile_sdk_rs_checksum_method_mdoc_is_currently_valid() != 36629) {
-        return InitializationResult.apiChecksumMismatch
-    }
     if (uniffi_mobile_sdk_rs_checksum_method_mdoc_key_alias() != 45386) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mobile_sdk_rs_checksum_method_mdoc_validity_status() != 15025) {
+    if (uniffi_mobile_sdk_rs_checksum_method_mdoc_validity_status() != 13785) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_opticalbarcodecred_id() != 57284) {
@@ -37468,7 +37433,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_method_requestmatch180137_requested_fields() != 4609) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mobile_sdk_rs_checksum_method_requestmatch180137_validity_status() != 48497) {
+    if (uniffi_mobile_sdk_rs_checksum_method_requestmatch180137_validity_status() != 57220) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_permissionrequest_client_id() != 38125) {

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -8871,7 +8871,19 @@ public protocol MdocProtocol: AnyObject, Sendable {
     
     func invalidationDate() throws  -> String
     
+    /**
+     * Whether this mdoc is currently within its validity window.
+     */
+    func isCurrentlyValid()  -> Bool
+    
     func keyAlias()  -> KeyAlias
+    
+    /**
+     * The validity of this mdoc relative to the current time, derived from the
+     * MSO `validityInfo`. Intended for display; the verifier remains
+     * responsible for enforcing validity at presentation time.
+     */
+    func validityStatus()  -> MdocValidityStatus
     
 }
 open class Mdoc: MdocProtocol, @unchecked Sendable {
@@ -9058,9 +9070,33 @@ open func invalidationDate()throws  -> String  {
 })
 }
     
+    /**
+     * Whether this mdoc is currently within its validity window.
+     */
+open func isCurrentlyValid() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_mobile_sdk_rs_fn_method_mdoc_is_currently_valid(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+    
 open func keyAlias() -> KeyAlias  {
     return try!  FfiConverterTypeKeyAlias_lift(try! rustCall() {
     uniffi_mobile_sdk_rs_fn_method_mdoc_key_alias(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+    
+    /**
+     * The validity of this mdoc relative to the current time, derived from the
+     * MSO `validityInfo`. Intended for display; the verifier remains
+     * responsible for enforcing validity at presentation time.
+     */
+open func validityStatus() -> MdocValidityStatus  {
+    return try!  FfiConverterTypeMdocValidityStatus_lift(try! rustCall() {
+    uniffi_mobile_sdk_rs_fn_method_mdoc_validity_status(
             self.uniffiCloneHandle(),$0
     )
 })
@@ -13359,6 +13395,12 @@ public protocol RequestMatch180137Protocol: AnyObject, Sendable {
     
     func requestedFields()  -> [RequestedField180137]
     
+    /**
+     * Validity of the matched credential relative to the current time.
+     * Selection UI can use this to flag expired / not-yet-valid credentials.
+     */
+    func validityStatus()  -> MdocValidityStatus
+    
 }
 /**
  * A viable match for the credential request.
@@ -13427,6 +13469,18 @@ open func credentialId() -> Uuid  {
 open func requestedFields() -> [RequestedField180137]  {
     return try!  FfiConverterSequenceTypeRequestedField180137.lift(try! rustCall() {
     uniffi_mobile_sdk_rs_fn_method_requestmatch180137_requested_fields(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+    
+    /**
+     * Validity of the matched credential relative to the current time.
+     * Selection UI can use this to flag expired / not-yet-valid credentials.
+     */
+open func validityStatus() -> MdocValidityStatus  {
+    return try!  FfiConverterTypeMdocValidityStatus_lift(try! rustCall() {
+    uniffi_mobile_sdk_rs_fn_method_requestmatch180137_validity_status(
             self.uniffiCloneHandle(),$0
     )
 })
@@ -26789,6 +26843,97 @@ public func FfiConverterTypeMdocInitError_lower(_ value: MdocInitError) -> RustB
     return FfiConverterTypeMdocInitError.lower(value)
 }
 
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
+ * The validity of an mdoc relative to the current time, derived from the MSO
+ * `validityInfo` (`validFrom`/`validUntil`).
+ *
+ * This is informational metadata for display purposes. Validity enforcement is
+ * a verifier responsibility per ISO/IEC 18013-5; a holder may still present an
+ * expired or not-yet-valid credential and let the verifier decide.
+ */
+
+public enum MdocValidityStatus: Equatable, Hashable {
+    
+    /**
+     * The current time is within `[validFrom, validUntil]`.
+     */
+    case valid
+    /**
+     * `validUntil` is in the past.
+     */
+    case expired
+    /**
+     * `validFrom` is in the future.
+     */
+    case notYetValid
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension MdocValidityStatus: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeMdocValidityStatus: FfiConverterRustBuffer {
+    typealias SwiftType = MdocValidityStatus
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MdocValidityStatus {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .valid
+        
+        case 2: return .expired
+        
+        case 3: return .notYetValid
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: MdocValidityStatus, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .valid:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .expired:
+            writeInt(&buf, Int32(2))
+        
+        
+        case .notYetValid:
+            writeInt(&buf, Int32(3))
+        
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeMdocValidityStatus_lift(_ buf: RustBuffer) throws -> MdocValidityStatus {
+    return try FfiConverterTypeMdocValidityStatus.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeMdocValidityStatus_lower(_ value: MdocValidityStatus) -> RustBuffer {
+    return FfiConverterTypeMdocValidityStatus.lower(value)
+}
+
+
 
 public enum Oid4vp180137Error: Swift.Error, Equatable, Hashable, Foundation.LocalizedError {
 
@@ -36732,7 +36877,13 @@ private let initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_method_mdoc_invalidation_date() != 52225) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_mobile_sdk_rs_checksum_method_mdoc_is_currently_valid() != 36629) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_mobile_sdk_rs_checksum_method_mdoc_key_alias() != 45386) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mobile_sdk_rs_checksum_method_mdoc_validity_status() != 15025) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_opticalbarcodecred_id() != 57284) {
@@ -37315,6 +37466,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_requestmatch180137_requested_fields() != 4609) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mobile_sdk_rs_checksum_method_requestmatch180137_validity_status() != 48497) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_permissionrequest_client_id() != 38125) {

--- a/rust/src/credential/format/mdoc.rs
+++ b/rust/src/credential/format/mdoc.rs
@@ -50,6 +50,22 @@ pub struct Element {
     pub value: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+/// The validity of an mdoc relative to the current time, derived from the MSO
+/// `validityInfo` (`validFrom`/`validUntil`).
+///
+/// This is informational metadata for display purposes. Validity enforcement is
+/// a verifier responsibility per ISO/IEC 18013-5; a holder may still present an
+/// expired or not-yet-valid credential and let the verifier decide.
+pub enum MdocValidityStatus {
+    /// The current time is within `[validFrom, validUntil]`.
+    Valid,
+    /// `validUntil` is in the past.
+    Expired,
+    /// `validFrom` is in the future.
+    NotYetValid,
+}
+
 #[derive(uniffi::Object, Debug, Clone)]
 pub struct Mdoc {
     inner: Document,
@@ -190,6 +206,26 @@ impl Mdoc {
             .valid_until
             .format(&Iso8601::DEFAULT)
             .map_err(|e| MdocDateError::Formatting(format!("{e:?}")))
+    }
+
+    /// The validity of this mdoc relative to the current time, derived from the
+    /// MSO `validityInfo`. Intended for display; the verifier remains
+    /// responsible for enforcing validity at presentation time.
+    pub fn validity_status(&self) -> MdocValidityStatus {
+        let now = time::OffsetDateTime::now_utc();
+        let validity_info = &self.inner.mso.validity_info;
+        if now < validity_info.valid_from {
+            MdocValidityStatus::NotYetValid
+        } else if now > validity_info.valid_until {
+            MdocValidityStatus::Expired
+        } else {
+            MdocValidityStatus::Valid
+        }
+    }
+
+    /// Whether this mdoc is currently within its validity window.
+    pub fn is_currently_valid(&self) -> bool {
+        matches!(self.validity_status(), MdocValidityStatus::Valid)
     }
 
     pub async fn activity_log(
@@ -605,6 +641,29 @@ mod tests {
         .expect("failed to create mdoc");
 
         println!("Mdoc: {mdoc:?}")
+    }
+
+    #[test]
+    fn test_validity_status_is_consistent_with_is_currently_valid() {
+        let decoded_auth_data = BASE64_STANDARD
+            .decode(B64_AUTH_DATA)
+            .expect("failed to decode b64 auth data");
+
+        let decoded_provisioned_data = BASE64_STANDARD
+            .decode(B64_PROVISIONED_DATA)
+            .expect("failed to decode b64 provisioned data");
+
+        let mdoc = Mdoc::new_from_cbor_encoded_issuer_signed_dehydrated(
+            decoded_auth_data,
+            decoded_provisioned_data,
+            KeyAlias("default".into()),
+        )
+        .expect("failed to create mdoc");
+
+        assert_eq!(
+            mdoc.is_currently_valid(),
+            mdoc.validity_status() == super::MdocValidityStatus::Valid
+        );
     }
 
     /// Test that mdoc element values are preserved through storage roundtrip.

--- a/rust/src/credential/format/mdoc.rs
+++ b/rust/src/credential/format/mdoc.rs
@@ -53,10 +53,6 @@ pub struct Element {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
 /// The validity of an mdoc relative to the current time, derived from the MSO
 /// `validityInfo` (`validFrom`/`validUntil`).
-///
-/// This is informational metadata for display purposes. Validity enforcement is
-/// a verifier responsibility per ISO/IEC 18013-5; a holder may still present an
-/// expired or not-yet-valid credential and let the verifier decide.
 pub enum MdocValidityStatus {
     /// The current time is within `[validFrom, validUntil]`.
     Valid,
@@ -208,9 +204,7 @@ impl Mdoc {
             .map_err(|e| MdocDateError::Formatting(format!("{e:?}")))
     }
 
-    /// The validity of this mdoc relative to the current time, derived from the
-    /// MSO `validityInfo`. Intended for display; the verifier remains
-    /// responsible for enforcing validity at presentation time.
+    /// The validity of this mdoc relative to the current time, derived from `validityInfo`.
     pub fn validity_status(&self) -> MdocValidityStatus {
         let now = time::OffsetDateTime::now_utc();
         let validity_info = &self.inner.mso.validity_info;
@@ -221,11 +215,6 @@ impl Mdoc {
         } else {
             MdocValidityStatus::Valid
         }
-    }
-
-    /// Whether this mdoc is currently within its validity window.
-    pub fn is_currently_valid(&self) -> bool {
-        matches!(self.validity_status(), MdocValidityStatus::Valid)
     }
 
     pub async fn activity_log(
@@ -641,29 +630,6 @@ mod tests {
         .expect("failed to create mdoc");
 
         println!("Mdoc: {mdoc:?}")
-    }
-
-    #[test]
-    fn test_validity_status_is_consistent_with_is_currently_valid() {
-        let decoded_auth_data = BASE64_STANDARD
-            .decode(B64_AUTH_DATA)
-            .expect("failed to decode b64 auth data");
-
-        let decoded_provisioned_data = BASE64_STANDARD
-            .decode(B64_PROVISIONED_DATA)
-            .expect("failed to decode b64 provisioned data");
-
-        let mdoc = Mdoc::new_from_cbor_encoded_issuer_signed_dehydrated(
-            decoded_auth_data,
-            decoded_provisioned_data,
-            KeyAlias("default".into()),
-        )
-        .expect("failed to create mdoc");
-
-        assert_eq!(
-            mdoc.is_currently_valid(),
-            mdoc.validity_status() == super::MdocValidityStatus::Valid
-        );
     }
 
     /// Test that mdoc element values are preserved through storage roundtrip.

--- a/rust/src/oid4vp/dc_api/ios.rs
+++ b/rust/src/oid4vp/dc_api/ios.rs
@@ -164,6 +164,7 @@ impl IOSISO18013MobileDocumentRequest {
                                     field_map,
                                     requested_fields,
                                     missing_fields,
+                                    validity_status: mdoc.validity_status(),
                                 }));
                             }
                         }

--- a/rust/src/oid4vp/dc_api/requested_values.rs
+++ b/rust/src/oid4vp/dc_api/requested_values.rs
@@ -145,5 +145,6 @@ pub fn find_match(query: &DcqlCredentialQuery, credential: &Mdoc) -> Result<Requ
         field_map,
         requested_fields,
         missing_fields,
+        validity_status: credential.validity_status(),
     })
 }

--- a/rust/src/oid4vp/iso_18013_7/facade.rs
+++ b/rust/src/oid4vp/iso_18013_7/facade.rs
@@ -1147,6 +1147,7 @@ fn find_presentation_definition_match(
         field_map,
         requested_fields: requested_fields.into_values().collect(),
         missing_fields: Default::default(),
+        validity_status: credential.validity_status(),
     })
 }
 

--- a/rust/src/oid4vp/iso_18013_7/requested_values.rs
+++ b/rust/src/oid4vp/iso_18013_7/requested_values.rs
@@ -19,7 +19,6 @@ pub struct RequestMatch180137 {
     pub field_map: FieldMap,
     pub requested_fields: Vec<RequestedField180137>,
     pub missing_fields: BTreeMap<String, String>,
-    /// Does not affect matching.
     pub validity_status: MdocValidityStatus,
 }
 

--- a/rust/src/oid4vp/iso_18013_7/requested_values.rs
+++ b/rust/src/oid4vp/iso_18013_7/requested_values.rs
@@ -10,7 +10,7 @@ use openid4vp::core::dcql_query::{DcqlCredentialClaimsQueryPath, DcqlCredentialQ
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::credential::mdoc::Mdoc;
+use crate::credential::mdoc::{Mdoc, MdocValidityStatus};
 
 #[derive(Debug, Clone, uniffi::Object)]
 /// A viable match for the credential request.
@@ -19,6 +19,8 @@ pub struct RequestMatch180137 {
     pub field_map: FieldMap,
     pub requested_fields: Vec<RequestedField180137>,
     pub missing_fields: BTreeMap<String, String>,
+    /// Does not affect matching.
+    pub validity_status: MdocValidityStatus,
 }
 
 uniffi::custom_newtype!(FieldId180137, String);
@@ -47,6 +49,10 @@ impl RequestMatch180137 {
 
     pub fn requested_fields(&self) -> Vec<RequestedField180137> {
         self.requested_fields.clone()
+    }
+
+    pub fn validity_status(&self) -> MdocValidityStatus {
+        self.validity_status
     }
 }
 
@@ -218,6 +224,7 @@ pub fn find_match(
         field_map,
         requested_fields,
         missing_fields,
+        validity_status: credential.validity_status(),
     })
 }
 


### PR DESCRIPTION
Allow control of iOS's `invalidationDate` for DC-API, so the matcher doesn't filter expired credentials

All behavior changes should be opt-in