### PR TITLE
Showcase: update targetSdk from 35 to 36

### DIFF
--- a/android/Showcase/build.gradle.kts
+++ b/android/Showcase/build.gradle.kts
@@ -35,12 +35,12 @@ licensee {
 
 android {
     namespace = "com.spruceid.mobilesdkexample"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.spruceid.mobilesdkexample"
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 60
         versionName = "1.18.2"
 

--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -32,7 +32,7 @@ apply plugin: "org.jetbrains.kotlin.plugin.compose"
 android {
     namespace = "com.spruceid.sprucekit_mobile"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
## Description

Updated Sprucekit Showcase `targetSdk` from 35 to 36. 

### Other changes

None

### Optional section

- I didn't updated the `targetSdk` for `MobileSdk` and `MobileSdkRs`, not sure about the possible consequences for dependent apps. cc @sbihel 
- We need to release a new Showcase version before 31 Aug.

## Tested

- [X] Android app compiled successfully
