### PR TITLE
Bump JNA version to fix Structure.getFieldOrder crash

### DIFF
--- a/android/MobileSdkRs/build.gradle
+++ b/android/MobileSdkRs/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
     implementation("androidx.compose.runtime:runtime:1.8.3")
 
-    implementation "net.java.dev.jna:jna:5.17.0@aar"
+    implementation "net.java.dev.jna:jna:5.19.1@aar"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2"
     implementation "androidx.annotation:annotation:1.9.1"
     implementation "androidx.core:core-ktx:1.16.0"


### PR DESCRIPTION
 ## Description
Bumps JNA from 5.17.0 → 5.19.1 to fix a production crash on Android. Apps were hitting a fatal crash in the UniFFI-generated `StorageManagerInterface` callback on app launch:

```
java.lang.Error: Structure.getFieldOrder() on class UniffiForeignFutureResultRustBuffer$UniffiByValue returns names ([callStatus, returnValue]) which do not match declared field names ([callStatus])
```
This is a [known JNA bug](https://github.com/java-native-access/jna/issues/1686) where a race condition in `sortFields()` allows concurrent threads to corrupt the field list, causing field-order validation to fail. The same crash was reported in Firefox Android.

The fixes shipped in 5.18.1; I'm upgrading to 5.19.1 (current latest) while I'm at it.                                               

## Tested                                                                                   
Built Showcase and installed on a Samsung device running Android 16. Verified:           
- Wallet home screen loads (triggers StorageManagerInterface.list() via CredentialPack.loadPacks() on init)
- "Generate a Spruce mDL" completes without crash

No iOS impact — JNA is Android-only. 