### PR TITLE
fix(ble): reliably release central-client scan registrations

### DIFF
--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBle.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBle.kt
@@ -36,6 +36,16 @@ class TransportBle {
          */
         if (deviceRetrievalOption == "Central") {
             logger.d("Selecting Transport Central Client $application")
+            // Release any previous central-client instance before replacing the field —
+            // once overwritten nothing else references it, so its still-registered scan
+            // callback could never be stopped (leak).
+            if (this::transportBleCentralClient.isInitialized) {
+                try {
+                    transportBleCentralClient.hardReset()
+                } catch (e: Exception) {
+                    logger.e("Error resetting previous central client", e)
+                }
+            }
             if (application == "Holder" && updateRequestData != null) {
                 // Holder as Central: receives request, sends response
                 transportBleCentralClient = TransportBleCentralClient(

--- a/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBleCentralClient.kt
+++ b/android/MobileSdk/src/main/java/com/spruceid/mobile/sdk/ble/TransportBleCentralClient.kt
@@ -251,11 +251,11 @@ class TransportBleCentralClient(
             super.onScanFailed(errorCode)
             logger.e("BLE scan failed (code=$errorCode)")
 
-            // Stop tracking the failed scan so we can retry cleanly.
+            // Unregister the failed/lingering scan and clear pending runnables so a
+            // failed registration can't accumulate. stopScanInternal() already handles
+            // the SecurityException and resets the scanning flag.
             synchronized(scanLock) {
-                scanning = false
-                scanTimeoutRunnable?.let { handler.removeCallbacks(it) }
-                scanTimeoutRunnable = null
+                stopScanInternal()
             }
 
             if (errorCode == SCAN_FAILED_SCANNING_TOO_FREQUENTLY &&
@@ -328,25 +328,37 @@ class TransportBleCentralClient(
 
                     scanTimeoutRunnable = Runnable {
                         synchronized(scanLock) {
-                            val current = scanGenerationCounter.get()
-                            if (armedGeneration != current) {
-                                logger.d(
-                                    "Stale scan timeout runnable " +
-                                        "(armed=$armedGeneration, current=$current); ignoring.",
-                                )
-                                return@Runnable
-                            }
-                            if (scanning) {
+                            val action = scanTimeoutAction(
+                                wasScanning = scanning,
+                                armedGeneration = armedGeneration,
+                                currentGeneration = scanGenerationCounter.get(),
+                            )
+                            // STOP_SCAN_ONLY and STOP_SCAN_AND_TEARDOWN both release THIS instance's
+                            // own scan, even when stale — never skip the stopScan, or an orphaned
+                            // instance leaks its registration (→ SCAN_FAILED_APPLICATION_REGISTRATION_FAILED,
+                            // needs a BLE restart). Only the teardown is fenced behind staleness.
+                            if (action != ScanTimeoutAction.NONE) {
                                 scanning = false
                                 try {
                                     bluetoothLeScanner.stopScan(leScanCallback)
                                 } catch (e: Exception) {
                                     logger.e("${e.message}")
                                 }
-                                scanTimeoutRunnable = null
-                                logger.i("connection timeout")
-                                emitter.timeout()
-                                disconnect()
+                            }
+                            scanTimeoutRunnable = null
+
+                            when (action) {
+                                ScanTimeoutAction.STOP_SCAN_AND_TEARDOWN -> {
+                                    logger.i("connection timeout")
+                                    emitter.timeout()
+                                    disconnect()
+                                }
+                                ScanTimeoutAction.STOP_SCAN_ONLY -> logger.d(
+                                    "Stale scan timeout runnable (armed=$armedGeneration, " +
+                                        "current=${scanGenerationCounter.get()}); " +
+                                        "unregistered own scan, skipping teardown.",
+                                )
+                                ScanTimeoutAction.NONE -> {}
                             }
                         }
                     }
@@ -423,4 +435,25 @@ class TransportBleCentralClient(
          */
         val scanGenerationCounter = AtomicLong(0)
     }
+}
+
+/** What a fired scan-timeout runnable should do (see [scanTimeoutAction]). */
+internal enum class ScanTimeoutAction { NONE, STOP_SCAN_ONLY, STOP_SCAN_AND_TEARDOWN }
+
+/**
+ * Decide what a fired scan-timeout runnable does. Invariant (regression fixed from #316): a stale
+ * timeout — one whose [armedGeneration] no longer matches the process-wide [currentGeneration]
+ * because a newer scan started — must STILL unregister its own scan (STOP_SCAN_ONLY); only the
+ * session teardown is skipped. Skipping the stopScan too (the previous behaviour) orphaned the scan
+ * registration and eventually exhausted Android's per-app scanner limit, surfacing as
+ * SCAN_FAILED_APPLICATION_REGISTRATION_FAILED (unrecoverable without a BLE/device restart).
+ */
+internal fun scanTimeoutAction(
+    wasScanning: Boolean,
+    armedGeneration: Long,
+    currentGeneration: Long,
+): ScanTimeoutAction = when {
+    !wasScanning -> ScanTimeoutAction.NONE
+    armedGeneration != currentGeneration -> ScanTimeoutAction.STOP_SCAN_ONLY
+    else -> ScanTimeoutAction.STOP_SCAN_AND_TEARDOWN
 }

--- a/android/MobileSdk/src/test/java/com/spruceid/mobile/sdk/ble/TransportBleCentralClientTest.kt
+++ b/android/MobileSdk/src/test/java/com/spruceid/mobile/sdk/ble/TransportBleCentralClientTest.kt
@@ -1,0 +1,50 @@
+package com.spruceid.mobile.sdk.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Tests for [scanTimeoutAction], the decision a fired scan-timeout runnable makes in
+ * [TransportBleCentralClient].
+ */
+class TransportBleCentralClientTest {
+
+    /**
+     * Regression guard (#316 side-effect): a STALE timeout — one whose armed generation no longer
+     * matches the process-wide counter because a newer scan started — must still unregister its own
+     * scan (STOP_SCAN_ONLY), never NONE. Skipping the stopScan orphaned the scan registration;
+     * repeated presentations then exhausted Android's per-app scanner limit and surfaced as
+     * SCAN_FAILED_APPLICATION_REGISTRATION_FAILED, which fails every subsequent scan until a
+     * BLE/device restart. The teardown (disconnect/timeout) is still skipped so a newer session's
+     * shared state machine is left untouched.
+     */
+    @Test
+    fun staleTimeoutStillStopsScanButSkipsTeardown() {
+        assertEquals(
+            ScanTimeoutAction.STOP_SCAN_ONLY,
+            scanTimeoutAction(wasScanning = true, armedGeneration = 1, currentGeneration = 2),
+        )
+    }
+
+    /** A fresh (non-stale) timeout that caught an in-progress scan stops the scan AND tears down. */
+    @Test
+    fun freshTimeoutStopsScanAndTearsDown() {
+        assertEquals(
+            ScanTimeoutAction.STOP_SCAN_AND_TEARDOWN,
+            scanTimeoutAction(wasScanning = true, armedGeneration = 7, currentGeneration = 7),
+        )
+    }
+
+    /** If the scan already ended before the timeout fired, do nothing — regardless of staleness. */
+    @Test
+    fun timeoutWithNoActiveScanDoesNothing() {
+        assertEquals(
+            ScanTimeoutAction.NONE,
+            scanTimeoutAction(wasScanning = false, armedGeneration = 1, currentGeneration = 1),
+        )
+        assertEquals(
+            ScanTimeoutAction.NONE,
+            scanTimeoutAction(wasScanning = false, armedGeneration = 1, currentGeneration = 2),
+        )
+    }
+}


### PR DESCRIPTION
## Problem
On repeated ISO 18013-5 proximity presentations where the holder (BLE central) scans but never connects — reader wedged/absent, or the user retries — the holder eventually hits `SCAN_FAILED_APPLICATION_REGISTRATION_FAILED`, after which *every* subsequent scan fails until Bluetooth/device restart. Cause: `ScanCallback` registrations that are never released accumulate past Android's per-app scanner limit.

## Root cause
`TransportBleCentralClient.scanTimeoutRunnable` fenced its work behind the process-wide `scanGenerationCounter` stale guard added in #316: for a stale instance (a newer scan bumped the global counter) it `return@Runnable`ed **before** `stopScan(leScanCallback)`. Because `TransportBle.initialize()` overwrites the single `transportBleCentralClient` field without stopping the old instance, that orphaned instance's only remaining cleanup was its own timeout runnable — which the guard now skipped, so its scan registration was never released.

Pre-#316 the timeout unconditionally called `stopScan`, so orphaned instances cleared themselves within ~30s and never accumulated. #316's guard (correctly added to stop a stale timeout from tearing down a newer session) removed that self-healing as a side effect — so registrations now accumulate without bound.

## Fix
- `scanTimeoutRunnable`: always `stopScan` the instance's own callback; the stale case skips only the `disconnect()`/`timeout` teardown. Decision extracted to the pure `scanTimeoutAction()` for testability.
- `onScanFailed`: unregister the callback before clearing the `scanning` flag.
- `TransportBle.initialize`: `hardReset()` a previous central client before overwriting the field.

## Testing
- Unit: `TransportBleCentralClientTest` (3 cases); the key one asserts a stale timeout returns `STOP_SCAN_ONLY` (still unregisters), not `NONE`.
- Device: built into the CA DMV mDL wallet holder, run on Pixel 9 + Samsung S23 — repeating the previously-failing sequence (scan, no connect, retry ×8–10) no longer permanently fails; recovers without a BLE/device restart.