### PR TITLE
iOS holder: NFC static-handover presentation (CAMV-975)

### DIFF
--- a/flutter/ios/Classes/MdlPresentationAdapter.swift
+++ b/flutter/ios/Classes/MdlPresentationAdapter.swift
@@ -161,6 +161,10 @@ private class PresentationDelegate: MdocProximityPresentationManager.Delegate {
                 ))
             }
 
+        case .connectingViaNfc:
+            // Unreachable via the plugin's pigeon today; map to the nearest existing state for now.
+            adapter?.updateState(MdlPresentationStateUpdate(state: .initializing))
+
         case .connected:
             adapter?.updateState(MdlPresentationStateUpdate(state: .connected))
 

--- a/ios/MobileSdk/Sources/MobileSdk/mdoc/proximity/PresentationManager.swift
+++ b/ios/MobileSdk/Sources/MobileSdk/mdoc/proximity/PresentationManager.swift
@@ -61,11 +61,16 @@ public class MdocProximityPresentationManager {
         case let .NFC(carrier):
             // NFC static handover is BLE central-client-mode only, on the UUID fixed by the handover.
             var l2capUsage: L2CAPUsage = .disableL2CAP
+            var hasCentralMode = false
             for mode in transmissionModes {
                 if case let .bleMdocCentralMode(usage) = mode {
                     l2capUsage = usage
+                    hasCentralMode = true
                     break
                 }
+            }
+            if !hasCentralMode {
+                print("NFC engagement forces BLE mdoc central client mode; ignoring the provided transmission modes")
             }
             central = CentralManager(mdoc: handle, serviceUuid: carrier.getUuid(), l2capUsage)
         }

--- a/ios/MobileSdk/Sources/MobileSdk/mdoc/proximity/PresentationManager.swift
+++ b/ios/MobileSdk/Sources/MobileSdk/mdoc/proximity/PresentationManager.swift
@@ -38,23 +38,36 @@ public class MdocProximityPresentationManager {
 
         var central: CentralManager?
         var peripheral: PeripheralManager?
-        let handle = DelegateWrapper(delegate: delegate, mdoc: mdoc)
+        let handle = DelegateWrapper(delegate: delegate, mdoc: mdoc, engagement: engagement)
 
-        for mode in transmissionModes {
-            switch mode {
-            case let .bleMdocCentralMode(l2capUsage):
-                if central != nil {
-                    print("multiple .bleMdocCentralMode instances provided, ignoring all but the first")
-                    break
+        switch engagement {
+        case .QRCode:
+            for mode in transmissionModes {
+                switch mode {
+                case let .bleMdocCentralMode(l2capUsage):
+                    if central != nil {
+                        print("multiple .bleMdocCentralMode instances provided, ignoring all but the first")
+                        break
+                    }
+                    central = CentralManager(mdoc: handle, l2capUsage)
+                case let .bleMdocPeripheralMode(l2capUsage):
+                    if peripheral != nil {
+                        print("multiple .bleMdocPeripheralMode instances provided, ignoring all but the first")
+                        break
+                    }
+                    peripheral = PeripheralManager(mdoc: handle, l2capUsage)
                 }
-                central = CentralManager(mdoc: handle, l2capUsage)
-            case let .bleMdocPeripheralMode(l2capUsage):
-                if peripheral != nil {
-                    print("multiple .bleMdocPeripheralMode instances provided, ignoring all but the first")
-                    break
-                }
-                peripheral = PeripheralManager(mdoc: handle, l2capUsage)
             }
+        case let .NFC(carrier):
+            // NFC static handover is BLE central-client-mode only, on the UUID fixed by the handover.
+            var l2capUsage: L2CAPUsage = .disableL2CAP
+            for mode in transmissionModes {
+                if case let .bleMdocCentralMode(usage) = mode {
+                    l2capUsage = usage
+                    break
+                }
+            }
+            central = CentralManager(mdoc: handle, serviceUuid: carrier.getUuid(), l2capUsage)
         }
 
         handle.set(bleCentral: central)
@@ -80,6 +93,7 @@ public class MdocProximityPresentationManager {
     class DelegateWrapper: NSObject & TransportCallback {
         private let inner: Delegate
         private let mdoc: Mdoc
+        private let engagement: DeviceEngagement
 
         private let backgroundQueue = DispatchQueue(
             label: "com.spruceid.mobilesdk.mdoc.proximity.presentationmanager",
@@ -94,19 +108,24 @@ public class MdocProximityPresentationManager {
                 case .initializing:
                     state = .initializing
                 case let .connecting(connecting):
-                    do {
-                        guard let data = try connecting.session.getQrHandover().data(using: .ascii) else {
-                            print("failed to parse QR code")
+                    switch engagement {
+                    case .QRCode:
+                        do {
+                            guard let data = try connecting.session.getQrHandover().data(using: .ascii) else {
+                                print("failed to parse QR code")
+                                self.state = .error
+                                return
+                            }
+                            state = .connecting(qrPayload: data)
+                        } catch {
+                            // Should be unreachable - get_qr_handover() only returns Err if the session mutex
+                            // is poisoned, which should never be able to happen.
+                            print("failed to obtain QR code")
                             self.state = .error
                             return
                         }
-                        state = .connecting(qrPayload: data)
-                    } catch {
-                        // Should be unreachable - get_qr_handover() only returns Err if the session mutex
-                        // is poisoned, which should never be able to happen.
-                        print("failed to obtain QR code")
-                        self.state = .error
-                        return
+                    case .NFC:
+                        state = .connectingViaNfc
                     }
                 case .connected:
                     state = .connected
@@ -123,9 +142,10 @@ public class MdocProximityPresentationManager {
             }
         }
 
-        init(delegate: Delegate, mdoc: Mdoc) {
+        init(delegate: Delegate, mdoc: Mdoc, engagement: DeviceEngagement) {
             inner = delegate
             self.mdoc = mdoc
+            self.engagement = engagement
             backgroundQueue.suspend()
         }
 
@@ -244,13 +264,24 @@ public class MdocProximityPresentationManager {
         }
 
         private func setupSession(_ initializing: Initializing) {
+            let engagementData: DeviceEngagementData
+            let peripheralServerMode: PeripheralServerDetails?
+            switch engagement {
+            case .QRCode:
+                engagementData = .qr
+                peripheralServerMode = initializing.peripheralDetails
+            case let .NFC(carrier):
+                engagementData = .nfc(carrier)
+                peripheralServerMode = nil
+            }
+
             let session: MdlPresentationSession
             do {
                 session = try initializeMdlPresentationFromBytes(
                     mdoc: mdoc,
                     centralClientMode: initializing.centralDetails,
-                    peripheralServerMode: initializing.peripheralDetails,
-                    engagement: .qr,
+                    peripheralServerMode: peripheralServerMode,
+                    engagement: engagementData,
                 )
             } catch {
                 print("unexpected error preparing the session: \(error.localizedDescription)")
@@ -367,6 +398,8 @@ public class MdocProximityPresentationManager {
         case action(required: RequiredAction)
         /// Attempting to establish a connection with the reader.
         case connecting(qrPayload: Data)
+        /// Awaiting the reader; engagement was delivered over NFC, so there's no QR payload.
+        case connectingViaNfc
         /// The reader has connected.
         case connected
         /// Receiving a request from the reader.
@@ -496,5 +529,8 @@ public class MdocProximityPresentationManager {
     public enum DeviceEngagement {
         /// Engage using a QR code.
         case QRCode
+        /// Engage using NFC static handover (ISO 18013-5). The carrier (BLE UUID + ephemeral keys) comes
+        /// from an `ApduHandoverDriver` driven by the platform NFC/SE layer; BLE is central-client-mode only.
+        case NFC(NegotiatedCarrierInfo)
     }
 }

--- a/ios/MobileSdk/Sources/MobileSdk/mdoc/proximity/ble/CentralManager.swift
+++ b/ios/MobileSdk/Sources/MobileSdk/mdoc/proximity/ble/CentralManager.swift
@@ -82,6 +82,15 @@ class CentralManager: NSObject & Transport {
         self.init(delegate: .mdoc(mdoc), UUID(), l2capUsage)
     }
 
+    /// Setup the central client for the mdoc on a pre-negotiated service UUID (e.g. fixed by an NFC static handover).
+    convenience init(
+        mdoc: MdocProximityPresentationManager.DelegateWrapper,
+        serviceUuid: String,
+        _ l2capUsage: L2CAPUsage,
+    ) {
+        self.init(delegate: .mdoc(mdoc), UUID(uuidString: serviceUuid), l2capUsage)
+    }
+
     enum State {
         case initializing
         /// Scanning for the peripheral.

--- a/ios/Showcase/Targets/AppUIKit/Sources/credentials/CredentialDetailsView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/credentials/CredentialDetailsView.swift
@@ -105,7 +105,10 @@ struct CredentialDetailsView: View {
                         } else if index == 2, let mdoc = mdoc() {  // Share
                             ShareMdocView(mdoc: mdoc)
                                 .tag(index)
-                        } else if index == 3 {  // Share PDF
+                        } else if index == 3, let mdoc = mdoc() {  // Share NFC
+                            NfcHolderSelfTestView(mdoc: mdoc)
+                                .tag(index)
+                        } else if index == 4 {  // Share PDF
                             SharePdfView(credentialPack: credentialPack)
                                 .tag(index)
                         }
@@ -159,6 +162,9 @@ struct CredentialDetailsView: View {
             if credentialPackHasMdoc(credentialPack: credentialPack!) {
                 credentialDetailsViewTabs.append(
                     CredentialDetailsViewTab(image: "QRCode")
+                )
+                credentialDetailsViewTabs.append(
+                    CredentialDetailsViewTab(image: "Wallet")
                 )
                 credentialDetailsViewTabs.append(
                     CredentialDetailsViewTab(image: "Export")

--- a/ios/Showcase/Targets/AppUIKit/Sources/credentials/NfcHolderSelfTestView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/credentials/NfcHolderSelfTestView.swift
@@ -1,0 +1,292 @@
+import CoreBluetooth
+import SpruceIDMobileSdk
+import SpruceIDMobileSdkRs
+import SwiftUI
+
+/// Single-device wiring self-test for NFC static-handover holder presentation.
+///
+/// Replaces the NFC radio with an in-memory APDU loopback (holder `ApduHandoverDriver` ↔
+/// reader `ReaderApduHandoverDriver`), then brings up both BLE roles on one device. A phone
+/// can't BLE-connect to itself, so this verifies wiring only — no full exchange, no entitlement.
+public struct NfcHolderSelfTestView: View {
+    @StateObject private var runner: NfcHolderSelfTestRunner
+
+    public init(mdoc: Mdoc) {
+        _runner = StateObject(wrappedValue: NfcHolderSelfTestRunner(mdoc: mdoc))
+    }
+
+    public var body: some View {
+        VStack(spacing: 16) {
+            Text("NFC Holder Self-Test")
+                .font(.headline)
+            Text("Single-device wiring check — no entitlement needed: a software loopback stands in for the NFC tap, then confirms the holder engages from the handover and brings up its BLE session. It doesn't run the real data exchange (one phone can't BLE-connect to itself), and a real over-the-air NFC tap additionally needs the Apple SE entitlement (pending).")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            HStack(alignment: .top, spacing: 24) {
+                stateColumn(title: "Holder", value: runner.holderState)
+                stateColumn(title: "Reader", value: runner.readerState)
+            }
+
+            if let outcome = runner.outcome {
+                Text(outcome)
+                    .font(.subheadline.bold())
+                    .foregroundStyle(runner.succeeded ? .green : .red)
+                    .multilineTextAlignment(.center)
+            }
+
+            ScrollView {
+                Text(runner.log)
+                    .font(.system(.caption2, design: .monospaced))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+            }
+            .frame(maxHeight: 240)
+            .padding(8)
+            .background(Color(.secondarySystemBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+
+            Button(runner.isRunning ? "Running…" : "Run self-test") {
+                runner.run()
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(runner.isRunning)
+        }
+        .padding()
+        .onDisappear { runner.stop() }
+    }
+
+    private func stateColumn(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title).font(.subheadline.bold())
+            Text(value).font(.system(.caption, design: .monospaced))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+final class NfcHolderSelfTestRunner: ObservableObject {
+    @Published var holderState = "—"
+    @Published var readerState = "—"
+    @Published var log = ""
+    @Published var outcome: String?
+    @Published var isRunning = false
+    @Published var succeeded = false
+
+    private let mdoc: Mdoc
+    private var holder: MdocProximityPresentationManager?
+    private var reader: MdocProximityReader?
+    private var holderDelegate: HolderDelegate?
+    private var readerDelegate: ReaderDelegate?
+    private var finished = false
+    private var holderEngaged = false
+    private var readerAdvertising = false
+
+    init(mdoc: Mdoc) {
+        self.mdoc = mdoc
+    }
+
+    func run() {
+        guard !isRunning else { return }
+        isRunning = true
+        finished = false
+        succeeded = false
+        outcome = nil
+        log = ""
+        holderState = "starting"
+        readerState = "starting"
+
+        do {
+            append("Running APDU handover loopback (no NFC radio)…")
+            let (readerHandover, carrier) = try Self.loopbackHandover()
+            append("Handover negotiated — BLE UUID \(carrier.getUuid())")
+
+            let holderDelegate = HolderDelegate(runner: self)
+            self.holderDelegate = holderDelegate
+            holder = MdocProximityPresentationManager(
+                mdoc: mdoc,
+                delegate: holderDelegate,
+                engagement: .NFC(carrier)
+            )
+
+            let readerDelegate = ReaderDelegate(runner: self)
+            self.readerDelegate = readerDelegate
+            reader = MdocProximityReader(
+                fromHandover: readerHandover,
+                delegate: readerDelegate,
+                requestedItems: ["org.iso.18013.5.1": ["given_name": false, "family_name": false]],
+                trustAnchorRegistry: TrustedCertificatesDataStore.shared.getAllCertificates().map { $0.content },
+                l2capUsage: .disableL2CAP
+            )
+            append("Holder scanning + reader advertising over BLE…")
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 15) { [weak self] in
+                self?.fail("Holder/reader did not reach ready states in time — check Bluetooth permission")
+            }
+        } catch {
+            fail("Loopback failed: \(error)")
+        }
+    }
+
+    func stop() {
+        holder?.disconnect()
+        reader?.disconnect()
+        holder = nil
+        reader = nil
+        holderDelegate = nil
+        readerDelegate = nil
+    }
+
+    /// Drive the reader↔holder APDU drivers in memory (standing in for the NFC radio).
+    static func loopbackHandover() throws -> (ReaderHandover, NegotiatedCarrierInfo) {
+        let holderDriver = try ApduHandoverDriver(negotiated: false, strict: false)
+        try holderDriver.regenerateStaticBleKeys()
+        let readerInit = newReaderApduHandoverDriver()
+        var command = readerInit.initialApdu
+        for _ in 0..<64 {
+            let response = holderDriver.processApdu(command: command)
+            switch try readerInit.driver.processRapdu(command: response) {
+            case .inProgress(let next):
+                command = next
+            case .done(let handover):
+                guard let carrier = holderDriver.getCarrierInfo() else {
+                    throw SelfTestError.noCarrierInfo
+                }
+                return (handover, carrier)
+            }
+        }
+        throw SelfTestError.handoverDidNotComplete
+    }
+
+    fileprivate func holderStateChanged(_ state: MdocProximityPresentationManager.State) {
+        holderState = Self.describe(holder: state)
+        append("holder → \(holderState)")
+        switch state {
+        case .connectingViaNfc:
+            holderEngaged = true
+            checkWiring()
+        case let .receivedRequest(request):
+            // Only reached if a reader actually connected (two-device run): auto-approve.
+            let items = Self.approveAll(request)
+            append("holder auto-approving: \(items)")
+            request.approve(items: items)
+        case .sentResponse:
+            succeed("Full session completed — holder presented the credential over BLE")
+        case .error, .readerDisconnected:
+            fail("Holder ended in \(holderState)")
+        default:
+            break
+        }
+    }
+
+    fileprivate func readerStateChanged(_ state: MdocProximityReader.State) {
+        readerState = Self.describe(reader: state)
+        append("reader → \(readerState)")
+        switch state {
+        case .connecting:
+            readerAdvertising = true
+            checkWiring()
+        case .receivedResponse:
+            succeed("Full session completed — reader received & verified the response over BLE")
+        case .error, .mdocDisconnected:
+            fail("Reader ended in \(readerState)")
+        default:
+            break
+        }
+    }
+
+    /// Single phone can't BLE-connect to itself → success = both sides reached their ready states (wiring OK).
+    private func checkWiring() {
+        guard holderEngaged, readerAdvertising, !finished else { return }
+        succeed("Wiring verified — holder engaged from the NFC handover (BLE central up); reader accepted the handover (advertising).")
+    }
+
+    private func succeed(_ message: String) {
+        guard !finished else { return }
+        finished = true
+        isRunning = false
+        succeeded = true
+        outcome = "✅ \(message)"
+        append("✅ \(message)")
+        stop()
+    }
+
+    private func fail(_ message: String) {
+        guard !finished else { return }
+        finished = true
+        isRunning = false
+        succeeded = false
+        outcome = "❌ \(message)"
+        append("❌ \(message)")
+        stop()
+    }
+
+    private func append(_ line: String) {
+        log += (log.isEmpty ? "" : "\n") + line
+    }
+
+    private static func approveAll(
+        _ request: MdocProximityPresentationManager.Request
+    ) -> [String: [String: [String]]] {
+        var approved: [String: [String: [String]]] = [:]
+        for itemRequest in request.items {
+            var namespaces: [String: [String]] = [:]
+            for (namespace, items) in itemRequest.namespaces {
+                namespaces[namespace] = Array(items.keys)
+            }
+            approved[itemRequest.docType] = namespaces
+        }
+        return approved
+    }
+
+    private static func describe(holder state: MdocProximityPresentationManager.State) -> String {
+        switch state {
+        case .initializing: return "initializing"
+        case .action(let required): return "action(\(required))"
+        case .connecting: return "connecting(qr)"
+        case .connectingViaNfc: return "connectingViaNfc"
+        case .connected: return "connected"
+        case .receivingRequest: return "receivingRequest"
+        case .receivedRequest: return "receivedRequest"
+        case .sendingResponse: return "sendingResponse"
+        case .sentResponse: return "sentResponse"
+        case .requestDismissed: return "requestDismissed"
+        case .readerDisconnected: return "readerDisconnected"
+        case .error: return "error"
+        }
+    }
+
+    private static func describe(reader state: MdocProximityReader.State) -> String {
+        switch state {
+        case .initializing: return "initializing"
+        case .connecting: return "connecting"
+        case .connected: return "connected"
+        case .sendingRequest: return "sendingRequest"
+        case .sentRequest: return "sentRequest"
+        case .receivingResponse: return "receivingResponse"
+        case .receivedResponse: return "receivedResponse"
+        case .mdocDisconnected: return "mdocDisconnected"
+        case .error: return "error"
+        case .action(let required): return "action(\(required))"
+        }
+    }
+
+    enum SelfTestError: Error { case noCarrierInfo, handoverDidNotComplete }
+}
+
+private final class HolderDelegate: MdocProximityPresentationManager.Delegate {
+    private weak var runner: NfcHolderSelfTestRunner?
+    init(runner: NfcHolderSelfTestRunner) { self.runner = runner }
+    func connectionState(changedTo state: MdocProximityPresentationManager.State) {
+        DispatchQueue.main.async { [weak runner] in runner?.holderStateChanged(state) }
+    }
+}
+
+private final class ReaderDelegate: MdocProximityReader.Delegate {
+    private weak var runner: NfcHolderSelfTestRunner?
+    init(runner: NfcHolderSelfTestRunner) { self.runner = runner }
+    func connectionState(changedTo state: MdocProximityReader.State) {
+        DispatchQueue.main.async { [weak runner] in runner?.readerStateChanged(state) }
+    }
+}

--- a/ios/Showcase/Targets/AppUIKit/Sources/credentials/NfcHolderSelfTestView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/credentials/NfcHolderSelfTestView.swift
@@ -82,6 +82,7 @@ final class NfcHolderSelfTestRunner: ObservableObject {
     private var finished = false
     private var holderEngaged = false
     private var readerAdvertising = false
+    private var runToken = 0
 
     init(mdoc: Mdoc) {
         self.mdoc = mdoc
@@ -90,6 +91,8 @@ final class NfcHolderSelfTestRunner: ObservableObject {
     func run() {
         guard !isRunning else { return }
         isRunning = true
+        runToken += 1
+        let token = runToken
         finished = false
         succeeded = false
         outcome = nil
@@ -122,7 +125,8 @@ final class NfcHolderSelfTestRunner: ObservableObject {
             append("Holder scanning + reader advertising over BLE…")
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 15) { [weak self] in
-                self?.fail("Holder/reader did not reach ready states in time — check Bluetooth permission")
+                guard let self, token == self.runToken else { return }
+                self.fail("Holder/reader did not reach ready states in time — check Bluetooth permission")
             }
         } catch {
             fail("Loopback failed: \(error)")
@@ -130,6 +134,7 @@ final class NfcHolderSelfTestRunner: ObservableObject {
     }
 
     func stop() {
+        runToken += 1
         holder?.disconnect()
         reader?.disconnect()
         holder = nil

--- a/ios/Showcase/Targets/AppUIKit/Sources/credentials/ShareMdocView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/credentials/ShareMdocView.swift
@@ -76,6 +76,8 @@ public struct ShareMdocQR: View {
                 authorizeBluetooth
             case .connecting(let qrPayload):
                 connectingView(qrPayload: qrPayload)
+            case .connectingViaNfc:
+                connectingViaNfcView
             case .connected:
                 connectedView
             case .receivingRequest(let bytesSoFar, let total):
@@ -168,6 +170,14 @@ public struct ShareMdocQR: View {
             .resizable()
             .scaledToFit()
             .aspectRatio(contentMode: .fit)
+    }
+
+    @ViewBuilder
+    var connectingViaNfcView: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+            Text("Hold your phone near the reader…")
+        }
     }
 
     @ViewBuilder

--- a/ios/Showcase/Targets/AppUIKit/Sources/credentials/ShareMdocView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/credentials/ShareMdocView.swift
@@ -76,8 +76,9 @@ public struct ShareMdocQR: View {
                 authorizeBluetooth
             case .connecting(let qrPayload):
                 connectingView(qrPayload: qrPayload)
+            // ShareMdocView only uses QR engagement; this state never occurs here.
             case .connectingViaNfc:
-                connectingViaNfcView
+                EmptyView()
             case .connected:
                 connectedView
             case .receivingRequest(let bytesSoFar, let total):
@@ -170,14 +171,6 @@ public struct ShareMdocQR: View {
             .resizable()
             .scaledToFit()
             .aspectRatio(contentMode: .fit)
-    }
-
-    @ViewBuilder
-    var connectingViaNfcView: some View {
-        VStack(spacing: 12) {
-            ProgressView()
-            Text("Hold your phone near the reader…")
-        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
Mirror the reader's `fromHandover:` entry on the holder side so the iOS SDK can present an mDL from an **NFC static-handover** engagement, not just a QR one.

`MdocProximityPresentationManager` gains `DeviceEngagement.NFC(NegotiatedCarrierInfo)`: it starts a BLE **central-client-mode** session on the UUID fixed by the handover and reuses the existing BLE transport + session code (the same path as QR). The Rust `ApduHandoverDriver` / `DeviceEngagementData.NFC` primitives already existed and are unchanged — this is the missing Swift wiring on top.

Linear: CAMV-975 (Apple NFC & SE Platform).

## ⚠️ Breaking change — release as 0.18.x
Adds two **public enum cases**: `DeviceEngagement.NFC(...)` and `MdocProximityPresentationManager.State.connectingViaNfc`. Downstream code that does an **exhaustive `switch` without a `default`** over either enum (e.g. a consumer's `connectionState(changedTo:)` handler, or the wallet) must add a branch to compile. No init/signature changes — call sites that don't switch over these enums are unaffected.

## Changes
- **PresentationManager**: `.NFC(carrier)` engagement + `State.connectingViaNfc`; `reset()`/`setupSession()` route NFC to central-only on the carrier UUID, skipping QR generation. Logs a warning if an `.NFC` engagement is passed no central transmission mode.
- **CentralManager**: mdoc `init` that scans a pre-negotiated service UUID (instead of a freshly generated one).
- **MdlPresentationAdapter** (Flutter plugin): handle the new state — unreachable via the plugin's pigeon today, keeps the switch exhaustive.
- **Showcase**: new **NFC tab** (matching Android's Share-NFC tab — `Wallet` icon, same slot) hosting a single-device **wiring self-test**: an in-memory APDU loopback (`ApduHandoverDriver` ↔ `ReaderApduHandoverDriver`) brings up both BLE roles to verify the NFC→BLE wiring **without NFC hardware or the SE entitlement**.

## Testing
- iOS SDK + Showcase build green; verified on a physical device (iPhone, iOS 26.5.1): the NFC tab self-test reaches **"Wiring verified"** (holder `connectingViaNfc` + reader `connecting`).
- A single phone can't BLE-connect to itself, so the self-test verifies wiring only. The full BLE session + response is the **same code already exercised by the QR flow**. A true over-the-air tap is gated on the Apple SE entitlement + the Java Card applet (out of scope here).
- No Rust changes; generated bindings unchanged (CI `git diff --exit-code` passes).
