### PR TITLE
Explicitly generate a random 96-bit IV from OS entropy (CWE-327 defense-in-depth)

### DIFF
--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/KeyManager.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/KeyManager.kt
@@ -9,14 +9,13 @@ import androidx.annotation.RequiresApi
 import com.spruceid.mobile.sdk.rs.CryptoCurveUtils
 import com.spruceid.mobile.sdk.rs.Jwk
 import com.spruceid.mobile.sdk.rs.KeyAlias
-import com.spruceid.mobile.sdk.rs.KeyStore as SpruceKitKeyStore
 import com.spruceid.mobile.sdk.rs.SigningKey
 import com.spruceid.mobile.sdk.rs.coseKeyEc2P256PublicKey
 import com.spruceid.mobile.sdk.rs.jwkFromPublicP256
 import java.security.KeyPairGenerator
 import java.security.KeyStore
+import java.security.SecureRandom
 import java.security.Signature
-import java.security.cert.Certificate
 import java.security.interfaces.ECPublicKey
 import java.security.spec.ECGenParameterSpec
 import javax.crypto.Cipher
@@ -24,9 +23,20 @@ import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.SecretKeySpec
+import com.spruceid.mobile.sdk.rs.KeyStore as SpruceKitKeyStore
 
 /** Implementation of the secure key management with Strongbox and TEE as backup. */
 class KeyManager : SpruceKitKeyStore {
+
+    private companion object {
+        /** GCM standard 96-bit (12-byte) initialization vector. */
+        const val GCM_IV_LENGTH = 12
+
+        /** GCM 128-bit authentication tag. */
+        const val GCM_TAG_LENGTH_BITS = 128
+
+        val secureRandom = SecureRandom()
+    }
 
     /**
      * Returns the Android Keystore.
@@ -362,7 +372,7 @@ class KeyManager : SpruceKitKeyStore {
     fun decryptPayload(id: String, iv: ByteArray, payload: ByteArray): ByteArray {
         val secretKey = getSecretKey(id)
         val cipher = Cipher.getInstance("AES/GCM/NoPadding")
-        val spec = GCMParameterSpec(128, iv)
+        val spec = GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv)
         cipher.init(Cipher.DECRYPT_MODE, secretKey, spec)
         return cipher.doFinal(payload)
     }
@@ -381,8 +391,9 @@ class KeyManager : SpruceKitKeyStore {
         val cipher = Cipher.getInstance("AES/GCM/NoPadding")
         val secretKey = SecretKeySpec(key, "AES")
 
-        cipher.init(Cipher.ENCRYPT_MODE, secretKey)
-        val iv = cipher.iv
+        val iv = ByteArray(GCM_IV_LENGTH).also { secureRandom.nextBytes(it) }
+        val parameterSpec = GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv)
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey, parameterSpec)
         val encrypted = cipher.doFinal(data)
 
         return Pair(iv, encrypted)
@@ -402,7 +413,7 @@ class KeyManager : SpruceKitKeyStore {
     fun decryptWithDirectKey(key: ByteArray, iv: ByteArray, encryptedData: ByteArray): ByteArray {
         val cipher = Cipher.getInstance("AES/GCM/NoPadding")
         val secretKey = SecretKeySpec(key, "AES")
-        val spec = GCMParameterSpec(128, iv)
+        val spec = GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv)
 
         cipher.init(Cipher.DECRYPT_MODE, secretKey, spec)
         return cipher.doFinal(encryptedData)

--- a/android/MobileSdk/src/test/java/com/spruceid/mobile/sdk/KeyManagerTest.kt
+++ b/android/MobileSdk/src/test/java/com/spruceid/mobile/sdk/KeyManagerTest.kt
@@ -35,4 +35,74 @@ class KeyManagerTest {
 
         assertArrayEquals(inputEqualTo, resultEqualTo)
     }
+
+    @Test
+    fun directKeyEncryptionRoundtrip() {
+        val keyManager = KeyManager()
+        val key = ByteArray(32) { it.toByte() }
+        val data = "some payload to protect".toByteArray()
+
+        val (iv, encrypted) = keyManager.encryptWithDirectKey(key, data)
+        val decrypted = keyManager.decryptWithDirectKey(key, iv, encrypted)
+
+        assertArrayEquals(data, decrypted)
+    }
+
+    @Test
+    fun directKeyEncryptionRoundtripEmptyPayload() {
+        val keyManager = KeyManager()
+        val key = ByteArray(32) { it.toByte() }
+
+        val (iv, encrypted) = keyManager.encryptWithDirectKey(key, ByteArray(0))
+        val decrypted = keyManager.decryptWithDirectKey(key, iv, encrypted)
+
+        assertArrayEquals(ByteArray(0), decrypted)
+    }
+
+    @Test
+    fun directKeyEncryptionUses96BitIv() {
+        val keyManager = KeyManager()
+        val key = ByteArray(32) { it.toByte() }
+
+        val (iv, _) = keyManager.encryptWithDirectKey(key, "data".toByteArray())
+
+        assertEquals(12, iv.size)
+    }
+
+    @Test
+    fun directKeyEncryptionGeneratesUniqueIvs() {
+        val keyManager = KeyManager()
+        val key = ByteArray(32) { it.toByte() }
+        val data = "same data".toByteArray()
+
+        val ivs = (1..10).map { keyManager.encryptWithDirectKey(key, data).first.toList() }
+
+        assertEquals(10, ivs.toSet().size)
+    }
+
+    @Test
+    fun directKeyDecryptionFailsOnTamperedCiphertext() {
+        val keyManager = KeyManager()
+        val key = ByteArray(32) { it.toByte() }
+
+        val (iv, encrypted) = keyManager.encryptWithDirectKey(key, "data".toByteArray())
+        encrypted[0] = (encrypted[0].toInt() xor 0x01).toByte()
+
+        assertThrows(Exception::class.java) {
+            keyManager.decryptWithDirectKey(key, iv, encrypted)
+        }
+    }
+
+    @Test
+    fun directKeyDecryptionFailsWithWrongKey() {
+        val keyManager = KeyManager()
+        val key = ByteArray(32) { it.toByte() }
+        val wrongKey = ByteArray(32) { (it + 1).toByte() }
+
+        val (iv, encrypted) = keyManager.encryptWithDirectKey(key, "data".toByteArray())
+
+        assertThrows(Exception::class.java) {
+            keyManager.decryptWithDirectKey(wrongKey, iv, encrypted)
+        }
+    }
 }


### PR DESCRIPTION
**Finding:** `javax.crypto.spec.GCMParameterSpec.!operator_javanewinit` ([CWE-327](https://cwe.mitre.org/data/definitions/327.html))
**Module:** `com.spruceid.mobile.sdk.KeyManager` (Android SDK)

### Finding summary

Flagged `GCMParameterSpec(128, iv)` constructor calls in `KeyManager.kt`, asserting the initialization vector is "not cryptographically strong". However, this assertion was a false positive.

### Why this is a false positive

**IVs are generated from OS entropy at encryption time.** Encryption paths initialize the cipher without an explicit IV, so the IV is generated by the crypto provider:
   - `encryptPayload` uses AndroidKeyStore-backed keys (StrongBox/TEE). The Keystore generates a random 96-bit IV inside secure hardware. AndroidKeyStore *rejects* caller-supplied IVs on encrypt unless `setRandomizedEncryptionRequired(false)` is set — this code does not opt out.
   - `encryptWithDirectKey` used Conscrypt's implicit provider-generated random IV.

### Hardening applied (defense-in-depth)

The following changes were made in `KeyManager.kt`:

- `encryptWithDirectKey` now explicitly generates a 96-bit IV via `java.security.SecureRandom` (seeded from OS entropy) rather than relying on provider defaults.
- Magic numbers replaced with named constants (`GCM_IV_LENGTH = 12`, `GCM_TAG_LENGTH_BITS = 128`).

## References

- [CWE-327](https://cwe.mitre.org/data/definitions/327.html)
- [Android Keystore: `setRandomizedEncryptionRequired`](https://developer.android.com/reference/android/security/keystore/KeyGenParameterSpec.Builder#setRandomizedEncryptionRequired(boolean))