### PR TITLE
VCALM: full QueryByExample matching and spec-compliant VP shape

### DIFF
--- a/rust/src/context.rs
+++ b/rust/src/context.rs
@@ -34,6 +34,10 @@ pub fn vc_playground_context(mut context: HashMap<String, String>) -> HashMap<St
         include_str!("../tests/context/purl_imsglobal_org_spec_ob_v3p0_context_3_0_2.json").into(),
     );
     context.insert(
+        "https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json".into(),
+        include_str!("../tests/context/purl_imsglobal_org_spec_ob_v3p0_context_3_0_3.json").into(),
+    );
+    context.insert(
         "https://w3id.org/citizenship/v4rc1".into(),
         include_str!("../tests/context/w3id_org_citizenship_v4rc1.json").into(),
     );
@@ -44,6 +48,10 @@ pub fn vc_playground_context(mut context: HashMap<String, String>) -> HashMap<St
     context.insert(
         "https://w3id.org/vc/render-method/v2rc2".into(),
         include_str!("../tests/context/w3id_org_vc_render_method_v2rc2.json").into(),
+    );
+    context.insert(
+        "https://w3id.org/identification/v1rc1".into(),
+        include_str!("../tests/context/w3id_org_identification_v1rc1.json").into(),
     );
     context.insert(
         "https://examples.vcplayground.org/contexts/alumni/v2.json".into(),

--- a/rust/src/vcalm/holder.rs
+++ b/rust/src/vcalm/holder.rs
@@ -419,8 +419,19 @@ impl VcalmHolder {
         .await
         .map_err(|e| VcalmError::Network(format!("big-stack signing thread: {e}")))??;
 
-        let value = serde_json::to_value(&signed)
+        let mut value = serde_json::to_value(&signed)
             .map_err(|e| VcalmError::Deserialization(e.to_string()))?;
+
+        // vcapi §3.6.5: `verifiableCredential` MUST be an array. ssi compacts a
+        // single credential to a bare object; re-wrap it. Signature-safe: the VP
+        // proof canonicalizes to RDF (ecdsa-rdfc-2019), and an object vs a
+        // one-element array yield identical N-Quads.
+        if let Some(vc) = value.get_mut("verifiableCredential") {
+            if !vc.is_array() {
+                let single = vc.take();
+                *vc = serde_json::Value::Array(vec![single]);
+            }
+        }
 
         let message = VcapiMessage {
             verifiable_presentation: Some(value),
@@ -1019,14 +1030,18 @@ impl VcalmHolder {
                     VcalmError::SdDeriveFailed("selected credential is not a JSON-LD VC".into())
                 })?;
                 if has_sd_base_proof(&json_vc.raw) {
-                    // GATE 2 holds — derive the selective-disclosure VC. A type-only
-                    // example names no subject fields; reveal the whole subject via
-                    // the parent pointer (a derived VC without `credentialSubject`
+                    // GATE 2 holds — derive the selective-disclosure VC. An example
+                    // naming no subject fields (type-only, or e.g. only
+                    // `credentialStatus`) still reveals the whole subject via the
+                    // parent pointer (a derived VC without `credentialSubject`
                     // would not be a valid VC at all).
                     let mut selective_pointers = selective_pointers_from_paths(paths);
-                    if selective_pointers.is_empty() {
-                        selective_pointers = selective_pointers_from_paths(std::slice::from_ref(
-                            &"credentialSubject".to_string(),
+                    let names_subject = paths
+                        .iter()
+                        .any(|p| p == "credentialSubject" || p.starts_with("credentialSubject."));
+                    if !names_subject {
+                        selective_pointers.extend(selective_pointers_from_paths(
+                            std::slice::from_ref(&"credentialSubject".to_string()),
                         ));
                     }
                     match json_vc
@@ -1136,6 +1151,11 @@ impl VcalmHolder {
             message.reference_id = reference_id;
         }
 
+        tracing::debug!(
+            "VCALM post_message request body: {}",
+            serde_json::to_string(&message).unwrap_or_else(|e| format!("<serialize error: {e}>"))
+        );
+
         let mut request = self.client.post(exchange_url).json(&message);
         if let Some(token) = &auth_header {
             request = request.header(AUTHORIZATION, format!("Bearer {token}"));
@@ -1147,6 +1167,8 @@ impl VcalmHolder {
             .map_err(|e| VcalmError::Network(e.to_string()))?;
         let status = resp.status();
         let body = read_body_capped(resp).await?;
+
+        tracing::debug!("VCALM post_message response status={status} body: {body}");
 
         let result = classify(status, &body)?;
 
@@ -1554,8 +1576,11 @@ fn build_presentation_from_json(
 }
 
 /// Extract the example-named fields (informational) from a QBE `example`:
-/// top-level `type`/`@context` (rendered as their JSON) and each `credentialSubject`
-/// key recursively. A leaf `""` renders as `"any value"` (§3.4.2).
+/// top-level `type`/`@context` (rendered as their JSON), each `credentialSubject`
+/// key recursively, and every OTHER top-level example property (e.g.
+/// `credentialStatus`) — the example names what the response credential must
+/// contain (§3.4.2), so those properties are displayed AND SD-revealed too.
+/// A leaf `""` renders as `"any value"` (§3.4.2).
 fn example_field_paths(example: &serde_json::Value) -> Vec<ExampleField> {
     let mut out = Vec::new();
     if let Some(obj) = example.as_object() {
@@ -1569,6 +1594,12 @@ fn example_field_paths(example: &serde_json::Value) -> Vec<ExampleField> {
         }
         if let Some(subject) = obj.get("credentialSubject") {
             collect_subject_paths("credentialSubject", subject, &mut out);
+        }
+        for (key, value) in obj {
+            if matches!(key.as_str(), "type" | "@context" | "credentialSubject") {
+                continue;
+            }
+            collect_subject_paths(key, value, &mut out);
         }
     }
     out
@@ -1716,15 +1747,20 @@ fn dotted_to_pointer(dotted: &str) -> String {
 
 /// Transform QBE-named field PATHS into the spec `selectivePointers`: an
 /// array of field-level RFC 6901 JSON pointers naming EXACTLY the QBE-requested
-/// `credentialSubject` fields. Structural/top-level keys (`type`, `@context`) are
-/// excluded — the derive auto-adds the issuer's `mandatoryPointers`, so the
-/// holder reveals only the QBE-named subject fields (no oversharing). Array-valued
-/// example fields already arrive here as a single parent path
-/// (`collect_subject_paths` treats arrays as leaves) → parent pointer.
+/// fields (`credentialSubject.*` plus other example-named properties such as
+/// `credentialStatus` — the response credential must contain what the example
+/// names, §3.4.2). Structural keys (`type`, `@context`) are excluded — the
+/// derive auto-adds the issuer's `mandatoryPointers`, so the holder reveals only
+/// the QBE-named fields (no oversharing). Array-valued example fields already
+/// arrive here as a single parent path (`collect_subject_paths` treats arrays as
+/// leaves) → parent pointer.
 fn selective_pointers_from_paths(paths: &[String]) -> Vec<ssi::JsonPointerBuf> {
     paths
         .iter()
-        .filter(|p| *p == "credentialSubject" || p.starts_with("credentialSubject."))
+        .filter(|p| {
+            let top = p.split('.').next().unwrap_or(p);
+            !matches!(top, "type" | "@context")
+        })
         .filter_map(|p| ssi::JsonPointerBuf::new(dotted_to_pointer(p)).ok())
         .collect()
 }

--- a/rust/src/vcalm/matching.rs
+++ b/rust/src/vcalm/matching.rs
@@ -106,7 +106,9 @@ pub(crate) fn vc_issuer(vc: &Value) -> Option<String> {
 /// 1. `example.type` subset of the VC `type` array;
 /// 2. `example.@context` subset of the VC `@context` array;
 /// 3. recursive `credentialSubject` subset (`""` = present, every named field required);
-/// 4. the issuer filter — if `acceptedIssuers`/`trustedIssuer` is present and
+/// 4. every OTHER example-named property (e.g. `credentialStatus`) present and
+///    matching, recursively (`""` = present with any value);
+/// 5. the issuer filter — if `acceptedIssuers`/`trustedIssuer` is present and
 ///    non-empty, the VC issuer must string-equal (RAW, no URL normalization) some
 ///    accepted-issuer value; absent -> unconstrained.
 ///
@@ -134,6 +136,22 @@ pub(crate) fn example_matches(query: &CredentialQuery, vc_raw: &Value) -> bool {
             let have_subject = vc_raw.get("credentialSubject").unwrap_or(&Value::Null);
             if !value_is_subset(want_subject, have_subject) {
                 return false;
+            }
+        }
+        // 4. every OTHER example-named property (e.g. `credentialStatus`) must be
+        //    present in the VC and match (§3.4.2 — the example names what the
+        //    credential must contain; `""` = present with any value).
+        if let Some(obj) = example.as_object() {
+            for (key, want) in obj {
+                if matches!(key.as_str(), "type" | "@context" | "credentialSubject") {
+                    continue;
+                }
+                let Some(have) = vc_raw.get(key) else {
+                    return false;
+                };
+                if !value_is_subset(want, have) {
+                    return false;
+                }
             }
         }
     }

--- a/rust/tests/context/purl_imsglobal_org_spec_ob_v3p0_context_3_0_3.json
+++ b/rust/tests/context/purl_imsglobal_org_spec_ob_v3p0_context_3_0_3.json
@@ -1,0 +1,444 @@
+{
+  "@context": {
+    "@protected": true,
+    "id": "@id",
+    "type": "@type",
+    "OpenBadgeCredential": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#OpenBadgeCredential"
+    },
+    "Achievement": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#Achievement",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "achievementType": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#achievementType"
+        },
+        "alignment": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#alignment",
+          "@container": "@set"
+        },
+        "creator": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#creator"
+        },
+        "creditsAvailable": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#creditsAvailable",
+          "@type": "https://www.w3.org/2001/XMLSchema#float"
+        },
+        "criteria": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#Criteria",
+          "@type": "@id"
+        },
+        "fieldOfStudy": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#fieldOfStudy"
+        },
+        "humanCode": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#humanCode"
+        },
+        "image": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#image",
+          "@type": "@id"
+        },
+        "otherIdentifier": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#otherIdentifier",
+          "@container": "@set"
+        },
+        "related": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#related",
+          "@container": "@set"
+        },
+        "resultDescription": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#resultDescription",
+          "@container": "@set"
+        },
+        "specialization": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#specialization"
+        },
+        "tag": {
+          "@id": "https://schema.org/keywords",
+          "@container": "@set"
+        },
+        "version": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#version"
+        },
+        "inLanguage": {
+          "@id": "https://schema.org/inLanguage"
+        }
+      }
+    },
+    "AchievementCredential": {
+      "@id": "OpenBadgeCredential"
+    },
+    "AchievementSubject": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#AchievementSubject",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "achievement": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#achievement"
+        },
+        "activityEndDate": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#activityEndDate",
+          "@type": "https://www.w3.org/2001/XMLSchema#date"
+        },
+        "activityStartDate": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#activityStartDate",
+          "@type": "https://www.w3.org/2001/XMLSchema#date"
+        },
+        "creditsEarned": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#creditsEarned",
+          "@type": "https://www.w3.org/2001/XMLSchema#float"
+        },
+        "identifier": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#identifier",
+          "@container": "@set"
+        },
+        "image": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#image",
+          "@type": "@id"
+        },
+        "licenseNumber": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#licenseNumber"
+        },
+        "result": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#result",
+          "@container": "@set"
+        },
+        "role": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#role"
+        },
+        "source": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#source",
+          "@type": "@id"
+        },
+        "term": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#term"
+        }
+      }
+    },
+    "Address": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#Address",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "addressCountry": {
+          "@id": "https://schema.org/addressCountry"
+        },
+        "addressCountryCode": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#CountryCode"
+        },
+        "addressLocality": {
+          "@id": "https://schema.org/addressLocality"
+        },
+        "addressRegion": {
+          "@id": "https://schema.org/addressRegion"
+        },
+        "geo": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#GeoCoordinates"
+        },
+        "postOfficeBoxNumber": {
+          "@id": "https://schema.org/postOfficeBoxNumber"
+        },
+        "postalCode": {
+          "@id": "https://schema.org/postalCode"
+        },
+        "streetAddress": {
+          "@id": "https://schema.org/streetAddress"
+        }
+      }
+    },
+    "Alignment": {
+      "@id": "https://schema.org/AlignmentObject",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "targetCode": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#targetCode"
+        },
+        "targetDescription": {
+          "@id": "https://schema.org/targetDescription"
+        },
+        "targetFramework": {
+          "@id": "https://schema.org/targetFramework"
+        },
+        "targetName": {
+          "@id": "https://schema.org/targetName"
+        },
+        "targetType": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#targetType"
+        },
+        "targetUrl": {
+          "@id": "https://schema.org/targetUrl",
+          "@type": "https://www.w3.org/2001/XMLSchema#anyURI"
+        }
+      }
+    },
+    "Criteria": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#Criteria"
+    },
+    "EndorsementCredential": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#EndorsementCredential"
+    },
+    "EndorsementSubject": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#EndorsementSubject",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "endorsementComment": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#endorsementComment"
+        }
+      }
+    },
+    "Evidence": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#Evidence",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "audience": {
+          "@id": "https://schema.org/audience"
+        },
+        "genre": {
+          "@id": "https://schema.org/genre"
+        }
+      }
+    },
+    "GeoCoordinates": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#GeoCoordinates",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "latitude": {
+          "@id": "https://schema.org/latitude"
+        },
+        "longitude": {
+          "@id": "https://schema.org/longitude"
+        }
+      }
+    },
+    "IdentifierEntry": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#IdentifierEntry",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "identifier": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#identifier"
+        },
+        "identifierType": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#identifierType"
+        }
+      }
+    },
+    "IdentityObject": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#IdentityObject",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "hashed": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#hashed",
+          "@type": "https://www.w3.org/2001/XMLSchema#boolean"
+        },
+        "identityHash": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#identityHash"
+        },
+        "identityType": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#identityType"
+        },
+        "salt": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#salt"
+        }
+      }
+    },
+    "Image": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#Image",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "caption": {
+          "@id": "https://schema.org/caption"
+        }
+      }
+    },
+    "Profile": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#Profile",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "additionalName": {
+          "@id": "https://schema.org/additionalName"
+        },
+        "address": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#address",
+          "@type": "@id"
+        },
+        "dateOfBirth": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#dateOfBirth",
+          "@type": "https://www.w3.org/2001/XMLSchema#date"
+        },
+        "email": {
+          "@id": "https://schema.org/email"
+        },
+        "familyName": {
+          "@id": "https://schema.org/familyName"
+        },
+        "familyNamePrefix": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#familyNamePrefix"
+        },
+        "givenName": {
+          "@id": "https://schema.org/givenName"
+        },
+        "honorificPrefix": {
+          "@id": "https://schema.org/honorificPrefix"
+        },
+        "honorificSuffix": {
+          "@id": "https://schema.org/honorificSuffix"
+        },
+        "image": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#image",
+          "@type": "@id"
+        },
+        "otherIdentifier": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#otherIdentifier",
+          "@container": "@set"
+        },
+        "parentOrg": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#parentOrg",
+          "@type": "@id"
+        },
+        "patronymicName": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#patronymicName"
+        },
+        "phone": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#phone"
+        },
+        "official": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#official"
+        }
+      }
+    },
+    "Related": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#Related",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "version": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#version"
+        },
+        "inLanguage": {
+          "@id": "https://schema.org/inLanguage"
+        }
+      }
+    },
+    "Result": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#Result",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "achievedLevel": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#achievedLevel",
+          "@type": "https://www.w3.org/2001/XMLSchema#anyURI"
+        },
+        "resultDescription": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#resultDescription",
+          "@type": "https://www.w3.org/2001/XMLSchema#anyURI"
+        },
+        "status": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#status"
+        },
+        "value": {
+          "@id": "https://schema.org/value"
+        }
+      }
+    },
+    "ResultDescription": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#ResultDescription",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "allowedValue": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#allowedValue",
+          "@container": "@list"
+        },
+        "requiredLevel": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#requiredLevel",
+          "@type": "https://www.w3.org/2001/XMLSchema#anyURI"
+        },
+        "requiredValue": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#requiredValue"
+        },
+        "resultType": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#resultType"
+        },
+        "rubricCriterionLevel": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#rubricCriterionLevel",
+          "@container": "@set"
+        },
+        "valueMax": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#valueMax"
+        },
+        "valueMin": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#valueMin"
+        }
+      }
+    },
+    "RubricCriterionLevel": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#RubricCriterionLevel",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "level": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#level"
+        },
+        "points": {
+          "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#points"
+        }
+      }
+    },
+    "alignment": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#alignment",
+      "@container": "@set"
+    },
+    "description": {
+      "@id": "https://schema.org/description"
+    },
+    "endorsement": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#endorsement",
+      "@container": "@set"
+    },
+    "image": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#image",
+      "@type": "@id"
+    },
+    "inLanguage": {
+      "@id": "https://schema.org/inLanguage"
+    },
+    "name": {
+      "@id": "https://schema.org/name"
+    },
+    "narrative": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#narrative"
+    },
+    "url": {
+      "@id": "https://schema.org/url",
+      "@type": "https://www.w3.org/2001/XMLSchema#anyURI"
+    },
+    "awardedDate": {
+      "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#awardedDate",
+      "@type": "xsd:dateTime"
+    }
+  }
+}

--- a/rust/tests/context/w3id_org_identification_v1rc1.json
+++ b/rust/tests/context/w3id_org_identification_v1rc1.json
@@ -1,0 +1,108 @@
+{
+  "@context": {
+    "@protected": true,
+
+    "id": "@id",
+    "type": "@type",
+
+    "name": "https://schema.org/name",
+
+    "IdentificationDocumentCredential": "https://w3id.org/identification#IdentificationDocumentCredential",
+
+    "IdentificationDocument": {
+      "@id": "https://w3id.org/identification#IdentificationDocument",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "aamvaDhsCompliance": "https://w3id.org/vdl/aamva#dhsCompliance",
+        "aamvaDhsComplianceText": "https://w3id.org/vdl/aamva#dhsCompliance_text",
+        "aamvaDomesticDrivingPrivileges": {
+          "@id": "https://w3id.org/vdl/aamva#domesticDrivingPrivileges",
+          "@type": "@json"
+        },
+        "documentIdentifier": "https://w3id.org/identification#documentIdentifier",
+        "issuer": {
+          "@id": "https://www.w3.org/2018/credentials#issuer",
+          "@type": "@id"
+        },
+        "restrictions": "https://w3id.org/identification#restrictions",
+        "validFrom": {
+          "@id": "https://www.w3.org/2018/credentials#validFrom",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "validUntil": {
+          "@id": "https://www.w3.org/2018/credentials#validUntil",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        }
+      }
+    },
+
+    "Observation": {
+      "@id": "https://schema.org/Observation",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "description": "https://schema.org/description",
+        "observationDate": {
+          "@id": "https://schema.org/observationDate",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "unitCode": "https://schema.org/unitCode",
+        "value": {
+          "@id": "https://schema.org/value",
+          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
+        },
+        "variableMeasured": "https://schema.org/variableMeasured"
+      }
+    },
+
+    "PostalAddress": {
+      "@id": "https://schema.org/PostalAddress",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "streetAddress": "https://schema.org/streetAddress",
+        "addressRegion": "https://schema.org/addressRegion",
+        "addressLocality": "https://schema.org/addressLocality",
+        "addressCountry": "https://schema.org/addressCountry",
+        "postalCode": "https://schema.org/postalCode"
+      }
+    },
+
+    "Person": {
+      "@id": "https://schema.org/Person",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "additionalName": "https://schema.org/additionalName",
+        "address": "https://schema.org/address",
+        "birthDate": {
+          "@id": "https://schema.org/birthDate",
+          "@type": "https://schema.org/Date"
+        },
+        "email": "https://schema.org/email",
+        "eyeColor": "https://w3id.org/vdl#eyeColour",
+        "familyName": "https://schema.org/familyName",
+        "givenName": "https://schema.org/givenName",
+        "height": "https://schema.org/height",
+        "hairColor": "https://w3id.org/vdl#hairColour",
+        "identificationDocument": "https://w3id.org/identification#identificationDocument",
+        "image": "https://schema.org/image",
+        "telephone": "https://schema.org/telephone",
+        "weight": "https://schema.org/weight"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

This aligns VCALM holder matching and presentation with the VCALM 1.0 spec:
- **Matching (§3.4.2)**: every property named in a QBE `example` (e.g. `credentialStatus`) is now a required constraint. Previously only `type`/`@context`/`credentialSubject` were checked.
- **Selective disclosure**: example-named properties outside `credentialSubject` are now included in the derived VC's selective pointers, and no longer dropped when the example names no subject fields.
- **VP shape (§3.6.5)**: `verifiableCredential` is always sent as an array. Signature-safe: object vs one-element array canonicalize to identical N-Quads under ecdsa-rdfc-2019.
- Bundles the Open Badges v3.0.3 and `w3id.org/identification/v1rc1` JSON-LD contexts; adds debug logging for exchange request/response bodies.

### Other changes

N/A

### Optional section

This PR exceeds 500 lines because it contains context files.

## Tested

N/A