### PR TITLE
VCALM scope holder matching to provided credentials

### DIFF
--- a/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/VcalmAdapter.kt
+++ b/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/VcalmAdapter.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.util.Log
 import com.spruceid.mobile.sdk.KeyManager
 import com.spruceid.mobile.sdk.RustLogger
-import com.spruceid.mobile.sdk.StorageManager
 import com.spruceid.mobile.sdk.rs.CryptosuiteEntry
 import com.spruceid.mobile.sdk.rs.DidMethod
 import com.spruceid.mobile.sdk.rs.DidMethodUtils
@@ -12,6 +11,7 @@ import com.spruceid.mobile.sdk.rs.OfferedValidity
 import com.spruceid.mobile.sdk.rs.ParsedCredential
 import com.spruceid.mobile.sdk.rs.PresentationSigner
 import com.spruceid.mobile.sdk.rs.StepResult
+import com.spruceid.mobile.sdk.rs.StorageManagerInterface
 import com.spruceid.mobile.sdk.rs.VcalmException
 import com.spruceid.mobile.sdk.rs.VcalmHolder
 import com.spruceid.mobile.sdk.rs.VcalmOfferedCredential
@@ -20,7 +20,21 @@ import com.spruceid.mobile.sdk.rs.Vpr
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
 import org.json.JSONObject
+
+/**
+ * In-memory [StorageManagerInterface]. Keeps the VCALM holder's base
+ * [VdcCollection] empty so matching is driven only by `provideCredentials` — the
+ * app-wide on-disk store leaked other users' credentials across logout.
+ */
+internal class InMemoryVdcStorage : StorageManagerInterface {
+    private val store = ConcurrentHashMap<String, ByteArray>()
+    override suspend fun add(key: String, value: ByteArray) { store[key] = value }
+    override suspend fun get(key: String): ByteArray? = store[key]
+    override suspend fun list(): List<String> = store.keys.toList()
+    override suspend fun remove(key: String) { store.remove(key) }
+}
 
 /**
  * Signer for VCALM presentation.
@@ -119,12 +133,9 @@ internal class VcalmAdapter(
             "packIds=${credentialPackIds.size}")
         CoroutineScope(Dispatchers.IO).launch {
             try {
-                // The holder's own VdcCollection receives issuance (acceptOffer)
-                // credentials. To ALSO make the host app's existing wallet
-                // credentials presentable via QBE matching, load the passed packs
-                // into native ParsedCredential handles and seed the holder via
-                // provideCredentials.
-                val vdc = VdcCollection(StorageManager(context))
+                // Isolated (in-memory), NOT the shared on-disk store: matching is
+                // seeded only by the wallet packs provided below. See InMemoryVdcStorage.
+                val vdc = VdcCollection(InMemoryVdcStorage())
                 val signer = VcalmSigner(keyId)
                 Log.d(TAG, "createHolder: signer did=${signer.did()}")
 

--- a/flutter/ios/Classes/VcalmAdapter.swift
+++ b/flutter/ios/Classes/VcalmAdapter.swift
@@ -2,6 +2,34 @@ import Foundation
 import SpruceIDMobileSdk
 import SpruceIDMobileSdkRs
 
+/// In-memory `StorageManagerInterface`. Keeps the VCALM holder's base
+/// `VdcCollection` empty so matching is driven only by `provideCredentials` — the
+/// app-wide on-disk store leaked other users' credentials across logout.
+final class InMemoryVdcStorage: StorageManagerInterface, @unchecked Sendable {
+    private let lock = NSLock()
+    private var store: [String: Data] = [:]
+
+    func add(key: String, value: Data) async throws {
+        lock.lock(); defer { lock.unlock() }
+        store[key] = value
+    }
+
+    func get(key: String) async throws -> Data? {
+        lock.lock(); defer { lock.unlock() }
+        return store[key]
+    }
+
+    func list() async throws -> [String] {
+        lock.lock(); defer { lock.unlock() }
+        return Array(store.keys)
+    }
+
+    func remove(key: String) async throws {
+        lock.lock(); defer { lock.unlock() }
+        store.removeValue(forKey: key)
+    }
+}
+
 /// Error types for the VCALM signer.
 enum VcalmSignerError: Error {
     case illegalArgumentException(reason: String)
@@ -109,12 +137,9 @@ class VcalmAdapter: Vcalm {
         log("createHolder: keyId=\(keyId), trustedDids=\(trustedDids.count), packIds=\(credentialPackIds.count)")
         Task {
             do {
-                // The holder's own VdcCollection receives issuance (`acceptOffer`)
-                // credentials. To ALSO make the host app's existing wallet
-                // credentials presentable via QBE matching, load the passed packs
-                // into native ParsedCredential handles and seed the holder via
-                // provideCredentials.
-                let vdc = VdcCollection(engine: StorageManager(appGroupId: nil))
+                // Isolated (in-memory), NOT the shared on-disk store: matching is
+                // seeded only by the wallet packs provided below. See InMemoryVdcStorage.
+                let vdc = VdcCollection(engine: InMemoryVdcStorage())
                 let signer = try VcalmSigner(keyId: keyId)
 
                 let newHolder = try await VcalmHolder.newSession(


### PR DESCRIPTION
## Description

The VCALM holder was seeded from `StorageManager(appGroupId:)` (the app-wide, non-namespaced on-disk store) so its matcher could match any credential ever stored, regardless of the active user/namespace. A logged-out presentation surfaced a previously logged-in user's credentials (shown without claims).

This constructs the holder's base `VdcCollection` over a new in-memory `StorageManagerInterface` (iOS + Android). Matching is now driven solely by the wallet packs passed via `provideCredentials`, matching the OID4VP holder's behavior. 

### Other changes

N/A

### Optional section

N/A

## Tested

N/A