### PR TITLE
CAMV-1099: Support unsigned OpenID4VP requests over the DC API

### DIFF
--- a/rust/src/oid4vp/dc_api/mod.rs
+++ b/rust/src/oid4vp/dc_api/mod.rs
@@ -12,7 +12,7 @@ use build_response::Responder;
 use openid4vp::{
     core::{
         authorization_request::{
-            parameters::ExpectedOrigins,
+            parameters::{ExpectedOrigins, ResponseMode},
             verification::{verifier::P256Verifier, x509_hash, x509_san, RequestVerifier},
             AuthorizationRequest, AuthorizationRequestObject,
         },
@@ -100,6 +100,22 @@ impl RequestVerifier for WalletActivity {
         // Use the x509_hash validation with P256 verifier
         // Note: trusted_roots is None for now, meaning we don't verify the certificate chain
         x509_hash::validate::<P256Verifier>(self.metadata(), decoded_request, request_jwt, None)
+    }
+
+    async fn preregistered(
+        &self,
+        decoded_request: &AuthorizationRequestObject,
+        _request_jwt: Option<String>,
+    ) -> Result<()> {
+        // Unsigned DC API request: no request signature and no client_id to verify.
+        // Trust in the Verifier comes from the platform-supplied browser origin, which
+        // is bound into the response transcript via the DC API handover (see `respond`).
+        // Restrict to DC API response modes so a pre-registered client cannot bypass
+        // signature verification over a non-DC-API transport.
+        match decoded_request.response_mode() {
+            ResponseMode::DcApi | ResponseMode::DcApiJwt => Ok(()),
+            mode => bail!("unsigned requests are only accepted over the DC API, not {mode:?}"),
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

Unsigned OpenID4VP requests over the Digital Credentials API fail. On a Pixel 9 against `digital-credentials.dev`, signed requests work but unsigned ones fail with the browser showing "network error / error retrieving a token."

Root cause: unsigned DC API requests carry no `client_id`, so per OpenID4VP v1.0 §5.9.2 they are treated as a **pre-registered** client. `WalletActivity` only implemented the `x509_san_dns` / `x509_hash` verifiers, so unsigned requests hit the default `preregistered()` trait stub that bails with `'pre-registered' client verification not implemented`.

## Fix

Implement `preregistered()` for `WalletActivity`. Unsigned requests have no signature and no `client_id` to verify; trust comes from the platform-supplied browser origin, which is bound into the response transcript via the DC API handover. Acceptance is restricted to DC API response modes so a pre-registered client cannot bypass signature verification over a non-DC-API transport.

No wallet metadata change is needed: the `client_id_prefixes_supported` check is skipped when no prefix is present (the unsigned case). No `openid4vp` crate change is needed — `preregistered()` is a trait default method we override. Android-only path; iOS uses Apple `IdentityDocumentServices` and does not go through this code.

## Testing

Tested on a Pixel 9 (Showcase app) against `digital-credentials.dev`:
- Unsigned requests now complete successfully (vp_token returned, origin bound via handover).
- Signed requests unaffected.
- `cargo fmt --check` and `RUSTFLAGS="-Dwarnings" cargo clippy` pass.