### PR TITLE
Add verify_device_response function to for mdl reader

### DIFF
--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -1529,9 +1529,8 @@ fileprivate struct UniffiCallbackInterfaceAsyncHttpClient {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // This creates 1-element array, since this seems to be the only way to construct a const
-    // pointer that we can pass to the Rust code.
-    static let vtable: [UniffiVTableCallbackInterfaceAsyncHttpClient] = [UniffiVTableCallbackInterfaceAsyncHttpClient(
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfaceAsyncHttpClient = UniffiVTableCallbackInterfaceAsyncHttpClient(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeAsyncHttpClient.handleMap.remove(handle: uniffiHandle)
@@ -1589,11 +1588,19 @@ fileprivate struct UniffiCallbackInterfaceAsyncHttpClient {
                 droppedCallback: uniffiOutDroppedCallback
             )
         }
-    )]
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceAsyncHttpClient> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceAsyncHttpClient>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
 }
 
 private func uniffiCallbackInitAsyncHttpClient() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_asynchttpclient(UniffiCallbackInterfaceAsyncHttpClient.vtable)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_asynchttpclient(UniffiCallbackInterfaceAsyncHttpClient.vtablePtr)
 }
 
 #if swift(>=5.8)
@@ -2259,9 +2266,8 @@ fileprivate struct UniffiCallbackInterfaceCrypto {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // This creates 1-element array, since this seems to be the only way to construct a const
-    // pointer that we can pass to the Rust code.
-    static let vtable: [UniffiVTableCallbackInterfaceCrypto] = [UniffiVTableCallbackInterfaceCrypto(
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfaceCrypto = UniffiVTableCallbackInterfaceCrypto(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeCrypto.handleMap.remove(handle: uniffiHandle)
@@ -2304,11 +2310,19 @@ fileprivate struct UniffiCallbackInterfaceCrypto {
                 writeReturn: writeReturn
             )
         }
-    )]
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceCrypto> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceCrypto>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
 }
 
 private func uniffiCallbackInitCrypto() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_crypto(UniffiCallbackInterfaceCrypto.vtable)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_crypto(UniffiCallbackInterfaceCrypto.vtablePtr)
 }
 
 #if swift(>=5.8)
@@ -4650,9 +4664,8 @@ fileprivate struct UniffiCallbackInterfaceDraft18RequestSignerInterface {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // This creates 1-element array, since this seems to be the only way to construct a const
-    // pointer that we can pass to the Rust code.
-    static let vtable: [UniffiVTableCallbackInterfaceDraft18RequestSignerInterface] = [UniffiVTableCallbackInterfaceDraft18RequestSignerInterface(
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfaceDraft18RequestSignerInterface = UniffiVTableCallbackInterfaceDraft18RequestSignerInterface(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeDraft18RequestSignerInterface.handleMap.remove(handle: uniffiHandle)
@@ -4756,11 +4769,19 @@ fileprivate struct UniffiCallbackInterfaceDraft18RequestSignerInterface {
                 droppedCallback: uniffiOutDroppedCallback
             )
         }
-    )]
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceDraft18RequestSignerInterface> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceDraft18RequestSignerInterface>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
 }
 
 private func uniffiCallbackInitDraft18RequestSignerInterface() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_draft18requestsignerinterface(UniffiCallbackInterfaceDraft18RequestSignerInterface.vtable)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_draft18requestsignerinterface(UniffiCallbackInterfaceDraft18RequestSignerInterface.vtablePtr)
 }
 
 #if swift(>=5.8)
@@ -7587,9 +7608,8 @@ fileprivate struct UniffiCallbackInterfaceJwsSigner {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // This creates 1-element array, since this seems to be the only way to construct a const
-    // pointer that we can pass to the Rust code.
-    static let vtable: [UniffiVTableCallbackInterfaceJwsSigner] = [UniffiVTableCallbackInterfaceJwsSigner(
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfaceJwsSigner = UniffiVTableCallbackInterfaceJwsSigner(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeJwsSigner.handleMap.remove(handle: uniffiHandle)
@@ -7688,11 +7708,19 @@ fileprivate struct UniffiCallbackInterfaceJwsSigner {
                 droppedCallback: uniffiOutDroppedCallback
             )
         }
-    )]
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceJwsSigner> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceJwsSigner>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
 }
 
 private func uniffiCallbackInitJwsSigner() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_jwssigner(UniffiCallbackInterfaceJwsSigner.vtable)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_jwssigner(UniffiCallbackInterfaceJwsSigner.vtablePtr)
 }
 
 #if swift(>=5.8)
@@ -8117,9 +8145,8 @@ fileprivate struct UniffiCallbackInterfaceKeyStore {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // This creates 1-element array, since this seems to be the only way to construct a const
-    // pointer that we can pass to the Rust code.
-    static let vtable: [UniffiVTableCallbackInterfaceKeyStore] = [UniffiVTableCallbackInterfaceKeyStore(
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfaceKeyStore = UniffiVTableCallbackInterfaceKeyStore(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeKeyStore.handleMap.remove(handle: uniffiHandle)
@@ -8159,11 +8186,19 @@ fileprivate struct UniffiCallbackInterfaceKeyStore {
                 lowerError: FfiConverterTypeCryptoError_lower
             )
         }
-    )]
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceKeyStore> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceKeyStore>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
 }
 
 private func uniffiCallbackInitKeyStore() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_keystore(UniffiCallbackInterfaceKeyStore.vtable)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_keystore(UniffiCallbackInterfaceKeyStore.vtablePtr)
 }
 
 #if swift(>=5.8)
@@ -8313,9 +8348,8 @@ fileprivate struct UniffiCallbackInterfaceLogWriter {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // This creates 1-element array, since this seems to be the only way to construct a const
-    // pointer that we can pass to the Rust code.
-    static let vtable: [UniffiVTableCallbackInterfaceLogWriter] = [UniffiVTableCallbackInterfaceLogWriter(
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfaceLogWriter = UniffiVTableCallbackInterfaceLogWriter(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeLogWriter.handleMap.remove(handle: uniffiHandle)
@@ -8376,11 +8410,19 @@ fileprivate struct UniffiCallbackInterfaceLogWriter {
                 writeReturn: writeReturn
             )
         }
-    )]
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceLogWriter> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceLogWriter>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
 }
 
 private func uniffiCallbackInitLogWriter() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_logwriter(UniffiCallbackInterfaceLogWriter.vtable)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_logwriter(UniffiCallbackInterfaceLogWriter.vtablePtr)
 }
 
 #if swift(>=5.8)
@@ -14269,9 +14311,8 @@ fileprivate struct UniffiCallbackInterfaceSigningKey {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // This creates 1-element array, since this seems to be the only way to construct a const
-    // pointer that we can pass to the Rust code.
-    static let vtable: [UniffiVTableCallbackInterfaceSigningKey] = [UniffiVTableCallbackInterfaceSigningKey(
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfaceSigningKey = UniffiVTableCallbackInterfaceSigningKey(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeSigningKey.handleMap.remove(handle: uniffiHandle)
@@ -14334,11 +14375,19 @@ fileprivate struct UniffiCallbackInterfaceSigningKey {
                 lowerError: FfiConverterTypeCryptoError_lower
             )
         }
-    )]
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceSigningKey> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceSigningKey>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
 }
 
 private func uniffiCallbackInitSigningKey() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_signingkey(UniffiCallbackInterfaceSigningKey.vtable)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_signingkey(UniffiCallbackInterfaceSigningKey.vtablePtr)
 }
 
 #if swift(>=5.8)
@@ -15027,9 +15076,8 @@ fileprivate struct UniffiCallbackInterfaceStorageManagerInterface {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // This creates 1-element array, since this seems to be the only way to construct a const
-    // pointer that we can pass to the Rust code.
-    static let vtable: [UniffiVTableCallbackInterfaceStorageManagerInterface] = [UniffiVTableCallbackInterfaceStorageManagerInterface(
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfaceStorageManagerInterface = UniffiVTableCallbackInterfaceStorageManagerInterface(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeStorageManagerInterface.handleMap.remove(handle: uniffiHandle)
@@ -15212,11 +15260,19 @@ fileprivate struct UniffiCallbackInterfaceStorageManagerInterface {
                 droppedCallback: uniffiOutDroppedCallback
             )
         }
-    )]
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceStorageManagerInterface> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceStorageManagerInterface>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
 }
 
 private func uniffiCallbackInitStorageManagerInterface() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_storagemanagerinterface(UniffiCallbackInterfaceStorageManagerInterface.vtable)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_storagemanagerinterface(UniffiCallbackInterfaceStorageManagerInterface.vtablePtr)
 }
 
 #if swift(>=5.8)
@@ -15358,9 +15414,8 @@ fileprivate struct UniffiCallbackInterfaceSyncHttpClient {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // This creates 1-element array, since this seems to be the only way to construct a const
-    // pointer that we can pass to the Rust code.
-    static let vtable: [UniffiVTableCallbackInterfaceSyncHttpClient] = [UniffiVTableCallbackInterfaceSyncHttpClient(
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfaceSyncHttpClient = UniffiVTableCallbackInterfaceSyncHttpClient(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeSyncHttpClient.handleMap.remove(handle: uniffiHandle)
@@ -15400,11 +15455,19 @@ fileprivate struct UniffiCallbackInterfaceSyncHttpClient {
                 lowerError: FfiConverterTypeHttpClientError_lower
             )
         }
-    )]
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceSyncHttpClient> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceSyncHttpClient>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
 }
 
 private func uniffiCallbackInitSyncHttpClient() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_synchttpclient(UniffiCallbackInterfaceSyncHttpClient.vtable)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_synchttpclient(UniffiCallbackInterfaceSyncHttpClient.vtablePtr)
 }
 
 #if swift(>=5.8)
@@ -31677,9 +31740,8 @@ fileprivate struct UniffiCallbackInterfaceDraft18PresentationSigner {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // This creates 1-element array, since this seems to be the only way to construct a const
-    // pointer that we can pass to the Rust code.
-    static let vtable: [UniffiVTableCallbackInterfaceDraft18PresentationSigner] = [UniffiVTableCallbackInterfaceDraft18PresentationSigner(
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfaceDraft18PresentationSigner = UniffiVTableCallbackInterfaceDraft18PresentationSigner(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterCallbackInterfaceDraft18PresentationSigner.handleMap.remove(handle: uniffiHandle)
@@ -31865,11 +31927,19 @@ fileprivate struct UniffiCallbackInterfaceDraft18PresentationSigner {
                 writeReturn: writeReturn
             )
         }
-    )]
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceDraft18PresentationSigner> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceDraft18PresentationSigner>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
 }
 
 private func uniffiCallbackInitDraft18PresentationSigner() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_draft18presentationsigner(UniffiCallbackInterfaceDraft18PresentationSigner.vtable)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_draft18presentationsigner(UniffiCallbackInterfaceDraft18PresentationSigner.vtablePtr)
 }
 
 // FfiConverter protocol for callback interfaces
@@ -31958,9 +32028,8 @@ fileprivate struct UniffiCallbackInterfaceOid4vpPresentationSigner {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // This creates 1-element array, since this seems to be the only way to construct a const
-    // pointer that we can pass to the Rust code.
-    static let vtable: [UniffiVTableCallbackInterfaceOid4vpPresentationSigner] = [UniffiVTableCallbackInterfaceOid4vpPresentationSigner(
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfaceOid4vpPresentationSigner = UniffiVTableCallbackInterfaceOid4vpPresentationSigner(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterCallbackInterfaceOid4vpPresentationSigner.handleMap.remove(handle: uniffiHandle)
@@ -32146,11 +32215,19 @@ fileprivate struct UniffiCallbackInterfaceOid4vpPresentationSigner {
                 writeReturn: writeReturn
             )
         }
-    )]
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceOid4vpPresentationSigner> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceOid4vpPresentationSigner>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
 }
 
 private func uniffiCallbackInitOid4vpPresentationSigner() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_oid4vppresentationsigner(UniffiCallbackInterfaceOid4vpPresentationSigner.vtable)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_oid4vppresentationsigner(UniffiCallbackInterfaceOid4vpPresentationSigner.vtablePtr)
 }
 
 // FfiConverter protocol for callback interfaces
@@ -32284,9 +32361,8 @@ fileprivate struct UniffiCallbackInterfacePresentationSigner {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // This creates 1-element array, since this seems to be the only way to construct a const
-    // pointer that we can pass to the Rust code.
-    static let vtable: [UniffiVTableCallbackInterfacePresentationSigner] = [UniffiVTableCallbackInterfacePresentationSigner(
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfacePresentationSigner = UniffiVTableCallbackInterfacePresentationSigner(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterCallbackInterfacePresentationSigner.handleMap.remove(handle: uniffiHandle)
@@ -32472,11 +32548,19 @@ fileprivate struct UniffiCallbackInterfacePresentationSigner {
                 writeReturn: writeReturn
             )
         }
-    )]
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfacePresentationSigner> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfacePresentationSigner>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
 }
 
 private func uniffiCallbackInitPresentationSigner() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_presentationsigner(UniffiCallbackInterfacePresentationSigner.vtable)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_presentationsigner(UniffiCallbackInterfacePresentationSigner.vtablePtr)
 }
 
 // FfiConverter protocol for callback interfaces

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -1529,8 +1529,9 @@ fileprivate struct UniffiCallbackInterfaceAsyncHttpClient {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // Store the vtable directly.
-    static let vtable: UniffiVTableCallbackInterfaceAsyncHttpClient = UniffiVTableCallbackInterfaceAsyncHttpClient(
+    // This creates 1-element array, since this seems to be the only way to construct a const
+    // pointer that we can pass to the Rust code.
+    static let vtable: [UniffiVTableCallbackInterfaceAsyncHttpClient] = [UniffiVTableCallbackInterfaceAsyncHttpClient(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeAsyncHttpClient.handleMap.remove(handle: uniffiHandle)
@@ -1588,19 +1589,11 @@ fileprivate struct UniffiCallbackInterfaceAsyncHttpClient {
                 droppedCallback: uniffiOutDroppedCallback
             )
         }
-    )
-
-    // Rust stores this pointer for future callback invocations, so it must live
-    // for the process lifetime (not just for the init function call).
-    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceAsyncHttpClient> = {
-        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceAsyncHttpClient>.allocate(capacity: 1)
-        ptr.initialize(to: vtable)
-        return UnsafePointer(ptr)
-    }()
+    )]
 }
 
 private func uniffiCallbackInitAsyncHttpClient() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_asynchttpclient(UniffiCallbackInterfaceAsyncHttpClient.vtablePtr)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_asynchttpclient(UniffiCallbackInterfaceAsyncHttpClient.vtable)
 }
 
 #if swift(>=5.8)
@@ -2266,8 +2259,9 @@ fileprivate struct UniffiCallbackInterfaceCrypto {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // Store the vtable directly.
-    static let vtable: UniffiVTableCallbackInterfaceCrypto = UniffiVTableCallbackInterfaceCrypto(
+    // This creates 1-element array, since this seems to be the only way to construct a const
+    // pointer that we can pass to the Rust code.
+    static let vtable: [UniffiVTableCallbackInterfaceCrypto] = [UniffiVTableCallbackInterfaceCrypto(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeCrypto.handleMap.remove(handle: uniffiHandle)
@@ -2310,19 +2304,11 @@ fileprivate struct UniffiCallbackInterfaceCrypto {
                 writeReturn: writeReturn
             )
         }
-    )
-
-    // Rust stores this pointer for future callback invocations, so it must live
-    // for the process lifetime (not just for the init function call).
-    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceCrypto> = {
-        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceCrypto>.allocate(capacity: 1)
-        ptr.initialize(to: vtable)
-        return UnsafePointer(ptr)
-    }()
+    )]
 }
 
 private func uniffiCallbackInitCrypto() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_crypto(UniffiCallbackInterfaceCrypto.vtablePtr)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_crypto(UniffiCallbackInterfaceCrypto.vtable)
 }
 
 #if swift(>=5.8)
@@ -4664,8 +4650,9 @@ fileprivate struct UniffiCallbackInterfaceDraft18RequestSignerInterface {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // Store the vtable directly.
-    static let vtable: UniffiVTableCallbackInterfaceDraft18RequestSignerInterface = UniffiVTableCallbackInterfaceDraft18RequestSignerInterface(
+    // This creates 1-element array, since this seems to be the only way to construct a const
+    // pointer that we can pass to the Rust code.
+    static let vtable: [UniffiVTableCallbackInterfaceDraft18RequestSignerInterface] = [UniffiVTableCallbackInterfaceDraft18RequestSignerInterface(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeDraft18RequestSignerInterface.handleMap.remove(handle: uniffiHandle)
@@ -4769,19 +4756,11 @@ fileprivate struct UniffiCallbackInterfaceDraft18RequestSignerInterface {
                 droppedCallback: uniffiOutDroppedCallback
             )
         }
-    )
-
-    // Rust stores this pointer for future callback invocations, so it must live
-    // for the process lifetime (not just for the init function call).
-    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceDraft18RequestSignerInterface> = {
-        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceDraft18RequestSignerInterface>.allocate(capacity: 1)
-        ptr.initialize(to: vtable)
-        return UnsafePointer(ptr)
-    }()
+    )]
 }
 
 private func uniffiCallbackInitDraft18RequestSignerInterface() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_draft18requestsignerinterface(UniffiCallbackInterfaceDraft18RequestSignerInterface.vtablePtr)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_draft18requestsignerinterface(UniffiCallbackInterfaceDraft18RequestSignerInterface.vtable)
 }
 
 #if swift(>=5.8)
@@ -7608,8 +7587,9 @@ fileprivate struct UniffiCallbackInterfaceJwsSigner {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // Store the vtable directly.
-    static let vtable: UniffiVTableCallbackInterfaceJwsSigner = UniffiVTableCallbackInterfaceJwsSigner(
+    // This creates 1-element array, since this seems to be the only way to construct a const
+    // pointer that we can pass to the Rust code.
+    static let vtable: [UniffiVTableCallbackInterfaceJwsSigner] = [UniffiVTableCallbackInterfaceJwsSigner(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeJwsSigner.handleMap.remove(handle: uniffiHandle)
@@ -7708,19 +7688,11 @@ fileprivate struct UniffiCallbackInterfaceJwsSigner {
                 droppedCallback: uniffiOutDroppedCallback
             )
         }
-    )
-
-    // Rust stores this pointer for future callback invocations, so it must live
-    // for the process lifetime (not just for the init function call).
-    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceJwsSigner> = {
-        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceJwsSigner>.allocate(capacity: 1)
-        ptr.initialize(to: vtable)
-        return UnsafePointer(ptr)
-    }()
+    )]
 }
 
 private func uniffiCallbackInitJwsSigner() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_jwssigner(UniffiCallbackInterfaceJwsSigner.vtablePtr)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_jwssigner(UniffiCallbackInterfaceJwsSigner.vtable)
 }
 
 #if swift(>=5.8)
@@ -8145,8 +8117,9 @@ fileprivate struct UniffiCallbackInterfaceKeyStore {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // Store the vtable directly.
-    static let vtable: UniffiVTableCallbackInterfaceKeyStore = UniffiVTableCallbackInterfaceKeyStore(
+    // This creates 1-element array, since this seems to be the only way to construct a const
+    // pointer that we can pass to the Rust code.
+    static let vtable: [UniffiVTableCallbackInterfaceKeyStore] = [UniffiVTableCallbackInterfaceKeyStore(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeKeyStore.handleMap.remove(handle: uniffiHandle)
@@ -8186,19 +8159,11 @@ fileprivate struct UniffiCallbackInterfaceKeyStore {
                 lowerError: FfiConverterTypeCryptoError_lower
             )
         }
-    )
-
-    // Rust stores this pointer for future callback invocations, so it must live
-    // for the process lifetime (not just for the init function call).
-    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceKeyStore> = {
-        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceKeyStore>.allocate(capacity: 1)
-        ptr.initialize(to: vtable)
-        return UnsafePointer(ptr)
-    }()
+    )]
 }
 
 private func uniffiCallbackInitKeyStore() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_keystore(UniffiCallbackInterfaceKeyStore.vtablePtr)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_keystore(UniffiCallbackInterfaceKeyStore.vtable)
 }
 
 #if swift(>=5.8)
@@ -8348,8 +8313,9 @@ fileprivate struct UniffiCallbackInterfaceLogWriter {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // Store the vtable directly.
-    static let vtable: UniffiVTableCallbackInterfaceLogWriter = UniffiVTableCallbackInterfaceLogWriter(
+    // This creates 1-element array, since this seems to be the only way to construct a const
+    // pointer that we can pass to the Rust code.
+    static let vtable: [UniffiVTableCallbackInterfaceLogWriter] = [UniffiVTableCallbackInterfaceLogWriter(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeLogWriter.handleMap.remove(handle: uniffiHandle)
@@ -8410,19 +8376,11 @@ fileprivate struct UniffiCallbackInterfaceLogWriter {
                 writeReturn: writeReturn
             )
         }
-    )
-
-    // Rust stores this pointer for future callback invocations, so it must live
-    // for the process lifetime (not just for the init function call).
-    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceLogWriter> = {
-        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceLogWriter>.allocate(capacity: 1)
-        ptr.initialize(to: vtable)
-        return UnsafePointer(ptr)
-    }()
+    )]
 }
 
 private func uniffiCallbackInitLogWriter() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_logwriter(UniffiCallbackInterfaceLogWriter.vtablePtr)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_logwriter(UniffiCallbackInterfaceLogWriter.vtable)
 }
 
 #if swift(>=5.8)
@@ -14311,8 +14269,9 @@ fileprivate struct UniffiCallbackInterfaceSigningKey {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // Store the vtable directly.
-    static let vtable: UniffiVTableCallbackInterfaceSigningKey = UniffiVTableCallbackInterfaceSigningKey(
+    // This creates 1-element array, since this seems to be the only way to construct a const
+    // pointer that we can pass to the Rust code.
+    static let vtable: [UniffiVTableCallbackInterfaceSigningKey] = [UniffiVTableCallbackInterfaceSigningKey(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeSigningKey.handleMap.remove(handle: uniffiHandle)
@@ -14375,19 +14334,11 @@ fileprivate struct UniffiCallbackInterfaceSigningKey {
                 lowerError: FfiConverterTypeCryptoError_lower
             )
         }
-    )
-
-    // Rust stores this pointer for future callback invocations, so it must live
-    // for the process lifetime (not just for the init function call).
-    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceSigningKey> = {
-        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceSigningKey>.allocate(capacity: 1)
-        ptr.initialize(to: vtable)
-        return UnsafePointer(ptr)
-    }()
+    )]
 }
 
 private func uniffiCallbackInitSigningKey() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_signingkey(UniffiCallbackInterfaceSigningKey.vtablePtr)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_signingkey(UniffiCallbackInterfaceSigningKey.vtable)
 }
 
 #if swift(>=5.8)
@@ -15076,8 +15027,9 @@ fileprivate struct UniffiCallbackInterfaceStorageManagerInterface {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // Store the vtable directly.
-    static let vtable: UniffiVTableCallbackInterfaceStorageManagerInterface = UniffiVTableCallbackInterfaceStorageManagerInterface(
+    // This creates 1-element array, since this seems to be the only way to construct a const
+    // pointer that we can pass to the Rust code.
+    static let vtable: [UniffiVTableCallbackInterfaceStorageManagerInterface] = [UniffiVTableCallbackInterfaceStorageManagerInterface(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeStorageManagerInterface.handleMap.remove(handle: uniffiHandle)
@@ -15260,19 +15212,11 @@ fileprivate struct UniffiCallbackInterfaceStorageManagerInterface {
                 droppedCallback: uniffiOutDroppedCallback
             )
         }
-    )
-
-    // Rust stores this pointer for future callback invocations, so it must live
-    // for the process lifetime (not just for the init function call).
-    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceStorageManagerInterface> = {
-        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceStorageManagerInterface>.allocate(capacity: 1)
-        ptr.initialize(to: vtable)
-        return UnsafePointer(ptr)
-    }()
+    )]
 }
 
 private func uniffiCallbackInitStorageManagerInterface() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_storagemanagerinterface(UniffiCallbackInterfaceStorageManagerInterface.vtablePtr)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_storagemanagerinterface(UniffiCallbackInterfaceStorageManagerInterface.vtable)
 }
 
 #if swift(>=5.8)
@@ -15414,8 +15358,9 @@ fileprivate struct UniffiCallbackInterfaceSyncHttpClient {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // Store the vtable directly.
-    static let vtable: UniffiVTableCallbackInterfaceSyncHttpClient = UniffiVTableCallbackInterfaceSyncHttpClient(
+    // This creates 1-element array, since this seems to be the only way to construct a const
+    // pointer that we can pass to the Rust code.
+    static let vtable: [UniffiVTableCallbackInterfaceSyncHttpClient] = [UniffiVTableCallbackInterfaceSyncHttpClient(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeSyncHttpClient.handleMap.remove(handle: uniffiHandle)
@@ -15455,19 +15400,11 @@ fileprivate struct UniffiCallbackInterfaceSyncHttpClient {
                 lowerError: FfiConverterTypeHttpClientError_lower
             )
         }
-    )
-
-    // Rust stores this pointer for future callback invocations, so it must live
-    // for the process lifetime (not just for the init function call).
-    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceSyncHttpClient> = {
-        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceSyncHttpClient>.allocate(capacity: 1)
-        ptr.initialize(to: vtable)
-        return UnsafePointer(ptr)
-    }()
+    )]
 }
 
 private func uniffiCallbackInitSyncHttpClient() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_synchttpclient(UniffiCallbackInterfaceSyncHttpClient.vtablePtr)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_synchttpclient(UniffiCallbackInterfaceSyncHttpClient.vtable)
 }
 
 #if swift(>=5.8)
@@ -18975,6 +18912,108 @@ public func FfiConverterTypeJwsSignerInfo_lift(_ buf: RustBuffer) throws -> JwsS
 #endif
 public func FfiConverterTypeJwsSignerInfo_lower(_ value: JwsSignerInfo) -> RustBuffer {
     return FfiConverterTypeJwsSignerInfo.lower(value)
+}
+
+
+/**
+ * The result of verifying a `DeviceResponse` against an externally-supplied session transcript.
+ *
+ * Mirrors [`MDLReaderResponseData`] but carries no reader [`MDLSessionManager`], since the
+ * transcript is provided directly rather than established during BLE/NFC engagement.
+ */
+public struct MdlDeviceResponseVerification: Equatable, Hashable {
+    /**
+     * Contains the namespaces for the mDL directly, without top-level doc types.
+     */
+    public var verifiedResponse: [String: [String: MDocItem]]
+    /**
+     * Document types (doctypes) from the presented credentials.
+     */
+    public var docTypes: [String]
+    /**
+     * Outcome of issuer authentication.
+     */
+    public var issuerAuthentication: AuthenticationStatus
+    /**
+     * Outcome of device authentication.
+     */
+    public var deviceAuthentication: AuthenticationStatus
+    /**
+     * Errors that occurred during response processing.
+     */
+    public var errors: String?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * Contains the namespaces for the mDL directly, without top-level doc types.
+         */verifiedResponse: [String: [String: MDocItem]], 
+        /**
+         * Document types (doctypes) from the presented credentials.
+         */docTypes: [String], 
+        /**
+         * Outcome of issuer authentication.
+         */issuerAuthentication: AuthenticationStatus, 
+        /**
+         * Outcome of device authentication.
+         */deviceAuthentication: AuthenticationStatus, 
+        /**
+         * Errors that occurred during response processing.
+         */errors: String?) {
+        self.verifiedResponse = verifiedResponse
+        self.docTypes = docTypes
+        self.issuerAuthentication = issuerAuthentication
+        self.deviceAuthentication = deviceAuthentication
+        self.errors = errors
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension MdlDeviceResponseVerification: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeMDLDeviceResponseVerification: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MdlDeviceResponseVerification {
+        return
+            try MdlDeviceResponseVerification(
+                verifiedResponse: FfiConverterDictionaryStringDictionaryStringTypeMDocItem.read(from: &buf), 
+                docTypes: FfiConverterSequenceString.read(from: &buf), 
+                issuerAuthentication: FfiConverterTypeAuthenticationStatus.read(from: &buf), 
+                deviceAuthentication: FfiConverterTypeAuthenticationStatus.read(from: &buf), 
+                errors: FfiConverterOptionString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: MdlDeviceResponseVerification, into buf: inout [UInt8]) {
+        FfiConverterDictionaryStringDictionaryStringTypeMDocItem.write(value.verifiedResponse, into: &buf)
+        FfiConverterSequenceString.write(value.docTypes, into: &buf)
+        FfiConverterTypeAuthenticationStatus.write(value.issuerAuthentication, into: &buf)
+        FfiConverterTypeAuthenticationStatus.write(value.deviceAuthentication, into: &buf)
+        FfiConverterOptionString.write(value.errors, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeMDLDeviceResponseVerification_lift(_ buf: RustBuffer) throws -> MdlDeviceResponseVerification {
+    return try FfiConverterTypeMDLDeviceResponseVerification.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeMDLDeviceResponseVerification_lower(_ value: MdlDeviceResponseVerification) -> RustBuffer {
+    return FfiConverterTypeMDLDeviceResponseVerification.lower(value)
 }
 
 
@@ -31638,8 +31677,9 @@ fileprivate struct UniffiCallbackInterfaceDraft18PresentationSigner {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // Store the vtable directly.
-    static let vtable: UniffiVTableCallbackInterfaceDraft18PresentationSigner = UniffiVTableCallbackInterfaceDraft18PresentationSigner(
+    // This creates 1-element array, since this seems to be the only way to construct a const
+    // pointer that we can pass to the Rust code.
+    static let vtable: [UniffiVTableCallbackInterfaceDraft18PresentationSigner] = [UniffiVTableCallbackInterfaceDraft18PresentationSigner(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterCallbackInterfaceDraft18PresentationSigner.handleMap.remove(handle: uniffiHandle)
@@ -31825,19 +31865,11 @@ fileprivate struct UniffiCallbackInterfaceDraft18PresentationSigner {
                 writeReturn: writeReturn
             )
         }
-    )
-
-    // Rust stores this pointer for future callback invocations, so it must live
-    // for the process lifetime (not just for the init function call).
-    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceDraft18PresentationSigner> = {
-        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceDraft18PresentationSigner>.allocate(capacity: 1)
-        ptr.initialize(to: vtable)
-        return UnsafePointer(ptr)
-    }()
+    )]
 }
 
 private func uniffiCallbackInitDraft18PresentationSigner() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_draft18presentationsigner(UniffiCallbackInterfaceDraft18PresentationSigner.vtablePtr)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_draft18presentationsigner(UniffiCallbackInterfaceDraft18PresentationSigner.vtable)
 }
 
 // FfiConverter protocol for callback interfaces
@@ -31926,8 +31958,9 @@ fileprivate struct UniffiCallbackInterfaceOid4vpPresentationSigner {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // Store the vtable directly.
-    static let vtable: UniffiVTableCallbackInterfaceOid4vpPresentationSigner = UniffiVTableCallbackInterfaceOid4vpPresentationSigner(
+    // This creates 1-element array, since this seems to be the only way to construct a const
+    // pointer that we can pass to the Rust code.
+    static let vtable: [UniffiVTableCallbackInterfaceOid4vpPresentationSigner] = [UniffiVTableCallbackInterfaceOid4vpPresentationSigner(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterCallbackInterfaceOid4vpPresentationSigner.handleMap.remove(handle: uniffiHandle)
@@ -32113,19 +32146,11 @@ fileprivate struct UniffiCallbackInterfaceOid4vpPresentationSigner {
                 writeReturn: writeReturn
             )
         }
-    )
-
-    // Rust stores this pointer for future callback invocations, so it must live
-    // for the process lifetime (not just for the init function call).
-    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceOid4vpPresentationSigner> = {
-        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceOid4vpPresentationSigner>.allocate(capacity: 1)
-        ptr.initialize(to: vtable)
-        return UnsafePointer(ptr)
-    }()
+    )]
 }
 
 private func uniffiCallbackInitOid4vpPresentationSigner() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_oid4vppresentationsigner(UniffiCallbackInterfaceOid4vpPresentationSigner.vtablePtr)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_oid4vppresentationsigner(UniffiCallbackInterfaceOid4vpPresentationSigner.vtable)
 }
 
 // FfiConverter protocol for callback interfaces
@@ -32259,8 +32284,9 @@ fileprivate struct UniffiCallbackInterfacePresentationSigner {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // Store the vtable directly.
-    static let vtable: UniffiVTableCallbackInterfacePresentationSigner = UniffiVTableCallbackInterfacePresentationSigner(
+    // This creates 1-element array, since this seems to be the only way to construct a const
+    // pointer that we can pass to the Rust code.
+    static let vtable: [UniffiVTableCallbackInterfacePresentationSigner] = [UniffiVTableCallbackInterfacePresentationSigner(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterCallbackInterfacePresentationSigner.handleMap.remove(handle: uniffiHandle)
@@ -32446,19 +32472,11 @@ fileprivate struct UniffiCallbackInterfacePresentationSigner {
                 writeReturn: writeReturn
             )
         }
-    )
-
-    // Rust stores this pointer for future callback invocations, so it must live
-    // for the process lifetime (not just for the init function call).
-    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfacePresentationSigner> = {
-        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfacePresentationSigner>.allocate(capacity: 1)
-        ptr.initialize(to: vtable)
-        return UnsafePointer(ptr)
-    }()
+    )]
 }
 
 private func uniffiCallbackInitPresentationSigner() {
-    uniffi_mobile_sdk_rs_fn_init_callback_vtable_presentationsigner(UniffiCallbackInterfacePresentationSigner.vtablePtr)
+    uniffi_mobile_sdk_rs_fn_init_callback_vtable_presentationsigner(UniffiCallbackInterfacePresentationSigner.vtable)
 }
 
 // FfiConverter protocol for callback interfaces
@@ -36231,6 +36249,13 @@ public func initializeMdlPresentationFromBytes(mdoc: Mdoc, centralClientMode: Ce
     )
 })
 }
+public func deviceResponseVerificationAsJsonString(response: MdlDeviceResponseVerification)throws  -> String  {
+    return try  FfiConverterString.lift(try rustCallWithError(FfiConverterTypeMDLReaderResponseSerializeError_lift) {
+    uniffi_mobile_sdk_rs_fn_func_device_response_verification_as_json_string(
+        FfiConverterTypeMDLDeviceResponseVerification_lower(response),$0
+    )
+})
+}
 public func establishSession(handover: ReaderHandover, requestedItems: [String: [String: Bool]], trustAnchorRegistry: [String]?)throws  -> MdlReaderSessionData  {
     return try  FfiConverterTypeMDLReaderSessionData_lift(try rustCallWithError(FfiConverterTypeMDLReaderSessionError_lift) {
     uniffi_mobile_sdk_rs_fn_func_establish_session(
@@ -36263,6 +36288,40 @@ public func verifiedResponseAsJsonString(response: MdlReaderResponseData)throws 
     return try  FfiConverterString.lift(try rustCallWithError(FfiConverterTypeMDLReaderResponseSerializeError_lift) {
     uniffi_mobile_sdk_rs_fn_func_verified_response_as_json_string(
         FfiConverterTypeMDLReaderResponseData_lower(response),$0
+    )
+})
+}
+/**
+ * Parse and verify an ISO/IEC 18013-5 `DeviceResponse` using an externally-supplied
+ * `SessionTranscript`.
+ *
+ * Unlike [`handle_response`] — which relies on a reader [`MDLSessionManager`] that already holds
+ * the session transcript negotiated during BLE/NFC engagement (and first decrypts the transport
+ * `SessionData`) — this entry point is for flows where the platform provides the transcript and
+ * the device response directly. The motivating case is an iOS data transfer request (Digital
+ * Credentials API), where the OS hands back both the (already-decrypted) `DeviceResponse` and the
+ * session transcript it bound the exchange to.
+ *
+ * Arguments:
+ * * `device_response` — CBOR-encoded `DeviceResponse`.
+ * * `session_transcript` — CBOR-encoded `SessionTranscript` exactly as the holder authenticated
+ * over it (the bytes that occupy the `SessionTranscript` slot of `DeviceAuthentication`).
+ * * `trust_anchor_registry` — optional list of PEM-encoded IACA root certificates used for issuer
+ * authentication. When omitted (or empty) issuer authentication will not validate against any
+ * trusted root.
+ *
+ * Device authentication is verified via the COSE_Sign1 signature over the reconstructed
+ * `DeviceAuthentication` payload. MAC-based device authentication (ISO 18013-5 §9.1.3.5) requires
+ * the reader's ephemeral private key, which is not available in this flow, so it is not supported.
+ * Certificate revocation (CRL) checks are skipped, matching [`handle_response`].
+ */
+public func verifyDeviceResponse(deviceResponse: Data, sessionTranscript: Data, ephemeralReaderKey: Data, trustAnchorRegistry: [String]?)throws  -> MdlDeviceResponseVerification  {
+    return try  FfiConverterTypeMDLDeviceResponseVerification_lift(try rustCallWithError(FfiConverterTypeMDLReaderResponseError_lift) {
+    uniffi_mobile_sdk_rs_fn_func_verify_device_response(
+        FfiConverterData.lower(deviceResponse),
+        FfiConverterData.lower(sessionTranscript),
+        FfiConverterData.lower(ephemeralReaderKey),
+        FfiConverterOptionSequenceString.lower(trustAnchorRegistry),$0
     )
 })
 }
@@ -36535,6 +36594,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_func_initialize_mdl_presentation_from_bytes() != 43986) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_mobile_sdk_rs_checksum_func_device_response_verification_as_json_string() != 22202) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_mobile_sdk_rs_checksum_func_establish_session() != 7717) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -36545,6 +36607,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_func_verified_response_as_json_string() != 44695) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mobile_sdk_rs_checksum_func_verify_device_response() != 26654) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_func_generate_test_mdl() != 16030) {

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -36375,6 +36375,20 @@ public func verifiedResponseAsJsonString(response: MdlReaderResponseData)throws 
     )
 })
 }
+/**
+ * Verifies an mDL device response by using the session transcript and ephemeral
+ * reader key, and an optional trust anchor registry.
+ *
+ * Arguments:
+ * device_response: cbor encoded `isomdl::definitions::DeviceResponse`
+ * session_transcript: cbor encoded `isomdl::definitions::session::SessionTranscript`
+ * ephemeral_reader_key: 32-byte private key
+ * trust_anchor_registry: optional list of PEM encoded certificates
+ *
+ * Returns:
+ * An object with the verified response, document types, issuer authentication result,
+ * device authentication result, and an optional error string.
+ */
 public func verifyDeviceResponse(deviceResponse: Data, sessionTranscript: Data, ephemeralReaderKey: Data, trustAnchorRegistry: [String]?)throws  -> MdlDeviceResponseVerification  {
     return try  FfiConverterTypeMDLDeviceResponseVerification_lift(try rustCallWithError(FfiConverterTypeMDLReaderResponseError_lift) {
     uniffi_mobile_sdk_rs_fn_func_verify_device_response(
@@ -36669,7 +36683,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_func_verified_response_as_json_string() != 44695) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mobile_sdk_rs_checksum_func_verify_device_response() != 27348) {
+    if (uniffi_mobile_sdk_rs_checksum_func_verify_device_response() != 11409) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_func_generate_test_mdl() != 16030) {

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -36291,30 +36291,6 @@ public func verifiedResponseAsJsonString(response: MdlReaderResponseData)throws 
     )
 })
 }
-/**
- * Parse and verify an ISO/IEC 18013-5 `DeviceResponse` using an externally-supplied
- * `SessionTranscript`.
- *
- * Unlike [`handle_response`] — which relies on a reader [`MDLSessionManager`] that already holds
- * the session transcript negotiated during BLE/NFC engagement (and first decrypts the transport
- * `SessionData`) — this entry point is for flows where the platform provides the transcript and
- * the device response directly. The motivating case is an iOS data transfer request (Digital
- * Credentials API), where the OS hands back both the (already-decrypted) `DeviceResponse` and the
- * session transcript it bound the exchange to.
- *
- * Arguments:
- * * `device_response` — CBOR-encoded `DeviceResponse`.
- * * `session_transcript` — CBOR-encoded `SessionTranscript` exactly as the holder authenticated
- * over it (the bytes that occupy the `SessionTranscript` slot of `DeviceAuthentication`).
- * * `trust_anchor_registry` — optional list of PEM-encoded IACA root certificates used for issuer
- * authentication. When omitted (or empty) issuer authentication will not validate against any
- * trusted root.
- *
- * Device authentication is verified via the COSE_Sign1 signature over the reconstructed
- * `DeviceAuthentication` payload. MAC-based device authentication (ISO 18013-5 §9.1.3.5) requires
- * the reader's ephemeral private key, which is not available in this flow, so it is not supported.
- * Certificate revocation (CRL) checks are skipped, matching [`handle_response`].
- */
 public func verifyDeviceResponse(deviceResponse: Data, sessionTranscript: Data, ephemeralReaderKey: Data, trustAnchorRegistry: [String]?)throws  -> MdlDeviceResponseVerification  {
     return try  FfiConverterTypeMDLDeviceResponseVerification_lift(try rustCallWithError(FfiConverterTypeMDLReaderResponseError_lift) {
     uniffi_mobile_sdk_rs_fn_func_verify_device_response(
@@ -36609,7 +36585,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_func_verified_response_as_json_string() != 44695) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mobile_sdk_rs_checksum_func_verify_device_response() != 26654) {
+    if (uniffi_mobile_sdk_rs_checksum_func_verify_device_response() != 27348) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_func_generate_test_mdl() != 16030) {

--- a/rust/src/mdl/reader.rs
+++ b/rust/src/mdl/reader.rs
@@ -218,19 +218,10 @@ pub fn establish_session(
                 value: format!("Unable to build namespaces: {e:?}"),
             })?;
 
-    let registry = TrustAnchorRegistry::from_pem_certificates(
-        trust_anchor_registry
-            .into_iter()
-            .flat_map(|v| v.into_iter())
-            .map(|certificate_pem| PemTrustAnchor {
-                certificate_pem,
-                purpose: x509::trust_anchor::TrustPurpose::Iaca,
-            })
-            .collect(),
-    )
-    .map_err(|e| MDLReaderSessionError::Generic {
-        value: format!("unable to construct TrustAnchorRegistry: {e:?}"),
-    })?;
+    let registry =
+        build_registry(trust_anchor_registry).map_err(|e| MDLReaderSessionError::Generic {
+            value: format!("unable to construct TrustAnchorRegistry: {e:?}"),
+        })?;
 
     let (manager, request, ble_ident) =
         reader::SessionManager::establish_session(handover.0.clone(), namespaces, registry)
@@ -243,6 +234,23 @@ pub fn establish_session(
         request,
         ble_ident: ble_ident.to_vec(),
     })
+}
+
+fn build_registry(
+    trust_anchor_registry: Option<Vec<String>>,
+) -> Result<TrustAnchorRegistry, anyhow::Error> {
+    let registry = TrustAnchorRegistry::from_pem_certificates(
+        trust_anchor_registry
+            .into_iter()
+            .flat_map(|v| v.into_iter())
+            .map(|certificate_pem| PemTrustAnchor {
+                certificate_pem,
+                purpose: x509::trust_anchor::TrustPurpose::Iaca,
+            })
+            .collect(),
+    )?;
+
+    Ok(registry)
 }
 
 #[derive(thiserror::Error, uniffi::Error, Debug, PartialEq)]
@@ -487,6 +495,18 @@ pub fn device_response_verification_as_json_string(
     })
 }
 
+/// Verifies an mDL device response by using the session transcript and ephemeral
+/// reader key, and an optional trust anchor registry.
+///
+/// Arguments:
+/// device_response: cbor encoded `isomdl::definitions::DeviceResponse`
+/// session_transcript: cbor encoded `isomdl::definitions::session::SessionTranscript`
+/// ephemeral_reader_key: 32-byte private key
+/// trust_anchor_registry: optional list of PEM encoded certificates
+///
+/// Returns:
+/// An object with the verified response, document types, issuer authentication result,
+/// device authentication result, and an optional error string.
 #[uniffi::export]
 pub fn verify_device_response(
     device_response: Vec<u8>,
@@ -507,23 +527,15 @@ pub fn verify_device_response(
         })?;
     let session_transcript = ProvidedSessionTranscript(session_transcript);
 
-    let registry = TrustAnchorRegistry::from_pem_certificates(
-        trust_anchor_registry
-            .into_iter()
-            .flatten()
-            .map(|certificate_pem| PemTrustAnchor {
-                certificate_pem,
-                purpose: x509::trust_anchor::TrustPurpose::Iaca,
-            })
-            .collect(),
-    )
-    .map_err(|e| MDLReaderResponseError::Generic {
-        value: format!("unable to construct TrustAnchorRegistry: {e:?}"),
-    })?;
+    let registry =
+        build_registry(trust_anchor_registry).map_err(|e| MDLReaderResponseError::Generic {
+            value: format!("unable to construct TrustAnchorRegistry: {e:?}"),
+        })?;
 
+    // Tries to parse and verify an mDL among the document responses.
     let (document, x5chain, namespaces) =
         reader::parse(&device_response).map_err(|e| MDLReaderResponseError::Generic {
-            value: format!("unable to parse device response: {e:?}"),
+            value: format!("unable to obtain mDL from device response: {e:?}"),
         })?;
 
     let doc_types: Vec<String> = device_response
@@ -544,11 +556,14 @@ pub fn verify_device_response(
             if ephemeral_reader_key.is_empty() {
                 [0u8; 32]
             } else {
-                ephemeral_reader_key
-                    .try_into()
-                    .map_err(|e| MDLReaderResponseError::Generic {
-                        value: format!("unable to parse ephemeral_reader_key: {e:?}"),
-                    })?
+                ephemeral_reader_key.try_into().map_err(|e: Vec<u8>| {
+                    MDLReaderResponseError::Generic {
+                        value: format!(
+                            "unable to parse ephemeral_reader_key: expected 32 bytes, got {}",
+                            e.len()
+                        ),
+                    }
+                })?
             },
         ));
 

--- a/rust/src/mdl/reader.rs
+++ b/rust/src/mdl/reader.rs
@@ -15,6 +15,7 @@ use isomdl::{
     },
     presentation::{authentication::AuthenticationStatus as IsoMdlAuthenticationStatus, reader},
 };
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 #[derive(uniffi::Record)]
@@ -346,24 +347,30 @@ pub enum MDLReaderResponseSerializeError {
     Generic { value: String },
 }
 
+fn verified_response_to_json(
+    verified_response: &HashMap<String, HashMap<String, MDocItem>>,
+) -> Result<serde_json::Value, MDLReaderResponseSerializeError> {
+    serde_json::to_value(
+        verified_response
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.clone(),
+                    v.iter().map(|(k, v)| (k.clone(), v.into())).collect(),
+                )
+            })
+            .collect::<HashMap<String, HashMap<String, serde_json::Value>>>(),
+    )
+    .map_err(|e| MDLReaderResponseSerializeError::Generic {
+        value: e.to_string(),
+    })
+}
+
 impl MDLReaderResponseData {
     pub fn verified_response_as_json(
         &self,
     ) -> Result<serde_json::Value, MDLReaderResponseSerializeError> {
-        serde_json::to_value(
-            self.verified_response
-                .iter()
-                .map(|(k, v)| {
-                    (
-                        k.clone(),
-                        v.iter().map(|(k, v)| (k.clone(), v.into())).collect(),
-                    )
-                })
-                .collect::<HashMap<String, HashMap<String, serde_json::Value>>>(),
-        )
-        .map_err(|e| MDLReaderResponseSerializeError::Generic {
-            value: e.to_string(),
-        })
+        verified_response_to_json(&self.verified_response)
     }
 }
 
@@ -378,15 +385,9 @@ pub fn verified_response_as_json_string(
     })
 }
 
-#[uniffi::export]
-pub fn handle_response(
-    state: Arc<MDLSessionManager>,
-    response: Vec<u8>,
-) -> Result<MDLReaderResponseData, MDLReaderResponseError> {
-    let mut state = state.0.clone();
-    // blocking to avoid turning all functions async as revocation checks are currently unused due
-    // to `()`
-    let validated_response = super::block_on(state.handle_response(&response, &()));
+fn verified_namespaces_and_errors(
+    validated_response: &isomdl::presentation::authentication::ResponseAuthenticationOutcome,
+) -> Result<(HashMap<String, HashMap<String, MDocItem>>, Option<String>), MDLReaderResponseError> {
     let errors = if !validated_response.errors.is_empty() {
         Some(
             serde_json::to_string(&validated_response.errors).map_err(|e| {
@@ -400,7 +401,7 @@ pub fn handle_response(
     };
     let verified_response: Result<_, _> = validated_response
         .response
-        .into_iter()
+        .iter()
         .map(|(namespace, items)| {
             if let Some(items) = items.as_object() {
                 let items = items
@@ -418,6 +419,19 @@ pub fn handle_response(
     let verified_response = verified_response.map_err(|e| MDLReaderResponseError::Generic {
         value: format!("Unable to parse response: {e:?}"),
     })?;
+    Ok((verified_response, errors))
+}
+
+#[uniffi::export]
+pub fn handle_response(
+    state: Arc<MDLSessionManager>,
+    response: Vec<u8>,
+) -> Result<MDLReaderResponseData, MDLReaderResponseError> {
+    let mut state = state.0.clone();
+    // blocking to avoid turning all functions async as revocation checks are currently unused due
+    // to `()`
+    let validated_response = super::block_on(state.handle_response(&response, &()));
+    let (verified_response, errors) = verified_namespaces_and_errors(&validated_response)?;
     Ok(MDLReaderResponseData {
         state: Arc::new(MDLSessionManager(state)),
         verified_response,
@@ -426,4 +440,161 @@ pub fn handle_response(
         device_authentication: AuthenticationStatus::from(validated_response.device_authentication),
         errors,
     })
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct ProvidedSessionTranscript(ciborium::Value);
+
+impl isomdl::definitions::session::SessionTranscript for ProvidedSessionTranscript {}
+
+/// The result of verifying a `DeviceResponse` against an externally-supplied session transcript.
+///
+/// Mirrors [`MDLReaderResponseData`] but carries no reader [`MDLSessionManager`], since the
+/// transcript is provided directly rather than established during BLE/NFC engagement.
+#[derive(uniffi::Record, Debug)]
+pub struct MDLDeviceResponseVerification {
+    /// Contains the namespaces for the mDL directly, without top-level doc types.
+    verified_response: HashMap<String, HashMap<String, MDocItem>>,
+    /// Document types (doctypes) from the presented credentials.
+    pub doc_types: Vec<String>,
+    /// Outcome of issuer authentication.
+    pub issuer_authentication: AuthenticationStatus,
+    /// Outcome of device authentication.
+    pub device_authentication: AuthenticationStatus,
+    /// Errors that occurred during response processing.
+    pub errors: Option<String>,
+}
+
+impl MDLDeviceResponseVerification {
+    pub fn verified_response_as_json(
+        &self,
+    ) -> Result<serde_json::Value, MDLReaderResponseSerializeError> {
+        verified_response_to_json(&self.verified_response)
+    }
+}
+
+#[uniffi::export]
+pub fn device_response_verification_as_json_string(
+    response: MDLDeviceResponseVerification,
+) -> Result<String, MDLReaderResponseSerializeError> {
+    serde_json::to_string(&response.verified_response_as_json()?).map_err(|e| {
+        MDLReaderResponseSerializeError::Generic {
+            value: e.to_string(),
+        }
+    })
+}
+
+#[uniffi::export]
+pub fn verify_device_response(
+    device_response: Vec<u8>,
+    session_transcript: Vec<u8>,
+    ephemeral_reader_key: Vec<u8>,
+    trust_anchor_registry: Option<Vec<String>>,
+) -> Result<MDLDeviceResponseVerification, MDLReaderResponseError> {
+    let device_response: isomdl::definitions::DeviceResponse =
+        isomdl::cbor::from_slice(&device_response).map_err(|e| {
+            MDLReaderResponseError::Generic {
+                value: format!("unable to decode device response: {e:?}"),
+            }
+        })?;
+
+    let session_transcript: ciborium::Value = isomdl::cbor::from_slice(&session_transcript)
+        .map_err(|e| MDLReaderResponseError::Generic {
+            value: format!("unable to decode session transcript: {e:?}"),
+        })?;
+    let session_transcript = ProvidedSessionTranscript(session_transcript);
+
+    let registry = TrustAnchorRegistry::from_pem_certificates(
+        trust_anchor_registry
+            .into_iter()
+            .flatten()
+            .map(|certificate_pem| PemTrustAnchor {
+                certificate_pem,
+                purpose: x509::trust_anchor::TrustPurpose::Iaca,
+            })
+            .collect(),
+    )
+    .map_err(|e| MDLReaderResponseError::Generic {
+        value: format!("unable to construct TrustAnchorRegistry: {e:?}"),
+    })?;
+
+    let (document, x5chain, namespaces) =
+        reader::parse(&device_response).map_err(|e| MDLReaderResponseError::Generic {
+            value: format!("unable to parse device response: {e:?}"),
+        })?;
+
+    let doc_types: Vec<String> = device_response
+        .documents
+        .as_ref()
+        .map(|docs| docs.iter().map(|d| d.doc_type.clone()).collect())
+        .unwrap_or_default();
+
+    let validated_response =
+        super::block_on(isomdl::presentation::reader_utils::validate_response(
+            session_transcript,
+            registry,
+            x5chain,
+            document.clone(),
+            namespaces,
+            doc_types,
+            &(),
+            if ephemeral_reader_key.is_empty() {
+                [0u8; 32]
+            } else {
+                ephemeral_reader_key
+                    .try_into()
+                    .map_err(|e| MDLReaderResponseError::Generic {
+                        value: format!("unable to parse ephemeral_reader_key: {e:?}"),
+                    })?
+            },
+        ));
+
+    let (verified_response, errors) = verified_namespaces_and_errors(&validated_response)?;
+    Ok(MDLDeviceResponseVerification {
+        verified_response,
+        doc_types: validated_response.doc_types,
+        issuer_authentication: AuthenticationStatus::from(validated_response.issuer_authentication),
+        device_authentication: AuthenticationStatus::from(validated_response.device_authentication),
+        errors,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Device authentication verifies a signature over a `DeviceAuthentication` structure that
+    /// embeds the `SessionTranscript`. For verification to succeed against an externally-supplied
+    /// transcript, [`ProvidedSessionTranscript`] must re-encode it byte-for-byte — so a transparent
+    /// decode/encode round-trip of deterministic CBOR must be the identity.
+    #[test]
+    fn provided_session_transcript_roundtrips_cbor_verbatim() {
+        // A representative, deterministically-encoded session-transcript-shaped value:
+        // a 3-element array of [ #6.24(bstr), {1: 2}, "QR" ].
+        let bytes: Vec<u8> = vec![
+            0x83, // array(3)
+            0xd8, 0x18, 0x43, 0x01, 0x02, 0x03, // 24(h'010203')
+            0xa1, 0x01, 0x02, // map: {1: 2}
+            0x62, 0x51, 0x52, // text: "QR"
+        ];
+
+        let transcript: ProvidedSessionTranscript =
+            isomdl::cbor::from_slice(&bytes).expect("decode session transcript");
+        let reencoded = isomdl::cbor::to_vec(&transcript).expect("encode session transcript");
+
+        assert_eq!(
+            bytes, reencoded,
+            "session transcript must round-trip byte-for-byte"
+        );
+    }
+
+    /// An invalid CBOR device response surfaces as an error rather than panicking.
+    #[test]
+    fn verify_device_response_rejects_malformed_cbor() {
+        let result = verify_device_response(vec![0xff, 0xff, 0xff], vec![0x80], vec![], None);
+        assert!(matches!(
+            result,
+            Err(MDLReaderResponseError::Generic { .. })
+        ));
+    }
 }

--- a/rust/src/mdl/reader.rs
+++ b/rust/src/mdl/reader.rs
@@ -385,9 +385,12 @@ pub fn verified_response_as_json_string(
     })
 }
 
+type VerifiedNamespaces = HashMap<String, HashMap<String, MDocItem>>;
+type VerifiedNamespacesAndErrors = (VerifiedNamespaces, Option<String>);
+
 fn verified_namespaces_and_errors(
     validated_response: &isomdl::presentation::authentication::ResponseAuthenticationOutcome,
-) -> Result<(HashMap<String, HashMap<String, MDocItem>>, Option<String>), MDLReaderResponseError> {
+) -> Result<VerifiedNamespacesAndErrors, MDLReaderResponseError> {
     let errors = if !validated_response.errors.is_empty() {
         Some(
             serde_json::to_string(&validated_response.errors).map_err(|e| {


### PR DESCRIPTION
## Description

Adds `verify_device_response` for Apple ID Verify RawData requests, the iOS framework returns `device_response`, `session_transcript` and `ephemeral_reader_key` (>=26.4), and the current code only handles verification and decoding of a `device_response` when it's negotiated and obtained through the `MDLSessionManager`.
