### PR TITLE
Protocol discovery function (for interaction URLs)

### DIFF
--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -23612,6 +23612,9 @@ public enum DiscoveryError: Swift.Error, Equatable, Hashable, Foundation.Localiz
      */
     case Network(String
     )
+    /**
+     * Interaction URL provided is invalid
+     */
     case InvalidUrl(String
     )
     /**
@@ -36352,16 +36355,11 @@ public func generateDidJwkUrl(jwk: Jwk) -> DidUrl  {
     )
 })
 }
-/**
- * Resolve all protocol exchange URLs from an `interaction:` discovery endpoint.
- * The discovery URL must pass [`validate_endpoint_url`] (HTTPS, or loopback http
- * for local dev — §3.7.1/B.2; also rejects `file:`/other schemes a QR code could smuggle in).
- */
-public func discoverProtocols(discoveryUrl: String)async throws  -> [String: String]  {
+public func discoverProtocols(interactionUrl: String)async throws  -> [String: String]  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
-                uniffi_mobile_sdk_rs_fn_func_discover_protocols(FfiConverterString.lower(discoveryUrl)
+                uniffi_mobile_sdk_rs_fn_func_discover_protocols(FfiConverterString.lower(interactionUrl)
                 )
             },
             pollFunc: ffi_mobile_sdk_rs_rust_future_poll_rust_buffer,
@@ -36808,7 +36806,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_func_generate_did_jwk_url() != 10045) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mobile_sdk_rs_checksum_func_discover_protocols() != 58385) {
+    if (uniffi_mobile_sdk_rs_checksum_func_discover_protocols() != 45158) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_func_jwk_from_public_p256() != 27776) {

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -36355,6 +36355,9 @@ public func generateDidJwkUrl(jwk: Jwk) -> DidUrl  {
     )
 })
 }
+/**
+ * Standalone FFI entry point: no caller-supplied client, so build a fresh one
+ */
 public func discoverProtocols(interactionUrl: String)async throws  -> [String: String]  {
     return
         try  await uniffiRustCallAsync(
@@ -36806,7 +36809,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_func_generate_did_jwk_url() != 10045) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mobile_sdk_rs_checksum_func_discover_protocols() != 45158) {
+    if (uniffi_mobile_sdk_rs_checksum_func_discover_protocols() != 46344) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_func_jwk_from_public_p256() != 27776) {

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -23602,6 +23602,148 @@ public func FfiConverterTypeDisclosureSelection_lower(_ value: DisclosureSelecti
 }
 
 
+
+public enum DiscoveryError: Swift.Error, Equatable, Hashable, Foundation.LocalizedError {
+
+    
+    
+    /**
+     * A transport-level failure (stringified `reqwest::Error`).
+     */
+    case Network(String
+    )
+    case InvalidUrl(String
+    )
+    /**
+     * A 5xx (or otherwise non-2xx/4xx) server response.
+     */
+    case ServerError(status: UInt16, body: String
+    )
+    /**
+     * A response body failed to deserialize (stringified `serde_json::Error`).
+     */
+    case Deserialization(String
+    )
+    /**
+     * A response body exceeded the configured size cap (B.4).
+     */
+    case ResponseTooLarge(limitBytes: UInt64
+    )
+    /**
+     * A non-HTTPS (or non-HTTP-scheme) URL was rejected (§3.7.1 / B.2). Plain
+     * `http` is only accepted for loopback hosts (local development).
+     */
+    case InsecureUrl(String
+    )
+
+    
+
+    
+
+    
+    public var errorDescription: String? {
+        String(reflecting: self)
+    }
+    
+}
+
+#if compiler(>=6)
+extension DiscoveryError: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeDiscoveryError: FfiConverterRustBuffer {
+    typealias SwiftType = DiscoveryError
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DiscoveryError {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        
+
+        
+        case 1: return .Network(
+            try FfiConverterString.read(from: &buf)
+            )
+        case 2: return .InvalidUrl(
+            try FfiConverterString.read(from: &buf)
+            )
+        case 3: return .ServerError(
+            status: try FfiConverterUInt16.read(from: &buf), 
+            body: try FfiConverterString.read(from: &buf)
+            )
+        case 4: return .Deserialization(
+            try FfiConverterString.read(from: &buf)
+            )
+        case 5: return .ResponseTooLarge(
+            limitBytes: try FfiConverterUInt64.read(from: &buf)
+            )
+        case 6: return .InsecureUrl(
+            try FfiConverterString.read(from: &buf)
+            )
+
+         default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: DiscoveryError, into buf: inout [UInt8]) {
+        switch value {
+
+        
+
+        
+        
+        case let .Network(v1):
+            writeInt(&buf, Int32(1))
+            FfiConverterString.write(v1, into: &buf)
+            
+        
+        case let .InvalidUrl(v1):
+            writeInt(&buf, Int32(2))
+            FfiConverterString.write(v1, into: &buf)
+            
+        
+        case let .ServerError(status,body):
+            writeInt(&buf, Int32(3))
+            FfiConverterUInt16.write(status, into: &buf)
+            FfiConverterString.write(body, into: &buf)
+            
+        
+        case let .Deserialization(v1):
+            writeInt(&buf, Int32(4))
+            FfiConverterString.write(v1, into: &buf)
+            
+        
+        case let .ResponseTooLarge(limitBytes):
+            writeInt(&buf, Int32(5))
+            FfiConverterUInt64.write(limitBytes, into: &buf)
+            
+        
+        case let .InsecureUrl(v1):
+            writeInt(&buf, Int32(6))
+            FfiConverterString.write(v1, into: &buf)
+            
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeDiscoveryError_lift(_ buf: RustBuffer) throws -> DiscoveryError {
+    return try FfiConverterTypeDiscoveryError.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeDiscoveryError_lower(_ value: DiscoveryError) -> RustBuffer {
+    return FfiConverterTypeDiscoveryError.lower(value)
+}
+
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
@@ -36210,6 +36352,25 @@ public func generateDidJwkUrl(jwk: Jwk) -> DidUrl  {
     )
 })
 }
+/**
+ * Resolve all protocol exchange URLs from an `interaction:` discovery endpoint.
+ * The discovery URL must pass [`validate_endpoint_url`] (HTTPS, or loopback http
+ * for local dev — §3.7.1/B.2; also rejects `file:`/other schemes a QR code could smuggle in).
+ */
+public func discoverProtocols(discoveryUrl: String)async throws  -> [String: String]  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_mobile_sdk_rs_fn_func_discover_protocols(FfiConverterString.lower(discoveryUrl)
+                )
+            },
+            pollFunc: ffi_mobile_sdk_rs_rust_future_poll_rust_buffer,
+            completeFunc: ffi_mobile_sdk_rs_rust_future_complete_rust_buffer,
+            freeFunc: ffi_mobile_sdk_rs_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterDictionaryStringString.lift,
+            errorHandler: FfiConverterTypeDiscoveryError_lift
+        )
+}
 public func jwkFromPublicP256(x: Data, y: Data) -> Jwk  {
     return try!  FfiConverterTypeJwk_lift(try! rustCall() {
     uniffi_mobile_sdk_rs_fn_func_jwk_from_public_p256(
@@ -36645,6 +36806,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_func_generate_did_jwk_url() != 10045) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mobile_sdk_rs_checksum_func_discover_protocols() != 58385) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_func_jwk_from_public_p256() != 27776) {

--- a/rust/src/discover_protocols.rs
+++ b/rust/src/discover_protocols.rs
@@ -43,7 +43,7 @@ pub enum DiscoveryError {
 pub(crate) const MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
 
 #[uniffi::export(async_runtime = "tokio")]
-// Standalone FFI entry point: no caller-supplied client, so build a fresh one
+/// Standalone FFI entry point: no caller-supplied client, so build a fresh one
 pub async fn discover_protocols(
     interaction_url: &str,
 ) -> Result<HashMap<String, String>, DiscoveryError> {
@@ -307,7 +307,6 @@ mod tests {
         let err = discover_protocols("file:///etc/passwd")
             .await
             .expect_err("file: scheme must be rejected");
-        println!("{}", err);
         assert!(matches!(err, DiscoveryError::InsecureUrl(_)));
     }
 

--- a/rust/src/discover_protocols.rs
+++ b/rust/src/discover_protocols.rs
@@ -1,0 +1,142 @@
+use reqwest::header::ACCEPT;
+use std::collections::HashMap;
+use std::time::Duration;
+use url::Url;
+
+/// The discovery document returned for an `interaction:` initiation (§3.7.4).
+#[derive(serde::Deserialize)]
+struct DiscoveryResponse {
+    protocols: HashMap<String, String>,
+}
+#[derive(thiserror::Error, Debug, uniffi::Error)]
+pub enum DiscoveryError {
+    /// A transport-level failure (stringified `reqwest::Error`).
+    #[error("Network error: {0}")]
+    Network(String),
+
+    // Interaction URL provided is invalid
+    #[error("invalid URL: {0}")]
+    InvalidUrl(String),
+
+    /// A 5xx (or otherwise non-2xx/4xx) server response.
+    #[error("Server returned error status {status}")]
+    ServerError { status: u16, body: String },
+
+    /// A response body failed to deserialize (stringified `serde_json::Error`).
+    #[error("Failed to deserialize response: {0}")]
+    Deserialization(String),
+
+    /// A response body exceeded the configured size cap (B.4).
+    #[error("response body exceeded the {limit_bytes}-byte limit")]
+    ResponseTooLarge { limit_bytes: u64 },
+
+    /// A non-HTTPS (or non-HTTP-scheme) URL was rejected (§3.7.1 / B.2). Plain
+    /// `http` is only accepted for loopback hosts (local development).
+    #[error("insecure URL rejected: {0}")]
+    InsecureUrl(String),
+}
+
+/// Cap on a discovery/exchange response body (B.4: large payloads can trigger
+/// DoS incidents — a malicious or broken server must not be able to exhaust the
+/// wallet's memory). Generous for any plausible VPR/VP payload.
+pub(crate) const MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
+
+#[uniffi::export(async_runtime = "tokio")]
+/// Resolve all protocol exchange URLs from an `interaction:` discovery endpoint.
+/// The discovery URL must pass [`validate_endpoint_url`] (HTTPS, or loopback http
+/// for local dev — §3.7.1/B.2; also rejects `file:`/other schemes a QR code could smuggle in).
+pub async fn discover_protocols(
+    discovery_url: &str,
+) -> Result<HashMap<String, String>, DiscoveryError> {
+    let discovery_url = Url::parse(discovery_url)
+        .map_err(|e| DiscoveryError::InvalidUrl(format!("invalid exchange URL: {e}")))?;
+    validate_endpoint_url(&discovery_url)?;
+
+    let client = reqwest::Client::builder()
+        .use_rustls_tls()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|e| DiscoveryError::Network(e.to_string()))?;
+
+    let resp = client
+        .get(discovery_url)
+        .header(ACCEPT, "application/json")
+        .send()
+        .await
+        .map_err(|e| DiscoveryError::Network(e.to_string()))?;
+
+    let status = resp.status();
+    let body = read_body_capped(resp).await?;
+
+    if !status.is_success() {
+        return Err(DiscoveryError::ServerError {
+            status: status.as_u16(),
+            body,
+        });
+    }
+
+    let discovery: DiscoveryResponse =
+        serde_json::from_str(&body).map_err(|e| DiscoveryError::Deserialization(e.to_string()))?;
+
+    Ok(discovery.protocols)
+}
+
+/// §3.7.1: The interaction URL must be an HTTPS URL that contains an interaction-specific identifier.
+/// The URL SHOULD be opaque and require no URL syntax processing before it is fetched by the receiving
+/// system — the HTTPS origin is the trust signal the whole interaction model hangs on, and a bearer
+/// token must never travel over plaintext. Plain `http` is allowed ONLY for loopback hosts (local
+/// development/test servers); every other scheme (`file:`, custom schemes a QR code could smuggle in)
+/// is rejected.
+pub(crate) fn validate_endpoint_url(url: &Url) -> Result<(), DiscoveryError> {
+    match url.scheme() {
+        "https" => Ok(()),
+        "http" => {
+            let loopback = match url.host() {
+                Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
+                Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
+                Some(url::Host::Domain(d)) => d.eq_ignore_ascii_case("localhost"),
+                None => false,
+            };
+            if loopback {
+                Ok(())
+            } else {
+                Err(DiscoveryError::InsecureUrl(format!(
+                    "plain http is only allowed for loopback hosts, got {url}"
+                )))
+            }
+        }
+        other => Err(DiscoveryError::InsecureUrl(format!(
+            "unsupported URL scheme `{other}`"
+        ))),
+    }
+}
+
+/// Read a response body with a hard size cap (B.4). Checks `Content-Length`
+/// first, then enforces the cap while streaming, so a server that lies about
+/// (or omits) the length still cannot exhaust memory.
+pub(crate) async fn read_body_capped(
+    mut resp: reqwest::Response,
+) -> Result<String, DiscoveryError> {
+    if let Some(len) = resp.content_length() {
+        if len > MAX_RESPONSE_BYTES as u64 {
+            return Err(DiscoveryError::ResponseTooLarge {
+                limit_bytes: MAX_RESPONSE_BYTES as u64,
+            });
+        }
+    }
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(|e| DiscoveryError::Network(e.to_string()))?
+    {
+        if buf.len() + chunk.len() > MAX_RESPONSE_BYTES {
+            return Err(DiscoveryError::ResponseTooLarge {
+                limit_bytes: MAX_RESPONSE_BYTES as u64,
+            });
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    String::from_utf8(buf)
+        .map_err(|e| DiscoveryError::Deserialization(format!("response body is not UTF-8: {e}")))
+}

--- a/rust/src/discover_protocols.rs
+++ b/rust/src/discover_protocols.rs
@@ -1,4 +1,5 @@
 use reqwest::header::ACCEPT;
+use reqwest::Client;
 use std::collections::HashMap;
 use std::time::Duration;
 use url::Url;
@@ -14,7 +15,7 @@ pub enum DiscoveryError {
     #[error("Network error: {0}")]
     Network(String),
 
-    // Interaction URL provided is invalid
+    /// Interaction URL provided is invalid
     #[error("invalid URL: {0}")]
     InvalidUrl(String),
 
@@ -42,24 +43,35 @@ pub enum DiscoveryError {
 pub(crate) const MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
 
 #[uniffi::export(async_runtime = "tokio")]
+// Standalone FFI entry point: no caller-supplied client, so build a fresh one
+pub async fn discover_protocols(
+    interaction_url: &str,
+) -> Result<HashMap<String, String>, DiscoveryError> {
+    let new_client = build_http_client()?;
+    discover_protocols_with_client(interaction_url, &new_client).await
+}
+
 /// Resolve all protocol exchange URLs from an `interaction:` discovery endpoint.
 /// The discovery URL must pass [`validate_endpoint_url`] (HTTPS, or loopback http
 /// for local dev — §3.7.1/B.2; also rejects `file:`/other schemes a QR code could smuggle in).
-pub async fn discover_protocols(
-    discovery_url: &str,
+pub(crate) async fn discover_protocols_with_client(
+    interaction_url: &str,
+    client: &Client,
 ) -> Result<HashMap<String, String>, DiscoveryError> {
-    let discovery_url = Url::parse(discovery_url)
-        .map_err(|e| DiscoveryError::InvalidUrl(format!("invalid exchange URL: {e}")))?;
-    validate_endpoint_url(&discovery_url)?;
+    let interaction_url = Url::parse(interaction_url)
+        .map_err(|e| DiscoveryError::InvalidUrl(format!("invalid interaction URL: {e}")))?;
+    validate_endpoint_url(&interaction_url)?;
 
-    let client = reqwest::Client::builder()
-        .use_rustls_tls()
-        .timeout(Duration::from_secs(30))
-        .build()
-        .map_err(|e| DiscoveryError::Network(e.to_string()))?;
+    if let Some((_, version)) = interaction_url.query_pairs().find(|(k, _)| k == "iuv") {
+        if version != "1" {
+            return Err(DiscoveryError::InvalidUrl(format!(
+                "unsupported interaction URL version: iuv={version} (expected 1)"
+            )));
+        }
+    }
 
     let resp = client
-        .get(discovery_url)
+        .get(interaction_url)
         .header(ACCEPT, "application/json")
         .send()
         .await
@@ -139,4 +151,182 @@ pub(crate) async fn read_body_capped(
     }
     String::from_utf8(buf)
         .map_err(|e| DiscoveryError::Deserialization(format!("response body is not UTF-8: {e}")))
+}
+
+pub(crate) fn build_http_client() -> Result<Client, DiscoveryError> {
+    let client = reqwest::Client::builder()
+        .use_rustls_tls()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|e| DiscoveryError::Network(e.to_string()))?;
+
+    Ok(client)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::discover_protocols::{discover_protocols, DiscoveryError};
+    use serde_json::json;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn initiation_interaction_runs_discovery() {
+        // Full protocol map returned from server when valid interaction URL is fetched using `Accept: application/json` header (§3.7.4)
+        let server = MockServer::start().await;
+        let base = server.uri();
+
+        // Representative URLs returned for each protocol
+        let vcapi_url = format!("{base}/workflows/123/exchanges/987");
+        let oid4vp_url = "openid4vp://?client_id=https%3A%2F%2Fapp.example%2Fworkflows%2F123%2Fexchanges%2F987%2Fopenid%2Fclient%2Fauthorization%2Fresponse&request_uri=https%3A%2F%2Fapp.example%2Fworkflows%2F123%2Fexchanges%2F987%2Fopenid%2Fclient%2Fauthorization%2Frequest";
+
+        Mock::given(method("GET"))
+            .and(path("/interactions/z8n38Dp7a"))
+            .and(header("accept", "application/json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "protocols": {
+                    "vcapi": vcapi_url,
+                    "OID4VP": oid4vp_url,
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let result = discover_protocols(&format!("{base}/interactions/z8n38Dp7a?iuv=1"))
+            .await
+            .expect("all supported protocols should be returned");
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(
+            result.get("vcapi").map(String::as_str),
+            Some(vcapi_url.as_str())
+        );
+        assert_eq!(result.get("OID4VP").map(String::as_str), Some(oid4vp_url));
+    }
+
+    #[tokio::test]
+    async fn server_5xx_is_server_error() {
+        // 500 server response results in `DiscoveryError::ServerError`
+        let server = MockServer::start().await;
+        let base = server.uri();
+
+        Mock::given(method("GET"))
+            .and(path("/interactions/z8n38Dp7a"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+            .mount(&server)
+            .await;
+
+        let err = discover_protocols(&format!("{base}/interactions/z8n38Dp7a"))
+            .await
+            .expect_err("a 500 response must be an error");
+
+        match err {
+            DiscoveryError::ServerError { status, body } => {
+                assert_eq!(status, 500);
+                assert_eq!(body, "boom");
+            }
+            other => panic!("expected ServerError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn server_4xx_is_server_error() {
+        // 4xx responses are also surfaced as `DiscoveryError::ServerError`.
+        let server = MockServer::start().await;
+        let base = server.uri();
+
+        Mock::given(method("GET"))
+            .and(path("/interactions/z8n38Dp7a"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let err = discover_protocols(&format!("{base}/interactions/z8n38Dp7a"))
+            .await
+            .expect_err("a 404 response must be an error");
+
+        assert!(matches!(
+            err,
+            DiscoveryError::ServerError { status: 404, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn non_json_body_is_deserialization_error() {
+        // Non-JSON response body results in `DiscoveryError::Deserialization`
+        let server = MockServer::start().await;
+        let base = server.uri();
+
+        Mock::given(method("GET"))
+            .and(path("/interactions/z8n38Dp7a"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("<html>not json</html>"))
+            .mount(&server)
+            .await;
+
+        let err = discover_protocols(&format!("{base}/interactions/z8n38Dp7a"))
+            .await
+            .expect_err("a non-JSON body must fail to deserialize");
+
+        assert!(matches!(err, DiscoveryError::Deserialization(_)));
+    }
+
+    #[tokio::test]
+    async fn json_without_protocols_key_is_deserialization_error() {
+        // A 200 response without the `protocols` key results in `DiscoveryError::Deserialization`
+        let server = MockServer::start().await;
+        let base = server.uri();
+
+        Mock::given(method("GET"))
+            .and(path("/interactions/z8n38Dp7a"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "foo": "bar" })))
+            .mount(&server)
+            .await;
+
+        let err = discover_protocols(&format!("{base}/interactions/z8n38Dp7a"))
+            .await
+            .expect_err("JSON missing `protocols` must be a deserialization error");
+
+        assert!(matches!(err, DiscoveryError::Deserialization(_)));
+    }
+
+    #[tokio::test]
+    async fn non_loopback_http_is_insecure() {
+        // A non-loopback plain-http URL is rejected (§3.7.1/B.2).
+        let err = discover_protocols("http://example.com/interactions/z8n38Dp7a")
+            .await
+            .expect_err("plain http to a non-loopback host must be rejected");
+
+        assert!(matches!(err, DiscoveryError::InsecureUrl(_)));
+    }
+
+    /// A `file:` URL (the sort a malicious QR code could smuggle in) is rejected.
+    #[tokio::test]
+    async fn file_scheme_is_insecure() {
+        let err = discover_protocols("file:///etc/passwd")
+            .await
+            .expect_err("file: scheme must be rejected");
+        println!("{}", err);
+        assert!(matches!(err, DiscoveryError::InsecureUrl(_)));
+    }
+
+    #[tokio::test]
+    async fn unsupported_iuv_version_is_invalid_url() {
+        // Unsupported interaction-URL version (`iuv` != 1) is rejected
+        let err = discover_protocols("https://example.com/interactions/z8n38Dp7a?iuv=2")
+            .await
+            .expect_err("iuv=2 is not supported");
+
+        assert!(matches!(err, DiscoveryError::InvalidUrl(_)));
+    }
+
+    #[tokio::test]
+    async fn malformed_url_is_invalid_url() {
+        // A syntactically malformed URL is rejected as `InvalidUrl`.
+        let err = discover_protocols("not a url")
+            .await
+            .expect_err("a malformed URL must be rejected");
+        assert!(matches!(err, DiscoveryError::InvalidUrl(_)));
+    }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -8,6 +8,7 @@ pub mod context;
 pub mod credential;
 pub mod crypto;
 pub mod did;
+pub mod discover_protocols;
 pub mod haci;
 pub mod jwk;
 pub mod jws;

--- a/rust/src/vcalm/error.rs
+++ b/rust/src/vcalm/error.rs
@@ -128,7 +128,8 @@ impl From<crate::discover_protocols::DiscoveryError> for VcalmError {
                 VcalmError::ResponseTooLarge { limit_bytes }
             }
             DiscoveryError::InsecureUrl(v) => VcalmError::InsecureUrl(v),
-            other => VcalmError::Network(other.to_string()),
+            DiscoveryError::Network(v) => VcalmError::Network(v),
+            DiscoveryError::InvalidUrl(v) => VcalmError::Network(v),
         }
     }
 }

--- a/rust/src/vcalm/error.rs
+++ b/rust/src/vcalm/error.rs
@@ -115,3 +115,20 @@ impl From<uniffi::UnexpectedUniFFICallbackError> for VcalmError {
         VcalmError::UnexpectedUniFFICallbackError(value.reason)
     }
 }
+
+impl From<crate::discover_protocols::DiscoveryError> for VcalmError {
+    fn from(e: crate::discover_protocols::DiscoveryError) -> Self {
+        use crate::discover_protocols::DiscoveryError;
+        match e {
+            DiscoveryError::ServerError { status, body } => {
+                VcalmError::ServerError { status, body }
+            }
+            DiscoveryError::Deserialization(v) => VcalmError::Deserialization(v),
+            DiscoveryError::ResponseTooLarge { limit_bytes } => {
+                VcalmError::ResponseTooLarge { limit_bytes }
+            }
+            DiscoveryError::InsecureUrl(v) => VcalmError::InsecureUrl(v),
+            other => VcalmError::Network(other.to_string()),
+        }
+    }
+}

--- a/rust/src/vcalm/holder.rs
+++ b/rust/src/vcalm/holder.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
 
 use futures::StreamExt;
 use reqwest::header::AUTHORIZATION;
@@ -17,7 +16,9 @@ use uuid::Uuid;
 use crate::credential::json_vc::{JsonVc, SD_BASE_PROOF_CRYPTOSUITES};
 use crate::credential::{verify_raw_credential, Credential, InvalidCredential, ParsedCredential};
 use crate::crypto::KeyStore;
-use crate::discover_protocols::{discover_protocols, read_body_capped, validate_endpoint_url};
+use crate::discover_protocols::{
+    build_http_client, discover_protocols_with_client, read_body_capped, validate_endpoint_url,
+};
 use crate::oid4vp::presentation::{PresentationError, PresentationSigner};
 use crate::vdc_collection::VdcCollection;
 
@@ -100,11 +101,7 @@ impl VcalmHolder {
         context_map: Option<HashMap<String, String>>,
         keystore: Option<Arc<dyn KeyStore>>,
     ) -> Result<Arc<Self>, VcalmError> {
-        let client = reqwest::Client::builder()
-            .use_rustls_tls()
-            .timeout(Duration::from_secs(30))
-            .build()
-            .map_err(|e| VcalmError::Network(e.to_string()))?;
+        let client = build_http_client()?;
 
         // Default to the SDK's bundled JSON-LD contexts (W3C + the full set:
         // alumni, first-responder, citizenship, render-method,
@@ -174,18 +171,12 @@ impl VcalmHolder {
             // this API"). Route those through discovery — POSTing `{}` straight at a
             // discovery endpoint never starts the exchange. URLs without `iuv` keep
             // the existing direct-exchange-URL behavior.
-            match url.query_pairs().find(|(k, _)| k == "iuv") {
-                Some((_, v)) if v == "1" => self.discover_vcapi(url.as_str()).await?,
-                Some((_, v)) => {
-                    return Err(VcalmError::Network(format!(
-                        "unsupported interaction URL version: iuv={v} (expected 1)"
-                    )))
-                }
-                None => {
-                    // §3.7.1/B.2: HTTPS-only (loopback http allowed for local dev).
-                    validate_endpoint_url(&url)?;
-                    url
-                }
+            if url.query_pairs().any(|(k, _)| k == "iuv") {
+                self.discover_vcapi(url.as_str()).await?
+            } else {
+                // §3.7.1/B.2: HTTPS-only (loopback http allowed for local dev).
+                validate_endpoint_url(&url)?;
+                url
             }
         };
 
@@ -1080,7 +1071,7 @@ impl VcalmHolder {
     /// (HTTPS, or loopback http for local dev — §3.7.1/B.2; also rejects
     /// `file:`/other schemes a QR code could smuggle in).
     async fn discover_vcapi(&self, discovery_url: &str) -> Result<Url, VcalmError> {
-        let all_protocols = discover_protocols(discovery_url).await?;
+        let all_protocols = discover_protocols_with_client(discovery_url, &self.client).await?;
 
         let vcapi = all_protocols
             .get("vcapi")

--- a/rust/src/vcalm/holder.rs
+++ b/rust/src/vcalm/holder.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::StreamExt;
-use reqwest::header::{ACCEPT, AUTHORIZATION};
+use reqwest::header::AUTHORIZATION;
 use ssi::claims::vc::{
     syntax::{IdOr, NonEmptyObject},
     v1::JsonPresentation as JsonPresentationV1,
@@ -17,6 +17,7 @@ use uuid::Uuid;
 use crate::credential::json_vc::{JsonVc, SD_BASE_PROOF_CRYPTOSUITES};
 use crate::credential::{verify_raw_credential, Credential, InvalidCredential, ParsedCredential};
 use crate::crypto::KeyStore;
+use crate::discover_protocols::{discover_protocols, read_body_capped, validate_endpoint_url};
 use crate::oid4vp::presentation::{PresentationError, PresentationSigner};
 use crate::vdc_collection::VdcCollection;
 
@@ -25,11 +26,6 @@ use super::exchange::{classify, AcceptedMethodEntry, StepResult, VcapiMessage, V
 use super::issuance::{self, OfferedEntry};
 use super::matching::{self, QueryKind};
 use super::presentation::{unsupported_cryptosuite_negotiation, vpr_lists_sd_suite, VpSigner};
-
-/// Cap on a discovery/exchange response body (B.4: large payloads can trigger
-/// DoS incidents — a malicious or broken server must not be able to exhaust the
-/// wallet's memory). Generous for any plausible VPR/VP payload.
-const MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
 
 /// Interior, mutable session state retained across calls on a shared `Arc<VcalmHolder>`.
 /// Guarded by a `tokio::sync::Mutex` on the [`VcalmHolder`].
@@ -83,12 +79,6 @@ pub struct VcalmHolder {
     /// presentable via VCALM. Issuance (`accept_offer`) still stores into
     /// `vdc_collection`.
     pub(crate) provided_credentials: tokio::sync::Mutex<Option<Vec<Arc<ParsedCredential>>>>,
-}
-
-/// The discovery document returned for an `interaction:` initiation (§3.7.4).
-#[derive(serde::Deserialize)]
-struct DiscoveryResponse {
-    protocols: HashMap<String, String>,
 }
 
 #[uniffi::export(async_runtime = "tokio")]
@@ -1086,38 +1076,13 @@ impl VcalmHolder {
     }
 
     /// Resolve the `vcapi` exchange URL from an `interaction:` discovery endpoint.
-    /// The bearer token is intentionally NOT attached here. Both the discovery
-    /// URL and the discovered `vcapi` URL must pass [`validate_endpoint_url`]
+    /// Both the discovery URL and the discovered `vcapi` URL must pass [`validate_endpoint_url`]
     /// (HTTPS, or loopback http for local dev — §3.7.1/B.2; also rejects
     /// `file:`/other schemes a QR code could smuggle in).
     async fn discover_vcapi(&self, discovery_url: &str) -> Result<Url, VcalmError> {
-        let discovery_url = Url::parse(discovery_url)
-            .map_err(|e| VcalmError::Network(format!("invalid interaction URL: {e}")))?;
-        validate_endpoint_url(&discovery_url)?;
+        let all_protocols = discover_protocols(discovery_url).await?;
 
-        let resp = self
-            .client
-            .get(discovery_url)
-            .header(ACCEPT, "application/json")
-            .send()
-            .await
-            .map_err(|e| VcalmError::Network(e.to_string()))?;
-
-        let status = resp.status();
-        let body = read_body_capped(resp).await?;
-
-        if !status.is_success() {
-            return Err(VcalmError::ServerError {
-                status: status.as_u16(),
-                body,
-            });
-        }
-
-        let discovery: DiscoveryResponse =
-            serde_json::from_str(&body).map_err(|e| VcalmError::Deserialization(e.to_string()))?;
-
-        let vcapi = discovery
-            .protocols
+        let vcapi = all_protocols
             .get("vcapi")
             .ok_or(VcalmError::NoVcapiProtocol)?;
 
@@ -1337,63 +1302,6 @@ pub struct VcalmRequestedField {
 struct ExampleField {
     path: String,
     value: String,
-}
-
-/// Read a response body with a hard size cap (B.4). Checks `Content-Length`
-/// first, then enforces the cap while streaming, so a server that lies about
-/// (or omits) the length still cannot exhaust memory.
-async fn read_body_capped(mut resp: reqwest::Response) -> Result<String, VcalmError> {
-    if let Some(len) = resp.content_length() {
-        if len > MAX_RESPONSE_BYTES as u64 {
-            return Err(VcalmError::ResponseTooLarge {
-                limit_bytes: MAX_RESPONSE_BYTES as u64,
-            });
-        }
-    }
-    let mut buf: Vec<u8> = Vec::new();
-    while let Some(chunk) = resp
-        .chunk()
-        .await
-        .map_err(|e| VcalmError::Network(e.to_string()))?
-    {
-        if buf.len() + chunk.len() > MAX_RESPONSE_BYTES {
-            return Err(VcalmError::ResponseTooLarge {
-                limit_bytes: MAX_RESPONSE_BYTES as u64,
-            });
-        }
-        buf.extend_from_slice(&chunk);
-    }
-    String::from_utf8(buf)
-        .map_err(|e| VcalmError::Deserialization(format!("response body is not UTF-8: {e}")))
-}
-
-/// §3.7.1/B.2: interaction, discovery, and exchange URLs must be HTTPS — the
-/// HTTPS origin is the trust signal the whole interaction model hangs on, and a
-/// bearer token must never travel over plaintext. Plain `http` is allowed ONLY
-/// for loopback hosts (local development/test servers); every other scheme
-/// (`file:`, custom schemes a QR code could smuggle in) is rejected.
-fn validate_endpoint_url(url: &Url) -> Result<(), VcalmError> {
-    match url.scheme() {
-        "https" => Ok(()),
-        "http" => {
-            let loopback = match url.host() {
-                Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
-                Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
-                Some(url::Host::Domain(d)) => d.eq_ignore_ascii_case("localhost"),
-                None => false,
-            };
-            if loopback {
-                Ok(())
-            } else {
-                Err(VcalmError::InsecureUrl(format!(
-                    "plain http is only allowed for loopback hosts, got {url}"
-                )))
-            }
-        }
-        other => Err(VcalmError::InsecureUrl(format!(
-            "unsupported URL scheme `{other}`"
-        ))),
-    }
 }
 
 /// §3.4.3.2: "Holder implementations MUST ensure that the `domain` specified by


### PR DESCRIPTION
## Description

**Added:** `discover_protocols`, to fetch all protocols for an interaction URL
**Currently** `VcalmHolder.start_exchange` discovers all protocols, but only uses the `vcapi` key, throwing the other protocol data away. As a result, implementations in Swift/Kotlin have to make a separate GET call to discover protocols, offer them ALL to the user, then leverage functions like `start_exchange` only if the user selected `VCALM`. 
**Updated behaviour** allows the Rust side to continue discovering all the protocols.  `discover_protocols` is implemented as a free function (not tied to a struct) to make it accessible regardless of the protocol

### Other changes
Wired in the use of `discover_protocols` into `VcalmHolder.start_exchange`, and passed appropriate error types to `VcalmError`

## Tested
Existing test suites in `rust/src/vcalm/holder.rs` were validated, and use of `discover_protocols` in the SwiftUI layer was validated (is accessible and functions as expected)
