### PR TITLE
Android - observe BLE session events in peripheral only mode

### DIFF
--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/CredentialsViewModel.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/CredentialsViewModel.kt
@@ -75,6 +75,10 @@ class CredentialsViewModel(application: Application) : AndroidViewModel(applicat
                     _currState.value = PresentmentState.ERROR
                     _error.value = Error(state["error"].toString())
                 }
+
+                state.containsKey("success") -> {
+                    _currState.value = PresentmentState.SUCCESS
+                }
             }
         }
 
@@ -165,7 +169,6 @@ class CredentialsViewModel(application: Application) : AndroidViewModel(applicat
 
         try {
             presentation?.submitNamespaces(allowedNamespaces)
-            _currState.value = PresentmentState.SUCCESS
         } catch (e: Error) {
             Log.e("CredentialsViewModel.submitNamespaces", e.toString())
             _currState.value = PresentmentState.ERROR

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/BleSessionEmitter.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/BleSessionEmitter.kt
@@ -1,0 +1,75 @@
+package com.spruceid.mobile.sdk.ble
+
+import com.spruceid.mobile.sdk.BLESessionStateDelegate
+
+/**
+ * Forwards BLE transport events to the host [BLESessionStateDelegate], building payloads via
+ * [BleSessionUpdates]. Shared by both transports — [TransportBleCentralClient] and
+ * [TransportBlePeripheralServerHolder] — so neither calls `callback.update(...)` directly and
+ * the two roles report an identical event vocabulary.
+ *
+ * A null delegate is tolerated (no-op), matching the transports' optional callbacks.
+ */
+internal class BleSessionEmitter(private val callback: BLESessionStateDelegate?) {
+
+    /** Peer connected. */
+    fun connected() {
+        callback?.update(BleSessionUpdates.connected())
+    }
+
+    /** Connection ended (peer disconnect or transport-specific termination). */
+    fun disconnected() {
+        callback?.update(BleSessionUpdates.disconnected())
+    }
+
+    /** Transport/advertising error (message form). */
+    fun error(message: String?) {
+        callback?.update(BleSessionUpdates.error(message))
+    }
+
+    /** Transport error carrying the original throwable. */
+    fun error(error: Throwable) {
+        callback?.update(BleSessionUpdates.error(error))
+    }
+
+    /** Outbound mDL fully sent. */
+    fun success() {
+        callback?.update(BleSessionUpdates.success())
+    }
+
+    /** Incremental outbound mDL send progress. */
+    fun uploadProgress(progress: Int, max: Int) {
+        callback?.update(BleSessionUpdates.uploadProgress(progress, max))
+    }
+
+    /**
+     * Outbound send tick for callers that always signal completion (e.g. the peripheral holder,
+     * which is always a Holder): terminal [success] when complete, else [uploadProgress].
+     * Callers that gate success on role (the Central client's Reader role) call
+     * [success]/[uploadProgress] directly.
+     */
+    fun sendProgress(progress: Int, max: Int) {
+        callback?.update(
+            if (BleSessionUpdates.isComplete(progress, max)) {
+                BleSessionUpdates.success()
+            } else {
+                BleSessionUpdates.uploadProgress(progress, max)
+            }
+        )
+    }
+
+    /** Inbound mDL response received (Reader role). */
+    fun mdl(data: ByteArray) {
+        callback?.update(BleSessionUpdates.mdl(data))
+    }
+
+    /** Scan/connection attempt timed out. */
+    fun timeout() {
+        callback?.update(BleSessionUpdates.timeout())
+    }
+
+    /** Scan throttled by the system; retry pending. */
+    fun scanThrottled() {
+        callback?.update(BleSessionUpdates.scanThrottled())
+    }
+}

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/BleSessionUpdates.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/BleSessionUpdates.kt
@@ -1,0 +1,43 @@
+package com.spruceid.mobile.sdk.ble
+
+/**
+ * Single source of truth for the payloads emitted on
+ * [com.spruceid.mobile.sdk.BLESessionStateDelegate.update] by the BLE transports.
+ *
+ * Both [TransportBleCentralClient] (Holder-as-Central) and [TransportBlePeripheralServerHolder]
+ * (Holder-as-Peripheral) report the same session lifecycle to the host via these keys.
+ */
+internal object BleSessionUpdates {
+
+    /** Peer established the GATT connection. */
+    fun connected(): Map<String, Any> = mapOf("connected" to "")
+
+    /** Connection ended (peer disconnect or transport-specific termination). */
+    fun disconnected(): Map<String, Any> = mapOf("disconnected" to "")
+
+    /** A transport/advertising error the host should surface. */
+    fun error(message: String?): Map<String, Any> =
+        mapOf("error" to (message ?: "Unknown error"))
+
+    /** A transport error carrying the original throwable as the payload value. */
+    fun error(error: Throwable): Map<String, Any> = mapOf("error" to error)
+
+    /** Outbound mDL fully sent. */
+    fun success(): Map<String, Any> = mapOf("success" to "")
+
+    /** Incremental outbound mDL send progress. */
+    fun uploadProgress(progress: Int, max: Int): Map<String, Any> =
+        mapOf("uploadProgress" to mapOf("curr" to progress, "max" to max))
+
+    /** Inbound mDL response received (Reader role). */
+    fun mdl(data: ByteArray): Map<String, Any> = mapOf("mdl" to data)
+
+    /** Scan/connection attempt timed out. */
+    fun timeout(): Map<String, Any> = mapOf("timeout" to "")
+
+    /** Scan was throttled by the system and a retry is pending (transient hint). */
+    fun scanThrottled(): Map<String, Any> = mapOf("scan_throttled" to "")
+
+    /** Whether an outbound mDL send has finished (all bytes written). */
+    fun isComplete(progress: Int, max: Int): Boolean = progress == max
+}

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBle.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBle.kt
@@ -66,7 +66,7 @@ class TransportBle {
             logger.d("Selecting Peripheral Server Holder")
 
             transportBlePeripheralServerHolder = TransportBlePeripheralServerHolder(
-                application, serviceUUID, updateRequestData
+                application, serviceUUID, updateRequestData, callback
             )
             transportBlePeripheralServerHolder.start()
         }

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBleCentralClient.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBleCentralClient.kt
@@ -64,6 +64,9 @@ class TransportBleCentralClient(
     private var logger = BleLogger.getInstance("TransportBleCentralClient")
     private val isReader = application == "Reader"
 
+    // Forwards session events to the host delegate (see BleSessionEmitter).
+    private val emitter = BleSessionEmitter(callback)
+
     private lateinit var gattClient: GattClient
     private lateinit var identValue: ByteArray
 
@@ -107,7 +110,7 @@ class TransportBleCentralClient(
         val gattClientCallback: GattClientCallback = object : GattClientCallback() {
             override fun onPeerConnected() {
                 logger.d("Peer Connected")
-                callback?.update(mapOf(Pair("connected", "")))
+                emitter.connected()
 
                 // Reader as Central: Send the mDL request to Holder after connection
                 if (isReader && requestData != null) {
@@ -120,7 +123,7 @@ class TransportBleCentralClient(
                 logger.d("Peer Disconnected")
                 // Transition to disconnected state
                 stateMachine.transitionTo(BleConnectionStateMachine.State.DISCONNECTED)
-                callback?.update(mapOf(Pair("disconnected", "")))
+                emitter.disconnected()
                 gattClient.disconnect()
             }
 
@@ -129,21 +132,15 @@ class TransportBleCentralClient(
                     "progress: $progress max: $max"
                 )
 
-                if (progress == max) {
+                if (BleSessionUpdates.isComplete(progress, max)) {
                     // Only send success callback for Holder role, Reader waits for mDL response
                     if (!isReader) {
-                        callback?.update(mapOf(Pair("success", "")))
+                        emitter.success()
                     } else {
                         logger.d("mDL request sent successfully")
                     }
                 } else {
-                    callback?.update(
-                        mapOf(
-                            Pair(
-                                "uploadProgress", mapOf(Pair("curr", progress), Pair("max", max))
-                            )
-                        )
-                    )
+                    emitter.uploadProgress(progress, max)
                 }
             }
 
@@ -157,7 +154,7 @@ class TransportBleCentralClient(
                     if (isReader) {
                         // Reader mode: Forward the mDL response to the application
                         logger.d("Received mDL response: ${data.size} bytes")
-                        callback?.update(mapOf(Pair("mdl", data)))
+                        emitter.mdl(data)
                     } else {
                         // Holder mode: Process the request data
                         val cont = updateRequestData?.invoke(data) ?: true
@@ -174,7 +171,7 @@ class TransportBleCentralClient(
                     logger.e("${e.message}")
                     // Transition to error state on exception
                     stateMachine.transitionTo(BleConnectionStateMachine.State.ERROR, e.message)
-                    callback?.update(mapOf(Pair("error", e)))
+                    emitter.error(e)
                 } catch (e: RequestException) {
                     logger.e("${e.message}")
                     // this is a workaround for now investigate eReaderDevice key missing on last message
@@ -272,14 +269,14 @@ class TransportBleCentralClient(
                 // Surface a transient signal so the host UI can show a
                 // "please wait" hint instead of leaving the user staring
                 // at a blank scanning indicator.
-                callback?.update(mapOf(Pair("scan_throttled", "")))
+                emitter.scanThrottled()
                 val retry = Runnable {
                     try {
                         scanThrottleRetryRunnable = null
                         scan()
                     } catch (e: Exception) {
                         logger.e("Scan retry after throttle failed: ${e.message}")
-                        callback?.update(mapOf(Pair("error", "Scan retry failed: ${e.message}")))
+                        emitter.error("Scan retry failed: ${e.message}")
                     }
                 }
                 scanThrottleRetryRunnable = retry
@@ -300,7 +297,7 @@ class TransportBleCentralClient(
                     "Scan throttled by system (5/30s limit) and retry exhausted."
                 else -> "Scan failed (code=$errorCode)."
             }
-            callback?.update(mapOf(Pair("error", message)))
+            emitter.error(message)
         }
     }
 
@@ -348,7 +345,7 @@ class TransportBleCentralClient(
                                 }
                                 scanTimeoutRunnable = null
                                 logger.i("connection timeout")
-                                callback?.update(mapOf(Pair("timeout", "")))
+                                emitter.timeout()
                                 disconnect()
                             }
                         }

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBlePeripheralServerHolder.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBlePeripheralServerHolder.kt
@@ -6,6 +6,7 @@ import android.bluetooth.le.AdvertiseSettings
 import android.content.Context
 import android.util.Log
 import androidx.annotation.RequiresPermission
+import com.spruceid.mobile.sdk.BLESessionStateDelegate
 import java.util.*
 
 /**
@@ -15,7 +16,8 @@ import java.util.*
 class TransportBlePeripheralServerHolder(
     private var application: String,
     private var serviceUUID: UUID,
-    private var updateRequestData: ((data: ByteArray) -> Boolean)?
+    private var updateRequestData: ((data: ByteArray) -> Boolean)?,
+    private var callback: BLESessionStateDelegate? = null
 ) {
 
     private val stateMachine = BleConnectionStateMachine.getInstance(BleConnectionStateMachineInstanceType.SERVER)
@@ -24,6 +26,9 @@ class TransportBlePeripheralServerHolder(
         stateMachine.getBluetoothManager().adapter
     }
     private var logger = BleLogger.getInstance("TransportBlePeripheralServerHolder")
+
+    // Forwards session lifecycle to the host delegate (see BleSessionEmitter).
+    private val emitter = BleSessionEmitter(callback)
 
     private lateinit var blePeripheral: BlePeripheral
     private lateinit var gattServer: GattServer
@@ -55,6 +60,7 @@ class TransportBlePeripheralServerHolder(
                     BleConnectionStateMachine.State.ERROR,
                     reason,
                 )
+                emitter.error(reason)
             }
 
             override fun onError(error: Throwable) {
@@ -63,6 +69,7 @@ class TransportBlePeripheralServerHolder(
                     BleConnectionStateMachine.State.ERROR,
                     error.message,
                 )
+                emitter.error(error.message)
             }
 
             override fun onState(state: String) {
@@ -84,6 +91,7 @@ class TransportBlePeripheralServerHolder(
                         "Failed to transition to CONNECTED state"
                     )
                 }
+                emitter.connected()
             }
 
             override fun onPeerDisconnected() {
@@ -93,6 +101,7 @@ class TransportBlePeripheralServerHolder(
                 // Transition to disconnected state
                 stateMachine.transitionTo(BleConnectionStateMachine.State.DISCONNECTED)
                 gattServer.stop()
+                emitter.disconnected()
             }
 
             override fun onMessageSendProgress(progress: Int, max: Int) {
@@ -101,12 +110,14 @@ class TransportBlePeripheralServerHolder(
                 )
 
                 blePeripheral.stopAdvertise()
+                emitter.sendProgress(progress, max)
             }
 
             override fun onTransportSpecificSessionTermination() {
                 // Transition to disconnected state on termination
                 stateMachine.transitionTo(BleConnectionStateMachine.State.DISCONNECTED)
                 gattServer.stop()
+                emitter.disconnected()
             }
 
             override fun onMessageReceived(data: ByteArray) {

--- a/android/MobileSdk/src/test/java/com/spruceid/mobile/sdk/ble/BleSessionEmitterTest.kt
+++ b/android/MobileSdk/src/test/java/com/spruceid/mobile/sdk/ble/BleSessionEmitterTest.kt
@@ -1,0 +1,148 @@
+package com.spruceid.mobile.sdk.ble
+
+import com.spruceid.mobile.sdk.BLESessionStateDelegate
+import org.junit.Assert.*
+import org.junit.Test
+
+class BleSessionEmitterTest {
+    
+    private class RecordingDelegate : BLESessionStateDelegate() {
+        val updates = mutableListOf<Map<String, Any>>()
+        val errors = mutableListOf<Exception>()
+        override fun update(state: Map<String, Any>) { updates.add(state) }
+        override fun error(error: Exception) { errors.add(error) }
+    }
+
+    @Test
+    fun connectedDeliversConnectedPayload() {
+        val d = RecordingDelegate()
+        BleSessionEmitter(d).connected()
+        assertEquals(listOf(mapOf("connected" to "")), d.updates)
+    }
+
+    @Test
+    fun disconnectedDeliversDisconnectedPayload() {
+        val d = RecordingDelegate()
+        BleSessionEmitter(d).disconnected()
+        assertEquals(listOf(mapOf("disconnected" to "")), d.updates)
+    }
+
+    @Test
+    fun errorMessageDeliversErrorPayload() {
+        val d = RecordingDelegate()
+        BleSessionEmitter(d).error("scan failed")
+        assertEquals(listOf(mapOf("error" to "scan failed")), d.updates)
+    }
+
+    @Test
+    fun errorNullMessageDeliversFallback() {
+        val d = RecordingDelegate()
+        BleSessionEmitter(d).error(null as String?)
+        assertEquals(listOf(mapOf("error" to "Unknown error")), d.updates)
+    }
+
+    /** The Throwable overload preserves the throwable as the payload value. */
+    @Test
+    fun errorThrowableDeliversThrowablePayload() {
+        val d = RecordingDelegate()
+        val boom = IllegalStateException("kaboom")
+        BleSessionEmitter(d).error(boom)
+        assertEquals(listOf(mapOf<String, Any>("error" to boom)), d.updates)
+    }
+
+    @Test
+    fun successDeliversSuccessPayload() {
+        val d = RecordingDelegate()
+        BleSessionEmitter(d).success()
+        assertEquals(listOf(mapOf("success" to "")), d.updates)
+    }
+
+    @Test
+    fun uploadProgressDeliversCurrAndMax() {
+        val d = RecordingDelegate()
+        BleSessionEmitter(d).uploadProgress(30, 100)
+        assertEquals(
+            listOf(mapOf("uploadProgress" to mapOf("curr" to 30, "max" to 100))),
+            d.updates
+        )
+    }
+
+    /** sendProgress convenience: completion -> success, else uploadProgress. */
+    @Test
+    fun sendProgressAtMaxDeliversSuccess() {
+        val d = RecordingDelegate()
+        BleSessionEmitter(d).sendProgress(100, 100)
+        assertEquals(listOf(mapOf("success" to "")), d.updates)
+    }
+
+    @Test
+    fun sendProgressBelowMaxDeliversUploadProgress() {
+        val d = RecordingDelegate()
+        BleSessionEmitter(d).sendProgress(40, 100)
+        assertEquals(
+            listOf(mapOf("uploadProgress" to mapOf("curr" to 40, "max" to 100))),
+            d.updates
+        )
+    }
+
+    @Test
+    fun mdlDeliversResponseBytes() {
+        val d = RecordingDelegate()
+        val bytes = byteArrayOf(1, 2, 3)
+        BleSessionEmitter(d).mdl(bytes)
+        assertEquals(1, d.updates.size)
+        assertSame(bytes, d.updates[0]["mdl"])
+    }
+
+    @Test
+    fun timeoutDeliversTimeoutPayload() {
+        val d = RecordingDelegate()
+        BleSessionEmitter(d).timeout()
+        assertEquals(listOf(mapOf("timeout" to "")), d.updates)
+    }
+
+    @Test
+    fun scanThrottledDeliversScanThrottledPayload() {
+        val d = RecordingDelegate()
+        BleSessionEmitter(d).scanThrottled()
+        assertEquals(listOf(mapOf("scan_throttled" to "")), d.updates)
+    }
+
+    // --- ordering + null safety ---
+
+    @Test
+    fun fullHolderSequenceDeliveredInOrder() {
+        val d = RecordingDelegate()
+        val e = BleSessionEmitter(d)
+        e.connected()
+        e.sendProgress(50, 100)
+        e.sendProgress(100, 100)
+        e.disconnected()
+        assertEquals(
+            listOf(
+                mapOf("connected" to ""),
+                mapOf("uploadProgress" to mapOf("curr" to 50, "max" to 100)),
+                mapOf("success" to ""),
+                mapOf("disconnected" to "")
+            ),
+            d.updates
+        )
+        assertTrue(d.errors.isEmpty())
+    }
+
+    @Test
+    fun nullDelegateIsNoOp() {
+        val e = BleSessionEmitter(null)
+        e.connected()
+        e.disconnected()
+        e.error("x")
+        e.error(RuntimeException("y"))
+        e.success()
+        e.uploadProgress(1, 2)
+        e.sendProgress(2, 2)
+        e.mdl(byteArrayOf(0))
+        e.timeout()
+        e.scanThrottled()
+        // Reaching here without throwing is the assertion.
+    }
+}

--- a/android/MobileSdk/src/test/java/com/spruceid/mobile/sdk/ble/BleSessionUpdatesTest.kt
+++ b/android/MobileSdk/src/test/java/com/spruceid/mobile/sdk/ble/BleSessionUpdatesTest.kt
@@ -1,0 +1,56 @@
+package com.spruceid.mobile.sdk.ble
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class BleSessionUpdatesTest {
+
+    @Test
+    fun connectedEmitsConnectedKey() {
+        assertEquals(mapOf("connected" to ""), BleSessionUpdates.connected())
+    }
+
+    @Test
+    fun disconnectedEmitsDisconnectedKey() {
+        assertEquals(mapOf("disconnected" to ""), BleSessionUpdates.disconnected())
+    }
+
+    @Test
+    fun errorUsesProvidedMessage() {
+        assertEquals(mapOf("error" to "boom"), BleSessionUpdates.error("boom"))
+    }
+
+    @Test
+    fun errorFallsBackWhenMessageNull() {
+        assertEquals(mapOf("error" to "Unknown error"), BleSessionUpdates.error(null))
+    }
+
+    @Test
+    fun successEmitsSuccessKey() {
+        assertEquals(mapOf("success" to ""), BleSessionUpdates.success())
+    }
+
+    @Test
+    fun uploadProgressCarriesCurrAndMax() {
+        assertEquals(
+            mapOf("uploadProgress" to mapOf("curr" to 40, "max" to 100)),
+            BleSessionUpdates.uploadProgress(40, 100)
+        )
+    }
+
+    @Test
+    fun isCompleteWhenProgressEqualsMax() {
+        assertTrue(BleSessionUpdates.isComplete(100, 100))
+    }
+
+    @Test
+    fun isNotCompleteBelowMax() {
+        assertFalse(BleSessionUpdates.isComplete(40, 100))
+        assertFalse(BleSessionUpdates.isComplete(0, 100))
+    }
+    
+    @Test
+    fun successPayloadHasNoProgressFields() {
+        assertFalse(BleSessionUpdates.success().containsKey("uploadProgress"))
+    }
+}


### PR DESCRIPTION
## Description

When an mDL holder presents in `PresentationMode.PERIPHERAL_ONLY`, the holder runs as a BLE peripheral via `TransportBlePeripheralServerHolder`. That class was never given the `BLESessionStateDelegate` and never invoked it, so the host application received **none** of the BLE session lifecycle events (`connected`, `uploadProgress`, `success`, `disconnected`).

Any host that drives its presentment UI off those events — e.g. showing upload progress or dismissing on success — has no way to know the exchange progressed or completed, even though the mDL is actually sent. The Central client (`TransportBleCentralClient`) emits these events, so `CENTRAL_ONLY` / `DUAL_MODE` work; only the peripheral path was silent.

This PR threads the delegate into the peripheral holder and emits the same events the central
client does, so both BLE roles report an identical session-state stream.

## Root cause

- `TransportBle.initialize()` constructed the peripheral holder without the `callback`
- `TransportBlePeripheralServerHolder` had no `BLESessionStateDelegate` field and its GATT / advertise callbacks only logged and drove the internal state machine — they never called `update()`.
- Request handling (`selectNamespaces` / `readerName`) still worked because that path flows through `IsoMdlPresentation`'s own delegate rather than the transport, which is why the bug surfaces specifically as a missing **connection/progress/completion** signal.

## Changes

- **`TransportBle.kt`** — pass `callback` into the peripheral-holder branch.
- **`TransportBlePeripheralServerHolder.kt`** — accept an optional `BLESessionStateDelegate` and emit from its GATT / advertise callbacks:
  - `onPeerConnected` → `connected`
  - `onMessageSendProgress` → `uploadProgress {curr, max}`, and `success` on completion
  - `onPeerDisconnected` / `onTransportSpecificSessionTermination` → `disconnected`
  - advertise `onStartFailure` / `onError` → `error`
- **`BleSessionUpdates.kt`** (new) — a single, framework-free source of truth for the delegate payloads (`connected` / `disconnected` / `error` / `success` / `uploadProgress`) plus an `isComplete(progress, max)` predicate. Both transports now build their payloads here, so the two roles can't drift apart again.
- **`TransportBleCentralClient.kt`** — routed its existing `connected` / `disconnected` / `success` / `uploadProgress` emissions through `BleSessionUpdates`. Behaviour is unchanged; the Reader role still suppresses `success` on completion (it awaits the inbound mDL response).
- **`BleSessionUpdatesTest.kt`** (new) — unit tests pinning every payload shape and the `isComplete` decision, locking the contract shared by both transports.

## Tested

Manual two-device verification in `PERIPHERAL_ONLY`: with a logging delegate, the holder now reports `connected` on peer connect and `uploadProgress` → `success` on send; before the fix none of these were delivered while the mDL still transferred.