### PR TITLE
Continuously observes network reachability and keeps `hasConnection` up to date.

### DIFF
--- a/ios/Showcase/Targets/AppUIKit/Sources/Utils.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/Utils.swift
@@ -3,7 +3,6 @@ import SpruceIDMobileSdk
 import SpruceIDMobileSdkRs
 import Foundation
 import SwiftUI
-import Network
 
 // modifier
 struct HideViewModifier: ViewModifier {
@@ -88,25 +87,6 @@ func generateQRCode(from data: Data) -> UIImage {
         }
     }
     return UIImage(systemName: "xmark.circle") ?? UIImage()
-}
-
-func checkInternetConnection() -> Bool {
-    let monitor = NWPathMonitor()
-    let queue = DispatchQueue.global(qos: .background)
-    var isConnected = false
-
-    let semaphore = DispatchSemaphore(value: 0)
-
-    monitor.pathUpdateHandler = { path in
-        isConnected = (path.status == .satisfied)
-        semaphore.signal()
-        monitor.cancel()
-    }
-
-    monitor.start(queue: queue)
-    semaphore.wait()
-
-    return isConnected
 }
 
 func generateTxtFile(content: String, filename: String) -> URL? {

--- a/ios/Showcase/Targets/AppUIKit/Sources/dataStores/StatusListObservable.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/dataStores/StatusListObservable.swift
@@ -1,9 +1,14 @@
 import Foundation
+import Network
 import SpruceIDMobileSdk
 
 class StatusListObservable: ObservableObject {
     @Published var statusLists: [String: CredentialStatusList]
-    @Published var hasConnection: Bool
+    @Published private(set) var hasConnection: Bool
+
+    private let connectionMonitor = NWPathMonitor()
+    private let connectionMonitorQueue = DispatchQueue(
+        label: "com.spruceid.showcase.StatusListObservable.connectionMonitor")
 
     init(
         statusLists: [String: CredentialStatusList] = [:],
@@ -11,6 +16,21 @@ class StatusListObservable: ObservableObject {
     ) {
         self.statusLists = statusLists
         self.hasConnection = hasConnection
+        startMonitoringConnection()
+    }
+
+    deinit {
+        connectionMonitor.cancel()
+    }
+
+    private func startMonitoringConnection() {
+        connectionMonitor.pathUpdateHandler = { [weak self] path in
+            let isConnected = path.status == .satisfied
+            Task { @MainActor [weak self] in
+                self?.hasConnection = isConnected
+            }
+        }
+        connectionMonitor.start(queue: connectionMonitorQueue)
     }
 
     @MainActor func fetchAndUpdateStatus(credentialPack: CredentialPack) async

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/WalletHomeView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/WalletHomeView.swift
@@ -158,8 +158,6 @@ struct WalletHomeBody: View {
                         }
                     }
                     .refreshable {
-                        statusListObservable.hasConnection =
-                            checkInternetConnection()
                         await loadCredentials()
                         await hacApplicationObservable.updateAllIssuanceStates()
                     }
@@ -170,8 +168,6 @@ struct WalletHomeBody: View {
                     onButtonClick: {
                         Task {
                             await generateMockMdl()
-                            statusListObservable.hasConnection =
-                                checkInternetConnection()
                             await loadCredentials()
                         }
                     }
@@ -181,7 +177,6 @@ struct WalletHomeBody: View {
         .animation(.easeInOut(duration: 0.3), value: loading)
         .onAppear(perform: {
             Task {
-                statusListObservable.hasConnection = checkInternetConnection()
                 await loadCredentials()
                 do {
                     try await credentialPackObservable.registerUnregisteredIDProviderDocuments()


### PR DESCRIPTION
## Description

This PR replaces the blocking, on-demand internet connectivity check on the iOS Showcase with a continuous network reachability observer.

Previously, checkInternetConnection() (in Utils.swift) spun up a new `NWPathMonitor` on every call and used a `DispatchSemaphore` to block the calling thread until the first path update arrived, then synchronously returned the result. This had to be invoked manually at every point where connectivity mattered (onAppear, pull-to-refresh, and after generating a mock mDL), and the blocking semaphore wait risked stalling whatever thread it was called from.

The updated behavior moves connectivity tracking into `StatusListObservable`. A single long-lived `NWPathMonitor` runs on a dedicated background queue and updates the published `hasConnection` property whenever the network path changes, hopping to the main actor for the assignment so SwiftUI observers update safely. The monitor is started in init and cancelled in deinit. As a result, `hasConnection` now stays continuously up to date on its own, and all the manual checkInternetConnection() call sites in WalletHomeView are removed.

This removes the semaphore-based blocking pattern entirely and ensures connectivity state reflects real-time changes rather than a one-shot snapshot taken at specific UI events.

### Other changes

- Made hasConnection private(set) since it is now owned and updated exclusively by StatusListObservable rather than mutated externally from the views.
- Deleted the now-unused checkInternetConnection() helper and dropped the import Network from Utils.swift, adding it to StatusListObservable.swift where it is now needed.

## Tested

1. Launched the app and confirmed connectivity-dependent UI reflects the current network state on the wallet home screen.
2. Toggled the device/simulator network on and off (e.g. via Airplane Mode) and verified hasConnection updates automatically without needing to pull-to-refresh or re-enter the screen.
3. Exercised pull-to-refresh, mock mDL generation, and initial screen load to confirm behavior is unchanged now that the explicit connectivity checks have been removed.