### PR TITLE
ACC-1410: Support multi-credential OID4VCI offers in iOS and Android Showcase

### DIFF
--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/AddToWalletView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/AddToWalletView.kt
@@ -178,7 +178,9 @@ fun AddToWalletView(
             Box(Modifier.weight(1f)) {
                 HorizontalPager(
                     state = pagerState,
-                    userScrollEnabled = false,
+                    // Swiping back to an already-decided step is safe: the
+                    // button bar below only renders for undecided, parsed
+                    // steps, guarded by `decidedIndices`.
                     modifier = Modifier.fillMaxSize()
                 ) { page ->
                     when (val step = stepItems[page]) {

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/AddToWalletView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/AddToWalletView.kt
@@ -4,10 +4,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -153,13 +156,25 @@ fun AddToWalletView(
             loadingText = "Storing credential..."
         )
     } else if (stepItems.isNotEmpty()) {
-        Column {
-            StepProgressView(current = pagerState.currentPage, total = stepItems.size)
+        val currentStep = stepItems[pagerState.currentPage]
 
-            // `weight(1f)` claims the space remaining after StepProgressView;
-            // a bare `fillMaxSize()` here would claim the whole Column's
-            // height on top of that, overflowing the screen and clipping the
-            // credential card's content.
+        // The app draws edge-to-edge (see MainActivity's enableEdgeToEdge()),
+        // so this screen has to claim the system bar insets itself, or the
+        // stepper/card content render underneath the status bar and the
+        // bottom button bar underneath the navigation bar.
+        Column(
+            Modifier
+                .fillMaxSize()
+                .statusBarsPadding()
+                .navigationBarsPadding()
+        ) {
+            StepProgressView(current = pagerState.currentPage, total = stepItems.size)
+            Spacer(Modifier.height(12.dp))
+
+            // `weight(1f)` claims the space remaining after StepProgressView
+            // and the bottom button bar; a bare `fillMaxSize()` here would
+            // claim the whole Column's height on top of that, overflowing
+            // the screen and clipping the credential card's content.
             Box(Modifier.weight(1f)) {
                 HorizontalPager(
                     state = pagerState,
@@ -182,48 +197,64 @@ fun AddToWalletView(
                             // internally, which requires a bounded-height parent.
                             // Scrollable columns give unbounded height, which
                             // collapses that weighted body to zero height.
-                            step.item.CredentialReviewInfo(footerActions = {
-                                Button(
-                                    onClick = {
-                                        acceptCurrent()
-                                    },
-                                    shape = RoundedCornerShape(5.dp),
-                                    colors = ButtonDefaults.buttonColors(
-                                        containerColor = ColorEmerald700,
-                                        contentColor = Color.White,
-                                    ),
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                ) {
-                                    Text(
-                                        text = "Add to Wallet",
-                                        fontFamily = Inter,
-                                        fontWeight = FontWeight.SemiBold,
-                                        color = Color.White,
-                                    )
-                                }
-
-                                Button(
-                                    onClick = {
-                                        declineCurrent()
-                                    },
-                                    shape = RoundedCornerShape(5.dp),
-                                    colors = ButtonDefaults.buttonColors(
-                                        containerColor = Color.Transparent,
-                                        contentColor = ColorRose600,
-                                    ),
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                ) {
-                                    Text(
-                                        text = "Decline",
-                                        fontFamily = Inter,
-                                        fontWeight = FontWeight.SemiBold,
-                                        color = ColorRose600,
-                                    )
-                                }
-                            })
+                            // fillMaxSize() + the Column's default top
+                            // arrangement keeps the card's content anchored
+                            // to the top of the page instead of centered.
+                            Column(Modifier.fillMaxSize()) {
+                                step.item.CredentialReviewInfo(footerActions = {})
+                            }
                         }
+                    }
+                }
+            }
+
+            // A fixed bottom bar, independent of the pager's content, so the
+            // buttons don't move around with cards of different lengths —
+            // matches the iOS layout. Only shown for a not-yet-decided,
+            // successfully parsed step; a failed step only offers ErrorView's
+            // own "Skip" action.
+            if (currentStep is CredentialStepItem.Parsed &&
+                !decidedIndices.contains(pagerState.currentPage)
+            ) {
+                Column(Modifier.padding(horizontal = 20.dp, vertical = 12.dp)) {
+                    Button(
+                        onClick = {
+                            acceptCurrent()
+                        },
+                        shape = RoundedCornerShape(5.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = ColorEmerald700,
+                            contentColor = Color.White,
+                        ),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                    ) {
+                        Text(
+                            text = "Add to Wallet",
+                            fontFamily = Inter,
+                            fontWeight = FontWeight.SemiBold,
+                            color = Color.White,
+                        )
+                    }
+
+                    Button(
+                        onClick = {
+                            declineCurrent()
+                        },
+                        shape = RoundedCornerShape(5.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Color.Transparent,
+                            contentColor = ColorRose600,
+                        ),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                    ) {
+                        Text(
+                            text = "Decline",
+                            fontFamily = Inter,
+                            fontWeight = FontWeight.SemiBold,
+                            color = ColorRose600,
+                        )
                     }
                 }
             }

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/AddToWalletView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/AddToWalletView.kt
@@ -1,7 +1,15 @@
 package com.spruceid.mobilesdkexample.credentials
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -11,6 +19,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -26,9 +35,12 @@ import com.spruceid.mobilesdkexample.ErrorView
 import com.spruceid.mobilesdkexample.LoadingView
 import com.spruceid.mobilesdkexample.db.WalletActivityLogs
 import com.spruceid.mobilesdkexample.navigation.Screen
+import com.spruceid.mobilesdkexample.ui.theme.ColorBase150
 import com.spruceid.mobilesdkexample.ui.theme.ColorEmerald700
 import com.spruceid.mobilesdkexample.ui.theme.ColorRose600
+import com.spruceid.mobilesdkexample.ui.theme.ColorStone950
 import com.spruceid.mobilesdkexample.ui.theme.Inter
+import com.spruceid.mobilesdkexample.utils.Toast
 import com.spruceid.mobilesdkexample.utils.activityHiltViewModel
 import com.spruceid.mobilesdkexample.utils.credentialDisplaySelector
 import com.spruceid.mobilesdkexample.utils.getCredentialIdTitleAndIssuer
@@ -36,9 +48,17 @@ import com.spruceid.mobilesdkexample.utils.getCurrentSqlDate
 import com.spruceid.mobilesdkexample.viewmodels.CredentialPacksViewModel
 import com.spruceid.mobilesdkexample.viewmodels.StatusListViewModel
 import com.spruceid.mobilesdkexample.viewmodels.WalletActivityLogsViewModel
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
+
+/**
+ * A single step in the acceptance flow: either the credential parsed
+ * successfully and is ready to review, or it didn't and the step can only
+ * be skipped.
+ */
+sealed class CredentialStepItem {
+    data class Parsed(val item: ICredentialView) : CredentialStepItem()
+    data class Failed(val message: String) : CredentialStepItem()
+}
 
 @Composable
 fun AddToWalletView(
@@ -49,127 +69,192 @@ fun AddToWalletView(
     val credentialPacksViewModel: CredentialPacksViewModel = activityHiltViewModel()
     val walletActivityLogsViewModel: WalletActivityLogsViewModel = activityHiltViewModel()
     val statusListViewModel: StatusListViewModel = activityHiltViewModel()
-    var credentialItems by remember { mutableStateOf<List<ICredentialView>>(emptyList()) }
-    var err by remember { mutableStateOf<String?>(null) }
+    var stepItems by remember { mutableStateOf<List<CredentialStepItem>>(emptyList()) }
+    var acceptedCount by remember { mutableIntStateOf(0) }
     var storing by remember { mutableStateOf(false) }
+    // Swiping the pager back to an already-decided step shouldn't let the
+    // user accept/decline it again.
+    var decidedIndices by remember { mutableStateOf<Set<Int>>(emptySet()) }
 
     val scope = rememberCoroutineScope()
+    val pagerState = rememberPagerState(initialPage = 0, pageCount = { stepItems.size })
 
     LaunchedEffect(Unit) {
-        credentialItems = rawCredentials.map { rawCredential ->
-            credentialDisplaySelector(rawCredential, statusListViewModel, null, null, null)
+        stepItems = rawCredentials.map { rawCredential ->
+            try {
+                CredentialStepItem.Parsed(
+                    credentialDisplaySelector(rawCredential, statusListViewModel, null, null, null)
+                )
+            } catch (e: Exception) {
+                CredentialStepItem.Failed(e.localizedMessage ?: "Unable to parse credential")
+            }
+        }
+        if (stepItems.isEmpty()) {
+            navController.navigate(Screen.HomeScreen.route) { popUpTo(0) }
         }
     }
 
-    fun back() {
-        navController.navigate(Screen.HomeScreen.route) {
-            popUpTo(0)
+    // Advances past the current step, or finishes the whole flow if this was
+    // the last one. Accept and decline are independent per-credential
+    // actions: declining one credential has no effect on the others.
+    fun advance() {
+        val currentIndex = pagerState.currentPage
+        if (currentIndex + 1 >= stepItems.size) {
+            Toast.showSuccess("$acceptedCount of ${stepItems.size} credentials accepted")
+            onSuccess?.invoke()
+            navController.navigate(Screen.HomeScreen.route) { popUpTo(0) }
+        } else {
+            scope.launch {
+                pagerState.animateScrollToPage(currentIndex + 1)
+            }
         }
     }
 
-    fun saveCredential() {
+    fun acceptCurrent() {
+        val currentIndex = pagerState.currentPage
+        if (decidedIndices.contains(currentIndex)) return
+        decidedIndices = decidedIndices + currentIndex
+        val rawCredential = rawCredentials[currentIndex]
         scope.launch {
             storing = true
-            var error: String? = null
-            this.async(Dispatchers.Default) {
-                try {
-                    // Parse every credential before persisting any of them, so a
-                    // single unparseable credential can't leave the wallet with a
-                    // partially-saved batch.
-                    val credentialPacks = rawCredentials.map { rawCredential ->
-                        val credentialPack = CredentialPack()
-                        credentialPack.tryAddAnyFormat(rawCredential, DEFAULT_SIGNING_KEY_ID)
-                        credentialPack
-                    }
-
-                    for (credentialPack in credentialPacks) {
-                        credentialPacksViewModel.saveCredentialPack(credentialPack)
-                        val credentialInfo = getCredentialIdTitleAndIssuer(credentialPack)
-                        walletActivityLogsViewModel.saveWalletActivityLog(
-                            walletActivityLogs = WalletActivityLogs(
-                                credentialPackId = credentialPack.id().toString(),
-                                credentialId = credentialInfo.first,
-                                credentialTitle = credentialInfo.second,
-                                issuer = credentialInfo.third,
-                                action = "Claimed",
-                                dateTime = getCurrentSqlDate(),
-                                additionalInformation = ""
-                            )
-                        )
-                    }
-                } catch (e: Exception) {
-                    error = e.localizedMessage
-                }
-            }.await()
-            if (error == null) {
-                onSuccess?.invoke()
-                back()
-            } else {
-                err = error
-                storing = false
+            try {
+                val credentialPack = CredentialPack()
+                credentialPack.tryAddAnyFormat(rawCredential, DEFAULT_SIGNING_KEY_ID)
+                credentialPacksViewModel.saveCredentialPack(credentialPack)
+                val credentialInfo = getCredentialIdTitleAndIssuer(credentialPack)
+                walletActivityLogsViewModel.saveWalletActivityLog(
+                    walletActivityLogs = WalletActivityLogs(
+                        credentialPackId = credentialPack.id().toString(),
+                        credentialId = credentialInfo.first,
+                        credentialTitle = credentialInfo.second,
+                        issuer = credentialInfo.third,
+                        action = "Claimed",
+                        dateTime = getCurrentSqlDate(),
+                        additionalInformation = ""
+                    )
+                )
+                acceptedCount += 1
+            } catch (e: Exception) {
+                // Treat a save failure like a decline for this credential
+                // rather than blocking the rest of the flow.
             }
+            storing = false
+            advance()
         }
     }
 
-    if (err != null) {
-        ErrorView(
-            errorTitle = "Error Adding Credential",
-            errorDetails = err!!,
-            onClose = {
-                back()
-            }
-        )
-    } else if (storing) {
+    fun declineCurrent() {
+        val currentIndex = pagerState.currentPage
+        if (decidedIndices.contains(currentIndex)) return
+        decidedIndices = decidedIndices + currentIndex
+        advance()
+    }
+
+    if (storing) {
         LoadingView(
             loadingText = "Storing credential..."
         )
-    } else if (credentialItems.isNotEmpty()) {
-        Column(Modifier.verticalScroll(rememberScrollState())) {
-            credentialItems.forEachIndexed { index, credentialItem ->
-                val isLast = index == credentialItems.lastIndex
-                credentialItem.CredentialReviewInfo(footerActions = {
-                    if (isLast) {
-                        Button(
-                            onClick = {
-                                saveCredential()
-                            },
-                            shape = RoundedCornerShape(5.dp),
-                            colors = ButtonDefaults.buttonColors(
-                                containerColor = ColorEmerald700,
-                                contentColor = Color.White,
-                            ),
-                            modifier = Modifier
-                                .fillMaxWidth()
-                        ) {
-                            Text(
-                                text = "Add to Wallet",
-                                fontFamily = Inter,
-                                fontWeight = FontWeight.SemiBold,
-                                color = Color.White,
-                            )
-                        }
+    } else if (stepItems.isNotEmpty()) {
+        Column {
+            StepProgressView(current = pagerState.currentPage, total = stepItems.size)
 
-                        Button(
-                            onClick = {
-                                back()
-                            },
-                            shape = RoundedCornerShape(5.dp),
-                            colors = ButtonDefaults.buttonColors(
-                                containerColor = Color.Transparent,
-                                contentColor = ColorRose600,
-                            ),
-                            modifier = Modifier
-                                .fillMaxWidth()
-                        ) {
-                            Text(
-                                text = "Close",
-                                fontFamily = Inter,
-                                fontWeight = FontWeight.SemiBold,
-                                color = ColorRose600,
-                            )
+            HorizontalPager(
+                state = pagerState,
+                userScrollEnabled = false,
+                modifier = Modifier.fillMaxSize()
+            ) { page ->
+                when (val step = stepItems[page]) {
+                    is CredentialStepItem.Failed -> {
+                        ErrorView(
+                            errorTitle = "Unable to Parse Credential",
+                            errorDetails = step.message,
+                            closeButtonLabel = "Skip",
+                            onClose = { declineCurrent() }
+                        )
+                    }
+
+                    is CredentialStepItem.Parsed -> {
+                        Column(Modifier.verticalScroll(rememberScrollState())) {
+                            step.item.CredentialReviewInfo(footerActions = {
+                                Button(
+                                    onClick = {
+                                        acceptCurrent()
+                                    },
+                                    shape = RoundedCornerShape(5.dp),
+                                    colors = ButtonDefaults.buttonColors(
+                                        containerColor = ColorEmerald700,
+                                        contentColor = Color.White,
+                                    ),
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                ) {
+                                    Text(
+                                        text = "Add to Wallet",
+                                        fontFamily = Inter,
+                                        fontWeight = FontWeight.SemiBold,
+                                        color = Color.White,
+                                    )
+                                }
+
+                                Button(
+                                    onClick = {
+                                        declineCurrent()
+                                    },
+                                    shape = RoundedCornerShape(5.dp),
+                                    colors = ButtonDefaults.buttonColors(
+                                        containerColor = Color.Transparent,
+                                        contentColor = ColorRose600,
+                                    ),
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                ) {
+                                    Text(
+                                        text = "Decline",
+                                        fontFamily = Inter,
+                                        fontWeight = FontWeight.SemiBold,
+                                        color = ColorRose600,
+                                    )
+                                }
+                            })
                         }
                     }
-                })
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Shows "Credential X of Y" plus a row of segments indicating progress
+ * through a multi-credential acceptance flow.
+ */
+@Composable
+fun StepProgressView(current: Int, total: Int) {
+    if (total > 1) {
+        Column(Modifier.padding(horizontal = 20.dp, vertical = 12.dp)) {
+            Text(
+                text = "Credential ${current + 1} of $total",
+                fontFamily = Inter,
+                fontWeight = FontWeight.Medium,
+                color = ColorStone950,
+            )
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+            ) {
+                for (idx in 0 until total) {
+                    Box(
+                        Modifier
+                            .weight(1f)
+                            .height(4.dp)
+                            .padding(end = if (idx == total - 1) 0.dp else 4.dp)
+                            .background(
+                                color = if (idx <= current) ColorEmerald700 else ColorBase150,
+                                shape = RoundedCornerShape(2.dp)
+                            )
+                    )
+                }
             }
         }
     }

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/AddToWalletView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/AddToWalletView.kt
@@ -10,9 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
@@ -158,23 +156,32 @@ fun AddToWalletView(
         Column {
             StepProgressView(current = pagerState.currentPage, total = stepItems.size)
 
-            HorizontalPager(
-                state = pagerState,
-                userScrollEnabled = false,
-                modifier = Modifier.fillMaxSize()
-            ) { page ->
-                when (val step = stepItems[page]) {
-                    is CredentialStepItem.Failed -> {
-                        ErrorView(
-                            errorTitle = "Unable to Parse Credential",
-                            errorDetails = step.message,
-                            closeButtonLabel = "Skip",
-                            onClose = { declineCurrent() }
-                        )
-                    }
+            // `weight(1f)` claims the space remaining after StepProgressView;
+            // a bare `fillMaxSize()` here would claim the whole Column's
+            // height on top of that, overflowing the screen and clipping the
+            // credential card's content.
+            Box(Modifier.weight(1f)) {
+                HorizontalPager(
+                    state = pagerState,
+                    userScrollEnabled = false,
+                    modifier = Modifier.fillMaxSize()
+                ) { page ->
+                    when (val step = stepItems[page]) {
+                        is CredentialStepItem.Failed -> {
+                            ErrorView(
+                                errorTitle = "Unable to Parse Credential",
+                                errorDetails = step.message,
+                                closeButtonLabel = "Skip",
+                                onClose = { declineCurrent() }
+                            )
+                        }
 
-                    is CredentialStepItem.Parsed -> {
-                        Column(Modifier.verticalScroll(rememberScrollState())) {
+                        is CredentialStepItem.Parsed -> {
+                            // No verticalScroll wrapper here: CredentialReviewInfo's
+                            // own body section uses Modifier.weight(1f, fill = false)
+                            // internally, which requires a bounded-height parent.
+                            // Scrollable columns give unbounded height, which
+                            // collapses that weighted body to zero height.
                             step.item.CredentialReviewInfo(footerActions = {
                                 Button(
                                     onClick = {

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/AddToWalletView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/AddToWalletView.kt
@@ -1,7 +1,10 @@
 package com.spruceid.mobilesdkexample.credentials
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
@@ -40,21 +43,22 @@ import kotlinx.coroutines.launch
 @Composable
 fun AddToWalletView(
     navController: NavHostController,
-    rawCredential: String,
+    rawCredentials: List<String>,
     onSuccess: (() -> Unit)? = null
 ) {
     val credentialPacksViewModel: CredentialPacksViewModel = activityHiltViewModel()
     val walletActivityLogsViewModel: WalletActivityLogsViewModel = activityHiltViewModel()
     val statusListViewModel: StatusListViewModel = activityHiltViewModel()
-    var credentialItem by remember { mutableStateOf<ICredentialView?>(null) }
+    var credentialItems by remember { mutableStateOf<List<ICredentialView>>(emptyList()) }
     var err by remember { mutableStateOf<String?>(null) }
     var storing by remember { mutableStateOf(false) }
 
     val scope = rememberCoroutineScope()
 
     LaunchedEffect(Unit) {
-        credentialItem =
+        credentialItems = rawCredentials.map { rawCredential ->
             credentialDisplaySelector(rawCredential, statusListViewModel, null, null, null)
+        }
     }
 
     fun back() {
@@ -69,24 +73,26 @@ fun AddToWalletView(
             var error: String? = null
             this.async(Dispatchers.Default) {
                 try {
-                    val credentialPack = CredentialPack()
+                    for (rawCredential in rawCredentials) {
+                        val credentialPack = CredentialPack()
 
-                    // Try add credential in any supported format
-                    credentialPack.tryAddAnyFormat(rawCredential, DEFAULT_SIGNING_KEY_ID)
+                        // Try add credential in any supported format
+                        credentialPack.tryAddAnyFormat(rawCredential, DEFAULT_SIGNING_KEY_ID)
 
-                    credentialPacksViewModel.saveCredentialPack(credentialPack)
-                    val credentialInfo = getCredentialIdTitleAndIssuer(credentialPack)
-                    walletActivityLogsViewModel.saveWalletActivityLog(
-                        walletActivityLogs = WalletActivityLogs(
-                            credentialPackId = credentialPack.id().toString(),
-                            credentialId = credentialInfo.first,
-                            credentialTitle = credentialInfo.second,
-                            issuer = credentialInfo.third,
-                            action = "Claimed",
-                            dateTime = getCurrentSqlDate(),
-                            additionalInformation = ""
+                        credentialPacksViewModel.saveCredentialPack(credentialPack)
+                        val credentialInfo = getCredentialIdTitleAndIssuer(credentialPack)
+                        walletActivityLogsViewModel.saveWalletActivityLog(
+                            walletActivityLogs = WalletActivityLogs(
+                                credentialPackId = credentialPack.id().toString(),
+                                credentialId = credentialInfo.first,
+                                credentialTitle = credentialInfo.second,
+                                issuer = credentialInfo.third,
+                                action = "Claimed",
+                                dateTime = getCurrentSqlDate(),
+                                additionalInformation = ""
+                            )
                         )
-                    )
+                    }
                 } catch (e: Exception) {
                     error = e.localizedMessage
                 }
@@ -113,47 +119,54 @@ fun AddToWalletView(
         LoadingView(
             loadingText = "Storing credential..."
         )
-    } else if (credentialItem != null) {
-        credentialItem!!.CredentialReviewInfo(footerActions = {
-            Button(
-                onClick = {
-                    saveCredential()
-                },
-                shape = RoundedCornerShape(5.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = ColorEmerald700,
-                    contentColor = Color.White,
-                ),
-                modifier = Modifier
-                    .fillMaxWidth()
-            ) {
-                Text(
-                    text = "Add to Wallet",
-                    fontFamily = Inter,
-                    fontWeight = FontWeight.SemiBold,
-                    color = Color.White,
-                )
-            }
+    } else if (credentialItems.isNotEmpty()) {
+        Column(Modifier.verticalScroll(rememberScrollState())) {
+            credentialItems.forEachIndexed { index, credentialItem ->
+                val isLast = index == credentialItems.lastIndex
+                credentialItem.CredentialReviewInfo(footerActions = {
+                    if (isLast) {
+                        Button(
+                            onClick = {
+                                saveCredential()
+                            },
+                            shape = RoundedCornerShape(5.dp),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = ColorEmerald700,
+                                contentColor = Color.White,
+                            ),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                        ) {
+                            Text(
+                                text = "Add to Wallet",
+                                fontFamily = Inter,
+                                fontWeight = FontWeight.SemiBold,
+                                color = Color.White,
+                            )
+                        }
 
-            Button(
-                onClick = {
-                    back()
-                },
-                shape = RoundedCornerShape(5.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = Color.Transparent,
-                    contentColor = ColorRose600,
-                ),
-                modifier = Modifier
-                    .fillMaxWidth()
-            ) {
-                Text(
-                    text = "Close",
-                    fontFamily = Inter,
-                    fontWeight = FontWeight.SemiBold,
-                    color = ColorRose600,
-                )
+                        Button(
+                            onClick = {
+                                back()
+                            },
+                            shape = RoundedCornerShape(5.dp),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = Color.Transparent,
+                                contentColor = ColorRose600,
+                            ),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                        ) {
+                            Text(
+                                text = "Close",
+                                fontFamily = Inter,
+                                fontWeight = FontWeight.SemiBold,
+                                color = ColorRose600,
+                            )
+                        }
+                    }
+                })
             }
-        })
+        }
     }
 }

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/AddToWalletView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/AddToWalletView.kt
@@ -95,19 +95,15 @@ fun AddToWalletView(
         }
     }
 
-    // Advances past the current step, or finishes the whole flow if this was
-    // the last one. Accept and decline are independent per-credential
-    // actions: declining one credential has no effect on the others.
-    fun advance() {
-        val currentIndex = pagerState.currentPage
-        if (currentIndex + 1 >= stepItems.size) {
+    // Finishes the whole flow once every credential has a decision,
+    // regardless of the order they were decided in. Until then, the user
+    // can freely swipe between offers and deciding one doesn't move them
+    // off the current page.
+    fun finishIfAllDecided() {
+        if (decidedIndices.size >= stepItems.size) {
             Toast.showSuccess("$acceptedCount of ${stepItems.size} credentials accepted")
             onSuccess?.invoke()
             navController.navigate(Screen.HomeScreen.route) { popUpTo(0) }
-        } else {
-            scope.launch {
-                pagerState.animateScrollToPage(currentIndex + 1)
-            }
         }
     }
 
@@ -140,7 +136,7 @@ fun AddToWalletView(
                 // rather than blocking the rest of the flow.
             }
             storing = false
-            advance()
+            finishIfAllDecided()
         }
     }
 
@@ -148,7 +144,7 @@ fun AddToWalletView(
         val currentIndex = pagerState.currentPage
         if (decidedIndices.contains(currentIndex)) return
         decidedIndices = decidedIndices + currentIndex
-        advance()
+        finishIfAllDecided()
     }
 
     if (storing) {

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/AddToWalletView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/AddToWalletView.kt
@@ -73,12 +73,16 @@ fun AddToWalletView(
             var error: String? = null
             this.async(Dispatchers.Default) {
                 try {
-                    for (rawCredential in rawCredentials) {
+                    // Parse every credential before persisting any of them, so a
+                    // single unparseable credential can't leave the wallet with a
+                    // partially-saved batch.
+                    val credentialPacks = rawCredentials.map { rawCredential ->
                         val credentialPack = CredentialPack()
-
-                        // Try add credential in any supported format
                         credentialPack.tryAddAnyFormat(rawCredential, DEFAULT_SIGNING_KEY_ID)
+                        credentialPack
+                    }
 
+                    for (credentialPack in credentialPacks) {
                         credentialPacksViewModel.saveCredentialPack(credentialPack)
                         val credentialInfo = getCredentialIdTitleAndIssuer(credentialPack)
                         walletActivityLogsViewModel.saveWalletActivityLog(

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/navigation/SetupNavGraph.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/navigation/SetupNavGraph.kt
@@ -143,7 +143,7 @@ fun SetupNavGraph(
             if (!rawCredential.isNullOrEmpty()) {
                 AddToWalletView(
                     navController,
-                    rawCredential
+                    listOf(rawCredential)
                 )
             } else {
                 navController.navigate(Screen.HomeScreen.route) {

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleOID4VCIView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleOID4VCIView.kt
@@ -126,7 +126,7 @@ fun HandleOID4VCIView(
                         httpClient, oid4vciClient, clientId, credentialIssuer, signer,
                         credentialToken, credentialOffer.credentialConfigurationIds()
                     )
-                    if (result != null) {
+                    if (result.isNotEmpty()) {
                         credentials = result
                     } else {
                         err = "Deferred credentials not supported"
@@ -162,7 +162,7 @@ fun HandleOID4VCIView(
                                 httpClient, oid4vciClient, clientId, credentialIssuer, signer,
                                 token, credentialOffer.credentialConfigurationIds()
                             )
-                            if (result != null) {
+                            if (result.isNotEmpty()) {
                                 credentials = result
                             } else {
                                 err = "Deferred credentials not supported"
@@ -218,7 +218,7 @@ fun HandleOID4VCIView(
                                 httpClient, oid4vciClient, clientId, credentialIssuer, signer,
                                 token, configIds
                             )
-                            if (result != null) {
+                            if (result.isNotEmpty()) {
                                 credentials = result
                             } else {
                                 err = "Deferred credentials not supported"
@@ -265,6 +265,8 @@ fun HandleOID4VCIView(
 
 // Exchanges every credential in the offer against the token, one request per
 // credential_configuration_id (each requires its own fresh nonce/proof).
+// Deferred credentials are skipped rather than aborting the whole batch, so
+// other credentials in the same offer still get issued.
 private suspend fun exchangeCredentials(
     httpClient: Oid4vciAsyncHttpClient,
     oid4vciClient: Oid4vciClient,
@@ -273,7 +275,7 @@ private suspend fun exchangeCredentials(
     signer: JwsSigner,
     credentialToken: CredentialToken,
     configIds: List<String>,
-): List<String>? {
+): List<String> {
     val results = mutableListOf<String>()
 
     for (configId in configIds) {
@@ -291,8 +293,7 @@ private suspend fun exchangeCredentials(
         Log.i("OID4VCI", "Exchanging Credential...")
         when (val response = oid4vciClient.exchangeCredential(httpClient, credentialToken, credentialId, proofs)) {
             is CredentialResponse.Deferred -> {
-                Log.i("OID4VCI", "Deferred credential received")
-                return null
+                Log.i("OID4VCI", "Deferred credential received, skipping")
             }
             is CredentialResponse.Immediate -> {
                 Log.i("OID4VCI", "Credential exchanged!")

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleOID4VCIView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleOID4VCIView.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.navigation.NavHostController
 import com.spruceid.mobile.sdk.KeyManager
 import com.spruceid.mobile.sdk.Oid4vciAsyncHttpClient
+import com.spruceid.mobile.sdk.rs.CredentialOrConfigurationId
 import com.spruceid.mobile.sdk.rs.CredentialResponse
 import com.spruceid.mobile.sdk.rs.CredentialToken
 import com.spruceid.mobile.sdk.rs.CredentialTokenState
@@ -51,7 +52,7 @@ fun HandleOID4VCIView(
 ) {
     var loading by remember { mutableStateOf(false) }
     var err by remember { mutableStateOf<String?>(null) }
-    var credential by remember { mutableStateOf<String?>(null) }
+    var credentials by remember { mutableStateOf<List<String>>(emptyList()) }
     val ctx = LocalContext.current
     val scope = rememberCoroutineScope()
     val callback =
@@ -67,6 +68,7 @@ fun HandleOID4VCIView(
     var hoistedClientId by remember { mutableStateOf<String?>(null) }
     var hoistedCredentialIssuer by remember { mutableStateOf<String?>(null) }
     var hoistedSigner by remember { mutableStateOf<JwsSigner?>(null) }
+    var hoistedConfigIds by remember { mutableStateOf<List<String>?>(null) }
 
     LaunchedEffect(Unit) {
         loading = true
@@ -113,15 +115,19 @@ fun HandleOID4VCIView(
             val credentialOffer = oid4vciClient.resolveOfferUrl(httpClient, offerUrl)
             val credentialIssuer = credentialOffer.credentialIssuer()
             hoistedCredentialIssuer = credentialIssuer
+            hoistedConfigIds = credentialOffer.credentialConfigurationIds()
             Log.i("OID4VCI", "Credential Offer resolver, with issuer: $credentialIssuer")
 
             when (val state = oid4vciClient.acceptOffer(httpClient, credentialOffer)) {
                 is CredentialTokenState.Ready -> {
                     Log.i("OID4VCI", "Credential ready to be exchanged")
                     val credentialToken = state.v1
-                    val result = exchangeCredential(httpClient, oid4vciClient, clientId, credentialIssuer, signer, credentialToken)
+                    val result = exchangeCredentials(
+                        httpClient, oid4vciClient, clientId, credentialIssuer, signer,
+                        credentialToken, credentialOffer.credentialConfigurationIds()
+                    )
                     if (result != null) {
-                        credential = result
+                        credentials = result
                     } else {
                         err = "Deferred credentials not supported"
                     }
@@ -152,9 +158,12 @@ fun HandleOID4VCIView(
                         codeParam.isNullOrEmpty() -> err = "Missing authorization code in callback"
                         else -> {
                             val token = waiting.proceed(httpClient, codeParam)
-                            val result = exchangeCredential(httpClient, oid4vciClient, clientId, credentialIssuer, signer, token)
+                            val result = exchangeCredentials(
+                                httpClient, oid4vciClient, clientId, credentialIssuer, signer,
+                                token, credentialOffer.credentialConfigurationIds()
+                            )
                             if (result != null) {
-                                credential = result
+                                credentials = result
                             } else {
                                 err = "Deferred credentials not supported"
                             }
@@ -202,11 +211,15 @@ fun HandleOID4VCIView(
                             val clientId = hoistedClientId ?: error("Client ID unavailable")
                             val credentialIssuer = hoistedCredentialIssuer ?: error("Credential issuer unavailable")
                             val signer = hoistedSigner ?: error("Signer unavailable")
+                            val configIds = hoistedConfigIds ?: error("Credential configuration ids unavailable")
 
                             val token = txCodeState.proceed(httpClient, pin)
-                            val result = exchangeCredential(httpClient, oid4vciClient, clientId, credentialIssuer, signer, token)
+                            val result = exchangeCredentials(
+                                httpClient, oid4vciClient, clientId, credentialIssuer, signer,
+                                token, configIds
+                            )
                             if (result != null) {
-                                credential = result
+                                credentials = result
                             } else {
                                 err = "Deferred credentials not supported"
                             }
@@ -236,10 +249,10 @@ fun HandleOID4VCIView(
             errorDetails = err!!,
             onClose = { navController.navigate(Screen.HomeScreen.route) { popUpTo(0) } }
         )
-    } else if (credential != null) {
+    } else if (credentials.isNotEmpty()) {
         AddToWalletView(
             navController = navController,
-            rawCredential = credential!!,
+            rawCredentials = credentials,
             onSuccess = {
                 scope.launch {
                     callback?.invoke()
@@ -250,37 +263,46 @@ fun HandleOID4VCIView(
     }
 }
 
-private suspend fun exchangeCredential(
+// Exchanges every credential in the offer against the token, one request per
+// credential_configuration_id (each requires its own fresh nonce/proof).
+private suspend fun exchangeCredentials(
     httpClient: Oid4vciAsyncHttpClient,
     oid4vciClient: Oid4vciClient,
     clientId: String,
     credentialIssuer: String,
     signer: JwsSigner,
     credentialToken: CredentialToken,
-): String? {
-    val credentialId = credentialToken.defaultCredentialId()
-    Log.i("OID4VCI", "Credential id: $credentialId")
+    configIds: List<String>,
+): List<String>? {
+    val results = mutableListOf<String>()
 
-    Log.i("OID4VCI", "Generating PoP...")
-    val nonce = credentialToken.getNonce(httpClient)
-    Log.i("OID4VCI", "Nonce: $nonce")
-    Log.i("OID4VCI", "Signing...")
-    val jwt = createJwtProof(clientId, credentialIssuer, null, nonce, signer)
-    Log.i("OID4VCI", "PoP JWT = $jwt")
-    val proofs = Proofs.Jwt(listOf(jwt))
+    for (configId in configIds) {
+        val credentialId = CredentialOrConfigurationId.Configuration(configId)
+        Log.i("OID4VCI", "Credential id: $credentialId")
 
-    Log.i("OID4VCI", "Exchanging Credential...")
-    return when (val response = oid4vciClient.exchangeCredential(httpClient, credentialToken, credentialId, proofs)) {
-        is CredentialResponse.Deferred -> {
-            Log.i("OID4VCI", "Deferred credential received")
-            null
-        }
-        is CredentialResponse.Immediate -> {
-            Log.i("OID4VCI", "Credential exchanged!")
-            val rawCredential = checkNotNull(response.v1.credentials.first()) { "Missing Credential" }
-            rawCredential.payload.toString(Charsets.UTF_8)
+        Log.i("OID4VCI", "Generating PoP...")
+        val nonce = credentialToken.getNonce(httpClient)
+        Log.i("OID4VCI", "Nonce: $nonce")
+        Log.i("OID4VCI", "Signing...")
+        val jwt = createJwtProof(clientId, credentialIssuer, null, nonce, signer)
+        Log.i("OID4VCI", "PoP JWT = $jwt")
+        val proofs = Proofs.Jwt(listOf(jwt))
+
+        Log.i("OID4VCI", "Exchanging Credential...")
+        when (val response = oid4vciClient.exchangeCredential(httpClient, credentialToken, credentialId, proofs)) {
+            is CredentialResponse.Deferred -> {
+                Log.i("OID4VCI", "Deferred credential received")
+                return null
+            }
+            is CredentialResponse.Immediate -> {
+                Log.i("OID4VCI", "Credential exchanged!")
+                val rawCredential = checkNotNull(response.v1.credentials.first()) { "Missing Credential" }
+                results.add(rawCredential.payload.toString(Charsets.UTF_8))
+            }
         }
     }
+
+    return results
 }
 
 fun getVCPlaygroundOID4VCIContext(ctx: Context): Map<String, String> {

--- a/ios/Showcase/Targets/AppUIKit/Sources/ContentView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/ContentView.swift
@@ -149,7 +149,7 @@ public struct ContentView: View {
                         addToWalletParams in
                         AddToWalletView(
                             path: $path,
-                            rawCredential: addToWalletParams.rawCredential
+                            rawCredentials: [addToWalletParams.rawCredential]
                         )
                     }
                     .navigationDestination(for: HandleOID4VCI.self) {

--- a/ios/Showcase/Targets/AppUIKit/Sources/credentials/AddToWalletView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/credentials/AddToWalletView.swift
@@ -45,22 +45,16 @@ struct AddToWalletView: View {
         AnyView(item.credentialReviewInfo())
     }
 
-    // Advances past the current step, or finishes the whole flow if this was
-    // the last one. Accept and decline are independent per-credential
-    // actions: declining one credential has no effect on the others.
-    func advance() {
-        if currentIndex + 1 >= stepItems.count {
+    // Finishes the whole flow once every credential has a decision,
+    // regardless of the order they were decided in. Until then, the user
+    // can freely swipe between offers and deciding one doesn't move them
+    // off the current page.
+    func finishIfAllDecided() {
+        if decidedIndices.count >= stepItems.count {
             ToastManager.shared.showSuccess(
                 message: "\(acceptedCount) of \(stepItems.count) credentials accepted"
             )
             back()
-        } else {
-            // `TabView(.page)` only slides on a selection change when that
-            // change happens inside `withAnimation` — a plain assignment
-            // jumps to the next page instantly.
-            withAnimation {
-                currentIndex += 1
-            }
         }
     }
 
@@ -98,13 +92,13 @@ struct AddToWalletView: View {
             print(error)
         }
         storing = false
-        advance()
+        finishIfAllDecided()
     }
 
     func declineCurrent() {
         guard !decidedIndices.contains(currentIndex) else { return }
         decidedIndices.insert(currentIndex)
-        advance()
+        finishIfAllDecided()
     }
 
     var body: some View {

--- a/ios/Showcase/Targets/AppUIKit/Sources/credentials/AddToWalletView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/credentials/AddToWalletView.swift
@@ -10,18 +10,16 @@ struct AddToWalletView: View {
     @EnvironmentObject private var credentialPackObservable:
         CredentialPackObservable
     @Binding var path: NavigationPath
-    var rawCredential: String
-    var credential: GenericJSON?
+    var rawCredentials: [String]
     @State var presentError: Bool
     @State var errorDetails: String
     @State var storing = false
 
-    @State var credentialItem: (any ICredentialView)?
+    @State var credentialItems: [any ICredentialView] = []
 
-    init(path: Binding<NavigationPath>, rawCredential: String) {
+    init(path: Binding<NavigationPath>, rawCredentials: [String]) {
         self._path = path
-        self.rawCredential = rawCredential
-        self.credentialItem = nil
+        self.rawCredentials = rawCredentials
         self.presentError = false
         self.errorDetails = ""
     }
@@ -35,26 +33,28 @@ struct AddToWalletView: View {
     func addToWallet() async {
         storing = true
         do {
-            let credentialPack = CredentialPack()
-            _ = try await credentialPack.tryAddAnyFormat(
-                rawCredential: rawCredential,
-                mdocKeyAlias: DEFAULT_SIGNING_KEY_ID
-            )
-            try await credentialPackObservable.add(
-                credentialPack: credentialPack
-            )
-            let credentialInfo = getCredentialIdTitleAndIssuer(
-                credentialPack: credentialPack
-            )
-            _ = WalletActivityLogDataStore.shared.insert(
-                credentialPackId: credentialPack.id.uuidString,
-                credentialId: credentialInfo.0,
-                credentialTitle: credentialInfo.1,
-                issuer: credentialInfo.2,
-                action: "Claimed",
-                dateTime: Date(),
-                additionalInformation: ""
-            )
+            for rawCredential in rawCredentials {
+                let credentialPack = CredentialPack()
+                _ = try await credentialPack.tryAddAnyFormat(
+                    rawCredential: rawCredential,
+                    mdocKeyAlias: DEFAULT_SIGNING_KEY_ID
+                )
+                try await credentialPackObservable.add(
+                    credentialPack: credentialPack
+                )
+                let credentialInfo = getCredentialIdTitleAndIssuer(
+                    credentialPack: credentialPack
+                )
+                _ = WalletActivityLogDataStore.shared.insert(
+                    credentialPackId: credentialPack.id.uuidString,
+                    credentialId: credentialInfo.0,
+                    credentialTitle: credentialInfo.1,
+                    issuer: credentialInfo.2,
+                    action: "Claimed",
+                    dateTime: Date(),
+                    additionalInformation: ""
+                )
+            }
             back()
         } catch {
             print(error)
@@ -77,9 +77,15 @@ struct AddToWalletView: View {
                 LoadingView(
                     loadingText: "Storing credential..."
                 )
-            } else if credentialItem != nil {
-                AnyView(credentialItem!.credentialReviewInfo())
-                    .padding(.bottom, 120)
+            } else if !credentialItems.isEmpty {
+                ScrollView {
+                    VStack {
+                        ForEach(0..<credentialItems.count, id: \.self) { idx in
+                            AnyView(credentialItems[idx].credentialReviewInfo())
+                        }
+                    }
+                }
+                .padding(.bottom, 120)
                 VStack {
                     Spacer()
                     Button {
@@ -125,9 +131,13 @@ struct AddToWalletView: View {
         .navigationBarBackButtonHidden(true)
         .task {
             do {
-                credentialItem = try await credentialDisplayerSelector(
-                    rawCredential: rawCredential
-                )
+                var items: [any ICredentialView] = []
+                for rawCredential in rawCredentials {
+                    items.append(try await credentialDisplayerSelector(
+                        rawCredential: rawCredential
+                    ))
+                }
+                credentialItems = items
             } catch {
                 print(error)
                 errorDetails = "Error: \(error)"
@@ -141,6 +151,6 @@ struct AddToWalletPreview: PreviewProvider {
     @State static var path: NavigationPath = .init()
 
     static var previews: some View {
-        AddToWalletView(path: $path, rawCredential: "")
+        AddToWalletView(path: $path, rawCredentials: [])
     }
 }

--- a/ios/Showcase/Targets/AppUIKit/Sources/credentials/AddToWalletView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/credentials/AddToWalletView.swift
@@ -30,6 +30,12 @@ struct AddToWalletView: View {
         }
     }
 
+    // Opens the `any ICredentialView` existential outside of a ViewBuilder
+    // context, since Swift can't open it implicitly inside a ForEach closure.
+    func reviewCard(for item: any ICredentialView) -> AnyView {
+        AnyView(item.credentialReviewInfo())
+    }
+
     func addToWallet() async {
         storing = true
         do {
@@ -81,7 +87,7 @@ struct AddToWalletView: View {
                 ScrollView {
                     VStack {
                         ForEach(0..<credentialItems.count, id: \.self) { idx in
-                            AnyView(credentialItems[idx].credentialReviewInfo())
+                            reviewCard(for: credentialItems[idx])
                         }
                     }
                 }

--- a/ios/Showcase/Targets/AppUIKit/Sources/credentials/AddToWalletView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/credentials/AddToWalletView.swift
@@ -55,7 +55,12 @@ struct AddToWalletView: View {
             )
             back()
         } else {
-            currentIndex += 1
+            // `TabView(.page)` only slides on a selection change when that
+            // change happens inside `withAnimation` — a plain assignment
+            // jumps to the next page instantly.
+            withAnimation {
+                currentIndex += 1
+            }
         }
     }
 

--- a/ios/Showcase/Targets/AppUIKit/Sources/credentials/AddToWalletView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/credentials/AddToWalletView.swift
@@ -6,22 +6,31 @@ struct AddToWallet: Hashable {
     var rawCredential: String
 }
 
+/// A single step in the acceptance flow: either the credential parsed
+/// successfully and is ready to review, or it didn't and the step can only
+/// be skipped.
+enum CredentialStepItem {
+    case parsed(any ICredentialView)
+    case failed(String)
+}
+
 struct AddToWalletView: View {
     @EnvironmentObject private var credentialPackObservable:
         CredentialPackObservable
     @Binding var path: NavigationPath
     var rawCredentials: [String]
-    @State var presentError: Bool
-    @State var errorDetails: String
     @State var storing = false
 
-    @State var credentialItems: [any ICredentialView] = []
+    @State var stepItems: [CredentialStepItem] = []
+    @State var currentIndex: Int = 0
+    @State var acceptedCount: Int = 0
+    // Swiping the TabView back to an already-decided step shouldn't let the
+    // user accept/decline it again.
+    @State var decidedIndices: Set<Int> = []
 
     init(path: Binding<NavigationPath>, rawCredentials: [String]) {
         self._path = path
         self.rawCredentials = rawCredentials
-        self.presentError = false
-        self.errorDetails = ""
     }
 
     func back() {
@@ -36,118 +45,187 @@ struct AddToWalletView: View {
         AnyView(item.credentialReviewInfo())
     }
 
-    func addToWallet() async {
+    // Advances past the current step, or finishes the whole flow if this was
+    // the last one. Accept and decline are independent per-credential
+    // actions: declining one credential has no effect on the others.
+    func advance() {
+        if currentIndex + 1 >= stepItems.count {
+            ToastManager.shared.showSuccess(
+                message: "\(acceptedCount) of \(stepItems.count) credentials accepted"
+            )
+            back()
+        } else {
+            currentIndex += 1
+        }
+    }
+
+    func acceptCurrent() async {
+        guard case .parsed = stepItems[currentIndex],
+              !decidedIndices.contains(currentIndex)
+        else { return }
+        decidedIndices.insert(currentIndex)
         storing = true
         do {
-            for rawCredential in rawCredentials {
-                let credentialPack = CredentialPack()
-                _ = try await credentialPack.tryAddAnyFormat(
-                    rawCredential: rawCredential,
-                    mdocKeyAlias: DEFAULT_SIGNING_KEY_ID
-                )
-                try await credentialPackObservable.add(
-                    credentialPack: credentialPack
-                )
-                let credentialInfo = getCredentialIdTitleAndIssuer(
-                    credentialPack: credentialPack
-                )
-                _ = WalletActivityLogDataStore.shared.insert(
-                    credentialPackId: credentialPack.id.uuidString,
-                    credentialId: credentialInfo.0,
-                    credentialTitle: credentialInfo.1,
-                    issuer: credentialInfo.2,
-                    action: "Claimed",
-                    dateTime: Date(),
-                    additionalInformation: ""
-                )
-            }
-            back()
+            let credentialPack = CredentialPack()
+            _ = try await credentialPack.tryAddAnyFormat(
+                rawCredential: rawCredentials[currentIndex],
+                mdocKeyAlias: DEFAULT_SIGNING_KEY_ID
+            )
+            try await credentialPackObservable.add(
+                credentialPack: credentialPack
+            )
+            let credentialInfo = getCredentialIdTitleAndIssuer(
+                credentialPack: credentialPack
+            )
+            _ = WalletActivityLogDataStore.shared.insert(
+                credentialPackId: credentialPack.id.uuidString,
+                credentialId: credentialInfo.0,
+                credentialTitle: credentialInfo.1,
+                issuer: credentialInfo.2,
+                action: "Claimed",
+                dateTime: Date(),
+                additionalInformation: ""
+            )
+            acceptedCount += 1
         } catch {
+            // Treat a save failure like a decline for this credential rather
+            // than blocking the rest of the flow.
             print(error)
-            errorDetails = "Error: \(error)"
-            presentError = true
         }
         storing = false
+        advance()
+    }
+
+    func declineCurrent() {
+        guard !decidedIndices.contains(currentIndex) else { return }
+        decidedIndices.insert(currentIndex)
+        advance()
     }
 
     var body: some View {
         ZStack {
-            if presentError {
-                ErrorView(
-                    errorTitle: "Unable to Parse Credential",
-                    errorDetails: errorDetails
-                ) {
-                    back()
-                }
-            } else if storing {
+            if storing {
                 LoadingView(
                     loadingText: "Storing credential..."
                 )
-            } else if !credentialItems.isEmpty {
-                ScrollView {
-                    VStack {
-                        ForEach(0..<credentialItems.count, id: \.self) { idx in
-                            reviewCard(for: credentialItems[idx])
+            } else if !stepItems.isEmpty {
+                let step = stepItems[currentIndex]
+
+                VStack(spacing: 0) {
+                    StepProgressView(current: currentIndex, total: stepItems.count)
+                        .padding(.top, 12)
+                        .padding(.horizontal, 20)
+
+                    TabView(selection: $currentIndex) {
+                        ForEach(Array(stepItems.enumerated()), id: \.offset) { index, item in
+                            Group {
+                                switch item {
+                                case .parsed(let credentialItem):
+                                    ScrollView {
+                                        reviewCard(for: credentialItem)
+                                    }
+                                    .padding(.bottom, 120)
+                                case .failed(let message):
+                                    ErrorView(
+                                        errorTitle: "Unable to Parse Credential",
+                                        errorDetails: message,
+                                        closeButtonLabel: "Skip"
+                                    ) {
+                                        declineCurrent()
+                                    }
+                                }
+                            }
+                            .tag(index)
                         }
                     }
+                    .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
                 }
-                .padding(.bottom, 120)
-                VStack {
-                    Spacer()
-                    Button {
-                        Task {
-                            await addToWallet()
+
+                if case .parsed = step, !decidedIndices.contains(currentIndex) {
+                    VStack {
+                        Spacer()
+                        Button {
+                            Task {
+                                await acceptCurrent()
+                            }
+                        } label: {
+                            Text("Add to Wallet")
+                                .frame(width: UIScreen.screenWidth)
+                                .padding(.horizontal, -20)
+                                .font(
+                                    .customFont(
+                                        font: .inter,
+                                        style: .medium,
+                                        size: .h4
+                                    )
+                                )
                         }
-                    } label: {
-                        Text("Add to Wallet")
-                            .frame(width: UIScreen.screenWidth)
-                            .padding(.horizontal, -20)
-                            .font(
-                                .customFont(
-                                    font: .inter,
-                                    style: .medium,
-                                    size: .h4
+                        .foregroundColor(.white)
+                        .padding(.vertical, 13)
+                        .background(Color("ColorEmerald700"))
+                        .cornerRadius(8)
+                        Button {
+                            declineCurrent()
+                        } label: {
+                            Text("Decline")
+                                .frame(width: UIScreen.screenWidth)
+                                .padding(.horizontal, -20)
+                                .font(
+                                    .customFont(
+                                        font: .inter,
+                                        style: .medium,
+                                        size: .h4
+                                    )
                                 )
-                            )
+                        }
+                        .foregroundColor(Color("ColorRose600"))
+                        .padding(.vertical, 13)
+                        .cornerRadius(8)
                     }
-                    .foregroundColor(.white)
-                    .padding(.vertical, 13)
-                    .background(Color("ColorEmerald700"))
-                    .cornerRadius(8)
-                    Button {
-                        back()
-                    } label: {
-                        Text("Decline")
-                            .frame(width: UIScreen.screenWidth)
-                            .padding(.horizontal, -20)
-                            .font(
-                                .customFont(
-                                    font: .inter,
-                                    style: .medium,
-                                    size: .h4
-                                )
-                            )
-                    }
-                    .foregroundColor(Color("ColorRose600"))
-                    .padding(.vertical, 13)
-                    .cornerRadius(8)
                 }
             }
         }
         .navigationBarBackButtonHidden(true)
         .task {
-            do {
-                var items: [any ICredentialView] = []
-                for rawCredential in rawCredentials {
-                    items.append(try await credentialDisplayerSelector(
+            var items: [CredentialStepItem] = []
+            for rawCredential in rawCredentials {
+                do {
+                    let item = try await credentialDisplayerSelector(
                         rawCredential: rawCredential
-                    ))
+                    )
+                    items.append(.parsed(item))
+                } catch {
+                    print(error)
+                    items.append(.failed("Error: \(error)"))
                 }
-                credentialItems = items
-            } catch {
-                print(error)
-                errorDetails = "Error: \(error)"
-                presentError = true
+            }
+            stepItems = items
+            if stepItems.isEmpty {
+                back()
+            }
+        }
+    }
+}
+
+/// Shows "Credential X of Y" plus a row of segments indicating progress
+/// through a multi-credential acceptance flow.
+struct StepProgressView: View {
+    let current: Int
+    let total: Int
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if total > 1 {
+                Text("Credential \(current + 1) of \(total)")
+                    .font(.customFont(font: .inter, style: .medium, size: .h4))
+                    .foregroundColor(Color("ColorStone950"))
+                HStack(spacing: 4) {
+                    ForEach(0..<total, id: \.self) { idx in
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(idx <= current ? Color("ColorEmerald700") : Color("ColorBase150"))
+                            .frame(height: 4)
+                    }
+                }
             }
         }
     }

--- a/ios/Showcase/Targets/AppUIKit/Sources/credentials/AddToWalletView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/credentials/AddToWalletView.swift
@@ -113,6 +113,7 @@ struct AddToWalletView: View {
                 VStack(spacing: 0) {
                     StepProgressView(current: currentIndex, total: stepItems.count)
                         .padding(.top, 12)
+                        .padding(.bottom, 12)
                         .padding(.horizontal, 20)
 
                     TabView(selection: $currentIndex) {

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleOID4VCIView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleOID4VCIView.swift
@@ -18,7 +18,7 @@ struct HandleOID4VCI: Hashable {
 struct HandleOID4VCIView: View {
     @State var loading: Bool = false
     @State var err: String?
-    @State var credential: String?
+    @State var credentials: [String] = []
     @State var credentialPack: CredentialPack?
 
     @State var showPinAlert: Bool = false
@@ -31,38 +31,47 @@ struct HandleOID4VCIView: View {
     @State var hoistedClientId: String?
     @State var hoistedCredentialIssuer: String?
     @State var hoistedSigner: JwsSigner?
+    @State var hoistedConfigIds: [String]?
 
     @Binding var path: NavigationPath
     let url: String
     let onSuccess: (() -> Void)?
 
+    // Exchanges every credential in the offer against the token, one request
+    // per credential_configuration_id (each requires its own fresh nonce/proof).
     func completeIssuance(
         token: CredentialToken,
         httpClient: Oid4vciAsyncHttpClient,
         oid4vciClient: Oid4vciClient,
         clientId: String,
         credentialIssuer: String,
-        signer: JwsSigner
-    ) async throws -> String? {
-        let credentialId = try token.defaultCredentialId()
+        signer: JwsSigner,
+        configIds: [String]
+    ) async throws -> [String]? {
+        var results: [String] = []
 
-        let nonce = try await token.getNonce(httpClient: httpClient)
-        let jwt = try await createJwtProof(issuer: clientId, audience: credentialIssuer, expireInSecs: nil, nonce: nonce, signer: signer)
-        let proofs = Proofs.jwt([jwt])
+        for configId in configIds {
+            let nonce = try await token.getNonce(httpClient: httpClient)
+            let jwt = try await createJwtProof(issuer: clientId, audience: credentialIssuer, expireInSecs: nil, nonce: nonce, signer: signer)
+            let proofs = Proofs.jwt([jwt])
 
-        let response = try await oid4vciClient.exchangeCredential(httpClient: httpClient, token: token, credential: credentialId, proofs: proofs)
+            let credentialId = CredentialOrConfigurationId.configuration(configId)
+            let response = try await oid4vciClient.exchangeCredential(httpClient: httpClient, token: token, credential: credentialId, proofs: proofs)
 
-        switch response {
-        case .deferred(_):
-            return nil
-        case .immediate(let immediate):
-            guard let rawCredential = immediate.credentials.first else {
-                throw NSError(domain: "OID4VCI", code: 0, userInfo: [
-                    "CredentialIssuer": credentialIssuer
-                ])
+            switch response {
+            case .deferred(_):
+                return nil
+            case .immediate(let immediate):
+                guard let rawCredential = immediate.credentials.first else {
+                    throw NSError(domain: "OID4VCI", code: 0, userInfo: [
+                        "CredentialIssuer": credentialIssuer
+                    ])
+                }
+                results.append(String(decoding: Data(rawCredential.payload), as: UTF8.self))
             }
-            return String(decoding: Data(rawCredential.payload), as: UTF8.self)
         }
+
+        return results
     }
 
     func getCredential(credentialOffer: String) {
@@ -90,12 +99,14 @@ struct HandleOID4VCIView: View {
 
                 let credentialOffer = try await oid4vciClient.resolveOfferUrl(httpClient: httpClient, credentialOfferUrl: offerUrl)
                 let credentialIssuer = credentialOffer.credentialIssuer()
+                let configIds = credentialOffer.credentialConfigurationIds()
 
                 self.hoistedHttpClient = httpClient
                 self.hoistedOid4vciClient = oid4vciClient
                 self.hoistedClientId = clientId
                 self.hoistedCredentialIssuer = credentialIssuer
                 self.hoistedSigner = signer
+                self.hoistedConfigIds = configIds
 
                 let state = try await oid4vciClient.acceptOffer(httpClient: httpClient, credentialOffer: credentialOffer)
 
@@ -125,15 +136,16 @@ struct HandleOID4VCIView: View {
                             err = "Authorization error: \(errorParam)"
                         } else if let codeParam, !codeParam.isEmpty {
                             let token = try await waiting.proceed(httpClient: httpClient, authorizationCode: codeParam)
-                            if let cred = try await completeIssuance(
+                            if let creds = try await completeIssuance(
                                 token: token,
                                 httpClient: httpClient,
                                 oid4vciClient: oid4vciClient,
                                 clientId: clientId,
                                 credentialIssuer: credentialIssuer,
-                                signer: signer
+                                signer: signer,
+                                configIds: configIds
                             ) {
-                                credential = cred
+                                credentials = creds
                                 onSuccess?()
                             } else {
                                 err = "Deferred credentials not supported"
@@ -150,15 +162,16 @@ struct HandleOID4VCIView: View {
                     loading = false
                     return
                 case .ready(let credentialToken):
-                    if let cred = try await completeIssuance(
+                    if let creds = try await completeIssuance(
                         token: credentialToken,
                         httpClient: httpClient,
                         oid4vciClient: oid4vciClient,
                         clientId: clientId,
                         credentialIssuer: credentialIssuer,
-                        signer: signer
+                        signer: signer,
+                        configIds: configIds
                     ) {
-                        credential = cred
+                        credentials = creds
                         onSuccess?()
                     } else {
                         err = "Deferred credentials not supported"
@@ -189,8 +202,8 @@ struct HandleOID4VCIView: View {
                 ) {
                     back()
                 }
-            } else if credential != nil {
-                AddToWalletView(path: _path, rawCredential: credential!)
+            } else if !credentials.isEmpty {
+                AddToWalletView(path: _path, rawCredentials: credentials)
             }
 
         }
@@ -208,11 +221,12 @@ struct HandleOID4VCIView: View {
                 let clientId = hoistedClientId
                 let credentialIssuer = hoistedCredentialIssuer
                 let signer = hoistedSigner
+                let configIds = hoistedConfigIds
                 pendingTxState = nil
                 pinInput = ""
 
                 guard let txState, let httpClient, let oid4vciClient,
-                      let clientId, let credentialIssuer, let signer
+                      let clientId, let credentialIssuer, let signer, let configIds
                 else {
                     err = "Internal error: missing PIN context"
                     return
@@ -222,15 +236,16 @@ struct HandleOID4VCIView: View {
                 Task {
                     do {
                         let token = try await txState.proceed(httpClient: httpClient, txCode: pin)
-                        if let cred = try await completeIssuance(
+                        if let creds = try await completeIssuance(
                             token: token,
                             httpClient: httpClient,
                             oid4vciClient: oid4vciClient,
                             clientId: clientId,
                             credentialIssuer: credentialIssuer,
-                            signer: signer
+                            signer: signer,
+                            configIds: configIds
                         ) {
-                            credential = cred
+                            credentials = creds
                             onSuccess?()
                         } else {
                             err = "Deferred credentials not supported"

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleOID4VCIView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleOID4VCIView.swift
@@ -39,6 +39,8 @@ struct HandleOID4VCIView: View {
 
     // Exchanges every credential in the offer against the token, one request
     // per credential_configuration_id (each requires its own fresh nonce/proof).
+    // Deferred credentials are skipped rather than aborting the whole batch,
+    // so other credentials in the same offer still get issued.
     func completeIssuance(
         token: CredentialToken,
         httpClient: Oid4vciAsyncHttpClient,
@@ -47,7 +49,7 @@ struct HandleOID4VCIView: View {
         credentialIssuer: String,
         signer: JwsSigner,
         configIds: [String]
-    ) async throws -> [String]? {
+    ) async throws -> [String] {
         var results: [String] = []
 
         for configId in configIds {
@@ -60,7 +62,7 @@ struct HandleOID4VCIView: View {
 
             switch response {
             case .deferred(_):
-                return nil
+                continue
             case .immediate(let immediate):
                 guard let rawCredential = immediate.credentials.first else {
                     throw NSError(domain: "OID4VCI", code: 0, userInfo: [
@@ -136,7 +138,7 @@ struct HandleOID4VCIView: View {
                             err = "Authorization error: \(errorParam)"
                         } else if let codeParam, !codeParam.isEmpty {
                             let token = try await waiting.proceed(httpClient: httpClient, authorizationCode: codeParam)
-                            if let creds = try await completeIssuance(
+                            let creds = try await completeIssuance(
                                 token: token,
                                 httpClient: httpClient,
                                 oid4vciClient: oid4vciClient,
@@ -144,7 +146,8 @@ struct HandleOID4VCIView: View {
                                 credentialIssuer: credentialIssuer,
                                 signer: signer,
                                 configIds: configIds
-                            ) {
+                            )
+                            if !creds.isEmpty {
                                 credentials = creds
                                 onSuccess?()
                             } else {
@@ -162,7 +165,7 @@ struct HandleOID4VCIView: View {
                     loading = false
                     return
                 case .ready(let credentialToken):
-                    if let creds = try await completeIssuance(
+                    let creds = try await completeIssuance(
                         token: credentialToken,
                         httpClient: httpClient,
                         oid4vciClient: oid4vciClient,
@@ -170,7 +173,8 @@ struct HandleOID4VCIView: View {
                         credentialIssuer: credentialIssuer,
                         signer: signer,
                         configIds: configIds
-                    ) {
+                    )
+                    if !creds.isEmpty {
                         credentials = creds
                         onSuccess?()
                     } else {
@@ -236,7 +240,7 @@ struct HandleOID4VCIView: View {
                 Task {
                     do {
                         let token = try await txState.proceed(httpClient: httpClient, txCode: pin)
-                        if let creds = try await completeIssuance(
+                        let creds = try await completeIssuance(
                             token: token,
                             httpClient: httpClient,
                             oid4vciClient: oid4vciClient,
@@ -244,7 +248,8 @@ struct HandleOID4VCIView: View {
                             credentialIssuer: credentialIssuer,
                             signer: signer,
                             configIds: configIds
-                        ) {
+                        )
+                        if !creds.isEmpty {
                             credentials = creds
                             onSuccess?()
                         } else {


### PR DESCRIPTION
Support multi-credential OID4VCI offers in iOS and Android Showcase apps

## Description

An OID4VCI offer can list more than one `credential_configuration_id`. Before this PR, both apps called `defaultCredentialId()` to pick a single credential to exchange — which errors out (`AmbiguousCredentialOffer`) whenever an offer has more than one configuration ID. So multi-credential offers failed entirely instead of being handled.

This PR makes `HandleOID4VCIView` loop over every `credential_configuration_id` in the offer, exchanging each with its own fresh nonce/proof, and makes `AddToWalletView` accept a list of credentials instead of one — rendering a review card per credential with a single Add/Decline action for the batch. Same pattern on iOS and Android. The Rust/FFI layer and Flutter plugin already supported this; the gap was app-layer only.

_Summarize the changes included in this pull request. What is the current behavior and what is the updated/expected behavior of this PR? Include relevant context, and reasoning behind architectural/design decisions._

### Design / Video


https://github.com/user-attachments/assets/10f431f4-883d-45ed-975f-8e6d5b3e9c1a

https://github.com/user-attachments/assets/18702a87-bd9c-48cf-a69b-62f8614833af



### Other changes

_Describe any minor or "drive-by" changes here._

### Optional section

* Reviewers, please pay special attention to...
* If this PR exceeds 500 lines, please explain why

## Tested

Ran the `oid4vci-rs` example server with a 3-credential config (`cargo run --example server -- examples/server-multi.json --pre-auth`), exposed via `cloudflared`, and drove the full flow on a physical iOS and Android device via deep link. Confirmed all 3 credentials were exchanged and saved. Single-credential paths and the existing deep-link entry points verified by inspection (list-of-one behaves identically to the old single value).

