### PR TITLE
Surface dynamic credential providers + presentation-required issuance in the Flutter plugin

### DIFF
--- a/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/Oid4vci.g.kt
+++ b/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/Oid4vci.g.kt
@@ -448,6 +448,51 @@ data class Oid4vciError (
 
   override fun hashCode(): Int = toList().hashCode()
 }
+
+/**
+ * Issuance interrupted: the issuer requires an OID4VP presentation before it
+ * will release the credential (issuer error `presentation_required`).
+ *
+ * Recovery: run the OID4VP flow with [authorizationRequestJson] as the
+ * request string, then re-run the issuance from the same offer URL. A second
+ * `Oid4vciPresentationRequired` on the retry is a failure.
+ *
+ * Only reachable when `supportedVersions` is empty (auto) or contains
+ * [Oid4vciVersion.legacy]: the v1 HTTP client discards error-response
+ * bodies, so a pure-v1 exchange cannot detect it.
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class Oid4vciPresentationRequired (
+  /**
+   * The OID4VP authorization request JSON, verbatim from the issuer's
+   * `presentation_required` error body.
+   */
+  val authorizationRequestJson: String
+) : Oid4vciResult()
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): Oid4vciPresentationRequired {
+      val authorizationRequestJson = pigeonVar_list[0] as String
+      return Oid4vciPresentationRequired(authorizationRequestJson)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      authorizationRequestJson,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other !is Oid4vciPresentationRequired) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    return Oid4vciPigeonUtils.deepEquals(toList(), other.toList())  }
+
+  override fun hashCode(): Int = toList().hashCode()
+}
 private open class Oid4vciPigeonCodec : StandardMessageCodec() {
   override fun readValueOfType(type: Byte, buffer: ByteBuffer): Any? {
     return when (type) {
@@ -506,6 +551,11 @@ private open class Oid4vciPigeonCodec : StandardMessageCodec() {
           Oid4vciError.fromList(it)
         }
       }
+      140.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          Oid4vciPresentationRequired.fromList(it)
+        }
+      }
       else -> super.readValueOfType(type, buffer)
     }
   }
@@ -553,6 +603,10 @@ private open class Oid4vciPigeonCodec : StandardMessageCodec() {
       }
       is Oid4vciError -> {
         stream.write(139)
+        writeValue(stream, value.toList())
+      }
+      is Oid4vciPresentationRequired -> {
+        stream.write(140)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)

--- a/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/Oid4vciAdapter.kt
+++ b/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/Oid4vciAdapter.kt
@@ -65,6 +65,8 @@ internal class Oid4vciAdapter(private val context: Context) : Oid4vci {
                     supportedVersions = supportedVersions,
                 )
                 callback(Result.success(result))
+            } catch (e: Oid4vciException.PresentationRequired) {
+                callback(Result.success(presentationRequiredResult(e)))
             } catch (e: Exception) {
                 callback(Result.success(Oid4vciError(message = e.localizedMessage ?: "Unknown error")))
             }
@@ -151,6 +153,9 @@ internal class Oid4vciAdapter(private val context: Context) : Oid4vci {
                 val credentials = exchangeCredentialWithToken(ctx, credentialToken)
                 sessions.remove(sessionId)
                 callback(Result.success(Oid4vciSuccess(credentials)))
+            } catch (e: Oid4vciException.PresentationRequired) {
+                sessions.remove(sessionId)
+                callback(Result.success(presentationRequiredResult(e)))
             } catch (e: Exception) {
                 sessions.remove(sessionId)
                 callback(Result.success(Oid4vciError(e.message ?: "unknown")))
@@ -210,6 +215,9 @@ internal class Oid4vciAdapter(private val context: Context) : Oid4vci {
                 val credentials = exchangeCredentialWithToken(ctx, credentialToken)
                 sessions.remove(sessionId)
                 callback(Result.success(Oid4vciSuccess(credentials)))
+            } catch (e: Oid4vciException.PresentationRequired) {
+                sessions.remove(sessionId)
+                callback(Result.success(presentationRequiredResult(e)))
             } catch (e: Exception) {
                 sessions.remove(sessionId)
                 callback(Result.success(Oid4vciError(e.message ?: "unknown")))
@@ -226,6 +234,19 @@ internal class Oid4vciAdapter(private val context: Context) : Oid4vci {
     }
 
     // — Helpers —
+
+    /// `Oid4vciException` is a uniffi flat error: for `PresentationRequired`
+    /// the message is the verbatim OID4VP authorization_request JSON.
+    private fun presentationRequiredResult(
+        e: Oid4vciException.PresentationRequired,
+    ): Oid4vciResult {
+        val json = e.message.orEmpty()
+        return if (json.isNotEmpty()) {
+            Oid4vciPresentationRequired(authorizationRequestJson = json)
+        } else {
+            Oid4vciError(message = "presentation required (missing authorization_request)")
+        }
+    }
 
     private fun normalizeOfferUrl(credentialOffer: String): String =
         if (credentialOffer.startsWith("openid-credential-offer://")) credentialOffer

--- a/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/Oid4vp.g.kt
+++ b/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/Oid4vp.g.kt
@@ -533,6 +533,51 @@ data class CredentialRequirementData (
 
   override fun hashCode(): Int = toList().hashCode()
 }
+
+/**
+ * A dynamic credential offer surfaced by a registered native
+ * `DynamicCredentialProvider`.
+ *
+ * Offers are issued only if the user selects them: pass the `offerId` to
+ * `submitResponseWithOffers`. Only OID4VP-v1 sessions surface offers.
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class DynamicOfferData (
+  /** Provider-scoped identifier, echoed back via `submitResponseWithOffers`. */
+  val offerId: String,
+  /** The DCQL credential-query id this offer satisfies. */
+  val credentialQueryId: String,
+  /** Human-readable label for the consent UI. */
+  val title: String
+)
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): DynamicOfferData {
+      val offerId = pigeonVar_list[0] as String
+      val credentialQueryId = pigeonVar_list[1] as String
+      val title = pigeonVar_list[2] as String
+      return DynamicOfferData(offerId, credentialQueryId, title)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      offerId,
+      credentialQueryId,
+      title,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other !is DynamicOfferData) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    return Oid4vpPigeonUtils.deepEquals(toList(), other.toList())  }
+
+  override fun hashCode(): Int = toList().hashCode()
+}
 private open class Oid4vpPigeonCodec : StandardMessageCodec() {
   override fun readValueOfType(type: Byte, buffer: ByteBuffer): Any? {
     return when (type) {
@@ -596,6 +641,11 @@ private open class Oid4vpPigeonCodec : StandardMessageCodec() {
           CredentialRequirementData.fromList(it)
         }
       }
+      141.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          DynamicOfferData.fromList(it)
+        }
+      }
       else -> super.readValueOfType(type, buffer)
     }
   }
@@ -647,6 +697,10 @@ private open class Oid4vpPigeonCodec : StandardMessageCodec() {
       }
       is CredentialRequirementData -> {
         stream.write(140)
+        writeValue(stream, value.toList())
+      }
+      is DynamicOfferData -> {
+        stream.write(141)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)
@@ -705,6 +759,14 @@ interface Oid4vp {
    */
   fun submitResponse(selectedCredentials: List<PresentableCredentialKey>, selectedFieldPaths: List<List<String>>, options: ResponseOptions, callback: (Result<Oid4vpResult>) -> Unit)
   /**
+   * Submit the response, additionally issuing the dynamic credential offers
+   * selected by `offerId` from `getDynamicOffers`.
+   *
+   * `selectedCredentials` may be empty if at least one offer is selected.
+   * Unknown offer ids fail the whole submission.
+   */
+  fun submitResponseWithOffers(selectedCredentials: List<PresentableCredentialKey>, selectedFieldPaths: List<List<String>>, selectedOfferIds: List<String>, options: ResponseOptions, callback: (Result<Oid4vpResult>) -> Unit)
+  /**
    * Get credential requirements from the permission request
    *
    * @return List of credential requirements
@@ -722,6 +784,13 @@ interface Oid4vp {
    * @return List of credential query ID strings
    */
   fun getCredentialQueryIds(): List<String>
+  /**
+   * Get the dynamic credential offers for the current session.
+   *
+   * Empty when no providers are registered, none match the request, or the
+   * negotiated version is not v1. Call after `handleAuthorizationRequest`.
+   */
+  fun getDynamicOffers(): List<DynamicOfferData>
   /** Cancel and cleanup the current session */
   fun cancel()
 
@@ -818,6 +887,29 @@ interface Oid4vp {
         }
       }
       run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.sprucekit_mobile.Oid4vp.submitResponseWithOffers$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val selectedCredentialsArg = args[0] as List<PresentableCredentialKey>
+            val selectedFieldPathsArg = args[1] as List<List<String>>
+            val selectedOfferIdsArg = args[2] as List<String>
+            val optionsArg = args[3] as ResponseOptions
+            api.submitResponseWithOffers(selectedCredentialsArg, selectedFieldPathsArg, selectedOfferIdsArg, optionsArg) { result: Result<Oid4vpResult> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(Oid4vpPigeonUtils.wrapError(error))
+              } else {
+                val data = result.getOrNull()
+                reply.reply(Oid4vpPigeonUtils.wrapResult(data))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
         val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.sprucekit_mobile.Oid4vp.getCredentialRequirements$separatedMessageChannelSuffix", codec)
         if (api != null) {
           channel.setMessageHandler { _, reply ->
@@ -853,6 +945,21 @@ interface Oid4vp {
           channel.setMessageHandler { _, reply ->
             val wrapped: List<Any?> = try {
               listOf(api.getCredentialQueryIds())
+            } catch (exception: Throwable) {
+              Oid4vpPigeonUtils.wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.sprucekit_mobile.Oid4vp.getDynamicOffers$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            val wrapped: List<Any?> = try {
+              listOf(api.getDynamicOffers())
             } catch (exception: Throwable) {
               Oid4vpPigeonUtils.wrapError(exception)
             }

--- a/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/Oid4vpAdapter.kt
+++ b/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/Oid4vpAdapter.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.spruceid.mobile.sdk.KeyManager
 import com.spruceid.mobile.sdk.rs.DidMethod
 import com.spruceid.mobile.sdk.rs.DidMethodUtils
+import com.spruceid.mobile.sdk.rs.DynamicCredentialOffer as RsDynamicCredentialOffer
 import com.spruceid.mobile.sdk.rs.Oid4vpHolder
 import com.spruceid.mobile.sdk.rs.Oid4vpPresentableCredential
 import com.spruceid.mobile.sdk.rs.Oid4vpPresentationSigner
@@ -95,6 +96,13 @@ internal class Oid4vpAdapter(
      */
     private var credentialsByKey: Map<PresentableCredentialKey, Oid4vpPresentableCredential> = emptyMap()
 
+    /**
+     * Dynamic credential offers for the current session, keyed by `offerId`.
+     * Dart echoes ids back; these records are the authoritative ones passed
+     * to the Rust session.
+     */
+    private var dynamicOffersById: Map<String, RsDynamicCredentialOffer> = emptyMap()
+
     /** Maps the pigeon-facing supported versions to the Rust facade enum. */
     private fun rustVersions(versions: List<Oid4vpVersion>): List<RsOid4vpVersion> =
         versions.map { version ->
@@ -136,7 +144,12 @@ internal class Oid4vpAdapter(
                     credentials.addAll(packCredentials)
                 }
 
-                if (credentials.isEmpty()) {
+                // Snapshot registered providers for the lifetime of this
+                // holder. With providers, an empty credential pack is valid:
+                // the whole response may be issued on the fly.
+                val providers = SprucekitMobilePlugin.dynamicCredentialProviders.toList()
+
+                if (credentials.isEmpty() && providers.isEmpty()) {
                     callback(Result.success(Oid4vpError(message = "No credentials found in provided packs")))
                     return@launch
                 }
@@ -145,12 +158,13 @@ internal class Oid4vpAdapter(
                 val signer = Oid4vpSigner(keyId)
 
                 // Create holder (version-agnostic facade)
-                val newHolder = Oid4vpHolder.newWithCredentials(
+                val newHolder = Oid4vpHolder.newWithCredentialsAndProviders(
                     credentials,
                     trustedDids,
                     signer,
                     contextMap,
-                    KeyManager()
+                    KeyManager(),
+                    providers
                 )
 
                 synchronized(this@Oid4vpAdapter) {
@@ -180,7 +194,10 @@ internal class Oid4vpAdapter(
                 }
 
                 // Handle URL format (remove "authorize" if present, similar to Showcase)
-                val processedUrl = url.replace("authorize", "")
+                // A JSON authorization-request body must pass through
+                // verbatim, so only munge URL-shaped inputs.
+                val trimmed = url.trim()
+                val processedUrl = if (trimmed.startsWith("{")) trimmed else url.replace("authorize", "")
 
                 // Start a session, restricting negotiation to `supportedVersions`.
                 val session = currentHolder.startWithSupportedVersions(processedUrl, rustVersions(supportedVersions))
@@ -209,12 +226,19 @@ internal class Oid4vpAdapter(
                     }
                 }
 
+                // Dynamic offers from registered providers; always empty
+                // for non-v1 sessions.
+                val offers = session.dynamicOffers()
+
                 synchronized(this@Oid4vpAdapter) {
                     this@Oid4vpAdapter.session = session
                     this@Oid4vpAdapter.credentialsByKey = keyMap
+                    // First record wins on duplicate offerIds.
+                    this@Oid4vpAdapter.dynamicOffersById =
+                        offers.distinctBy { it.offerId }.associateBy { it.offerId }
                 }
 
-                if (credentialData.isEmpty()) {
+                if (credentialData.isEmpty() && offers.isEmpty()) {
                     callback(Result.success(HandleAuthRequestError(
                         message = "No matching credentials found for this verification request"
                     )))
@@ -360,11 +384,94 @@ internal class Oid4vpAdapter(
         return groupedByQuery(session).map { it.first }
     }
 
+    override fun getDynamicOffers(): List<DynamicOfferData> {
+        val offers = synchronized(this) { dynamicOffersById }
+        return offers.values.map { offer ->
+            DynamicOfferData(
+                offerId = offer.offerId,
+                credentialQueryId = offer.credentialQueryId,
+                title = offer.title
+            )
+        }
+    }
+
+    override fun submitResponseWithOffers(
+        selectedCredentials: List<PresentableCredentialKey>,
+        selectedFieldPaths: List<List<String>>,
+        selectedOfferIds: List<String>,
+        options: ResponseOptions,
+        callback: (Result<Oid4vpResult>) -> Unit
+    ) {
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val currentSession = synchronized(this@Oid4vpAdapter) { session }
+                val keyMap = synchronized(this@Oid4vpAdapter) { credentialsByKey }
+                val offerMap = synchronized(this@Oid4vpAdapter) { dynamicOffersById }
+
+                if (currentSession == null) {
+                    callback(Result.success(Oid4vpError(message = "Session not initialized")))
+                    return@launch
+                }
+
+                val resolvedCredentials = selectedCredentials.mapNotNull { keyMap[it] }
+                val resolvedOffers = selectedOfferIds.mapNotNull { offerMap[it] }
+
+                // Each offer may be selected at most once — a duplicate id
+                // would be issued twice and still pass the size check below.
+                if (selectedOfferIds.toSet().size != selectedOfferIds.size) {
+                    callback(Result.success(Oid4vpError(
+                        message = "Duplicate dynamic offer id selected"
+                    )))
+                    return@launch
+                }
+
+                if (resolvedOffers.size != selectedOfferIds.size) {
+                    callback(Result.success(Oid4vpError(
+                        message = "Unknown dynamic offer id selected"
+                    )))
+                    return@launch
+                }
+
+                if (resolvedCredentials.isEmpty() && resolvedOffers.isEmpty()) {
+                    callback(Result.success(Oid4vpError(
+                        message = "No valid credentials or offers selected"
+                    )))
+                    return@launch
+                }
+
+                // `shouldStripQuotes` and `removeVpPathPrefix` are Draft
+                // 18-only knobs not surfaced by the pigeon API; keep off.
+                val responseOptions = RsResponseOptions(
+                    forceArraySerialization = options.forceArraySerialization,
+                    shouldStripQuotes = false,
+                    removeVpPathPrefix = false
+                )
+
+                // Selected offers are issued while creating the response.
+                val permissionResponse = currentSession.createPermissionResponseWithOffers(
+                    resolvedCredentials,
+                    selectedFieldPaths,
+                    resolvedOffers,
+                    responseOptions
+                )
+
+                currentSession.submitPermissionResponse(permissionResponse)
+
+                callback(Result.success(Oid4vpSuccess(message = "Presentation submitted successfully")))
+            } catch (e: Exception) {
+                callback(Result.success(Oid4vpError(
+                    message = e.localizedMessage ?: "Failed to submit response"
+                )))
+            }
+        }
+    }
+
     override fun cancel() {
         synchronized(this) {
             holder = null
             session = null
             credentialsByKey = emptyMap()
+            dynamicOffersById = emptyMap()
         }
     }
 }

--- a/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/SprucekitMobilePlugin.kt
+++ b/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/SprucekitMobilePlugin.kt
@@ -1,8 +1,10 @@
 package com.spruceid.sprucekit_mobile
 
+import com.spruceid.mobile.sdk.rs.DynamicCredentialProvider
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * SprucekitMobilePlugin
@@ -14,6 +16,22 @@ import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
  * the binding when the plugin attaches to a host Activity.
  */
 class SprucekitMobilePlugin : FlutterPlugin, ActivityAware {
+    companion object {
+        /**
+         * Dynamic credential providers registered by the host application.
+         * Providers issue per-presentation credentials natively; offers
+         * surface through `Oid4vp.getDynamicOffers` and selected offers are
+         * issued during `Oid4vp.submitResponseWithOffers`.
+         *
+         * Register before any OID4VP flow starts; a snapshot is taken per
+         * `Oid4vp.createHolder` and lives for that holder. Global to the
+         * process; safe for concurrent registration.
+         */
+        @JvmStatic
+        val dynamicCredentialProviders: MutableList<DynamicCredentialProvider> =
+            CopyOnWriteArrayList()
+    }
+
     private lateinit var oid4vciAdapter: Oid4vciAdapter
     private lateinit var credentialPackAdapter: CredentialPackAdapter
     private lateinit var oid4vpAdapter: Oid4vpAdapter

--- a/flutter/example/lib/demos/oid4vci_demo.dart
+++ b/flutter/example/lib/demos/oid4vci_demo.dart
@@ -131,6 +131,10 @@ class _Oid4vciDemoState extends State<Oid4vciDemo> {
       switch (result) {
         case Oid4vciSuccess(:final credentials):
           _issuedCredentials = credentials;
+        case Oid4vciPresentationRequired():
+          _error =
+              'Issuer requires an OID4VP presentation before issuance '
+              '(presentation_required) — not handled by this demo';
         case Oid4vciError(:final message):
           _error = message;
       }
@@ -221,6 +225,10 @@ class _Oid4vciDemoState extends State<Oid4vciDemo> {
       switch (result) {
         case Oid4vciSuccess(:final credentials):
           _issuedCredentials = credentials;
+        case Oid4vciPresentationRequired():
+          _error =
+              'Issuer requires an OID4VP presentation before issuance '
+              '(presentation_required) — not handled by this demo';
         case Oid4vciError(:final message):
           _error = message;
       }
@@ -242,6 +250,10 @@ class _Oid4vciDemoState extends State<Oid4vciDemo> {
         switch (result) {
           case Oid4vciSuccess(:final credentials):
             _issuedCredentials = credentials;
+          case Oid4vciPresentationRequired():
+            _error =
+                'Issuer requires an OID4VP presentation before issuance '
+                '(presentation_required) — not handled by this demo';
           case Oid4vciError(:final message):
             _error = message;
         }

--- a/flutter/example/lib/demos/oid4vp_demo.dart
+++ b/flutter/example/lib/demos/oid4vp_demo.dart
@@ -152,6 +152,10 @@ class _Oid4vpDemoState extends State<Oid4vpDemo> {
         switch (result) {
           case Oid4vciSuccess(:final credentials):
             _issuedCredentials = credentials;
+          case Oid4vciPresentationRequired():
+            _issuanceError =
+                'Issuer requires an OID4VP presentation before issuance '
+                '(presentation_required) — not handled by this demo';
           case Oid4vciError(:final message):
             _issuanceError = message;
         }

--- a/flutter/ios/Classes/Oid4vci.g.swift
+++ b/flutter/ios/Classes/Oid4vci.g.swift
@@ -429,6 +429,44 @@ struct Oid4vciError: Oid4vciResult {
   }
 }
 
+/// Issuance interrupted: the issuer requires an OID4VP presentation before it
+/// will release the credential (issuer error `presentation_required`).
+///
+/// Recovery: run the OID4VP flow with [authorizationRequestJson] as the
+/// request string, then re-run the issuance from the same offer URL. A second
+/// `Oid4vciPresentationRequired` on the retry is a failure.
+///
+/// Only reachable when `supportedVersions` is empty (auto) or contains
+/// [Oid4vciVersion.legacy]: the v1 HTTP client discards error-response
+/// bodies, so a pure-v1 exchange cannot detect it.
+///
+/// Generated class from Pigeon that represents data sent in messages.
+struct Oid4vciPresentationRequired: Oid4vciResult {
+  /// The OID4VP authorization request JSON, verbatim from the issuer's
+  /// `presentation_required` error body.
+  var authorizationRequestJson: String
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> Oid4vciPresentationRequired? {
+    let authorizationRequestJson = pigeonVar_list[0] as! String
+
+    return Oid4vciPresentationRequired(
+      authorizationRequestJson: authorizationRequestJson
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      authorizationRequestJson
+    ]
+  }
+  static func == (lhs: Oid4vciPresentationRequired, rhs: Oid4vciPresentationRequired) -> Bool {
+    return deepEqualsOid4vci(lhs.toList(), rhs.toList())  }
+  func hash(into hasher: inout Hasher) {
+    deepHashOid4vci(value: toList(), hasher: &hasher)
+  }
+}
+
 private class Oid4vciPigeonCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
@@ -470,6 +508,8 @@ private class Oid4vciPigeonCodecReader: FlutterStandardReader {
       return Oid4vciSuccess.fromList(self.readValue() as! [Any?])
     case 139:
       return Oid4vciError.fromList(self.readValue() as! [Any?])
+    case 140:
+      return Oid4vciPresentationRequired.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
     }
@@ -510,6 +550,9 @@ private class Oid4vciPigeonCodecWriter: FlutterStandardWriter {
       super.writeValue(value.toList())
     } else if let value = value as? Oid4vciError {
       super.writeByte(139)
+      super.writeValue(value.toList())
+    } else if let value = value as? Oid4vciPresentationRequired {
+      super.writeByte(140)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)

--- a/flutter/ios/Classes/Oid4vciAdapter.swift
+++ b/flutter/ios/Classes/Oid4vciAdapter.swift
@@ -120,6 +120,11 @@ class Oid4vciAdapter: Oid4vci {
                     supportedVersions: supportedVersions
                 )
                 completion(.success(result))
+            } catch let error as SpruceIDMobileSdkRs.Oid4vciError {
+                completion(.success(
+                    presentationRequiredResult(error)
+                        ?? Oid4vciError(message: error.localizedDescription)
+                ))
             } catch {
                 completion(.success(Oid4vciError(message: error.localizedDescription)))
             }
@@ -191,6 +196,12 @@ class Oid4vciAdapter: Oid4vci {
                 let credentials = try await exchangeCredentialWithToken(ctx: ctx, token: token)
                 await registry.remove(id: sessionId)
                 completion(.success(Oid4vciSuccess(credentials: credentials)))
+            } catch let error as SpruceIDMobileSdkRs.Oid4vciError {
+                await registry.remove(id: sessionId)
+                completion(.success(
+                    presentationRequiredResult(error)
+                        ?? Oid4vciError(message: error.localizedDescription)
+                ))
             } catch {
                 await registry.remove(id: sessionId)
                 completion(.success(Oid4vciError(message: error.localizedDescription)))
@@ -245,6 +256,12 @@ class Oid4vciAdapter: Oid4vci {
                 let credentials = try await exchangeCredentialWithToken(ctx: ctx, token: token)
                 await registry.remove(id: sessionId)
                 completion(.success(Oid4vciSuccess(credentials: credentials)))
+            } catch let error as SpruceIDMobileSdkRs.Oid4vciError {
+                await registry.remove(id: sessionId)
+                completion(.success(
+                    presentationRequiredResult(error)
+                        ?? Oid4vciError(message: error.localizedDescription)
+                ))
             } catch {
                 await registry.remove(id: sessionId)
                 completion(.success(Oid4vciError(message: error.localizedDescription)))
@@ -263,6 +280,20 @@ class Oid4vciAdapter: Oid4vci {
     }
 
     // MARK: - Helpers
+
+    /// Returns the pigeon result for `PresentationRequired`, nil for other
+    /// variants. The SDK error is a uniffi flat error: the payload is the
+    /// verbatim OID4VP authorization_request JSON. The SDK enum must stay
+    /// qualified as `SpruceIDMobileSdkRs.Oid4vciError` — it collides with the
+    /// pigeon class `Oid4vciError`.
+    private func presentationRequiredResult(
+        _ error: SpruceIDMobileSdkRs.Oid4vciError
+    ) -> Oid4vciResult? {
+        guard case let .PresentationRequired(message) = error else { return nil }
+        return message.isEmpty
+            ? Oid4vciError(message: "presentation required (missing authorization_request)")
+            : Oid4vciPresentationRequired(authorizationRequestJson: message)
+    }
 
     private func normalizeOfferUrl(_ credentialOffer: String) -> String {
         credentialOffer.starts(with: "openid-credential-offer://")

--- a/flutter/ios/Classes/Oid4vp.g.swift
+++ b/flutter/ios/Classes/Oid4vp.g.swift
@@ -542,6 +542,48 @@ struct CredentialRequirementData: Hashable {
   }
 }
 
+/// A dynamic credential offer surfaced by a registered native
+/// `DynamicCredentialProvider`.
+///
+/// Offers are issued only if the user selects them: pass the `offerId` to
+/// `submitResponseWithOffers`. Only OID4VP-v1 sessions surface offers.
+///
+/// Generated class from Pigeon that represents data sent in messages.
+struct DynamicOfferData: Hashable {
+  /// Provider-scoped identifier, echoed back via `submitResponseWithOffers`.
+  var offerId: String
+  /// The DCQL credential-query id this offer satisfies.
+  var credentialQueryId: String
+  /// Human-readable label for the consent UI.
+  var title: String
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> DynamicOfferData? {
+    let offerId = pigeonVar_list[0] as! String
+    let credentialQueryId = pigeonVar_list[1] as! String
+    let title = pigeonVar_list[2] as! String
+
+    return DynamicOfferData(
+      offerId: offerId,
+      credentialQueryId: credentialQueryId,
+      title: title
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      offerId,
+      credentialQueryId,
+      title,
+    ]
+  }
+  static func == (lhs: DynamicOfferData, rhs: DynamicOfferData) -> Bool {
+    return deepEqualsOid4vp(lhs.toList(), rhs.toList())  }
+  func hash(into hasher: inout Hasher) {
+    deepHashOid4vp(value: toList(), hasher: &hasher)
+  }
+}
+
 private class Oid4vpPigeonCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
@@ -573,6 +615,8 @@ private class Oid4vpPigeonCodecReader: FlutterStandardReader {
       return CredentialQueryGroupData.fromList(self.readValue() as! [Any?])
     case 140:
       return CredentialRequirementData.fromList(self.readValue() as! [Any?])
+    case 141:
+      return DynamicOfferData.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
     }
@@ -616,6 +660,9 @@ private class Oid4vpPigeonCodecWriter: FlutterStandardWriter {
       super.writeValue(value.toList())
     } else if let value = value as? CredentialRequirementData {
       super.writeByte(140)
+      super.writeValue(value.toList())
+    } else if let value = value as? DynamicOfferData {
+      super.writeByte(141)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)
@@ -677,6 +724,12 @@ protocol Oid4vp {
   ///   the same order as `selectedCredentials`
   /// @param options Response configuration options
   func submitResponse(selectedCredentials: [PresentableCredentialKey], selectedFieldPaths: [[String]], options: ResponseOptions, completion: @escaping (Result<Oid4vpResult, Error>) -> Void)
+  /// Submit the response, additionally issuing the dynamic credential offers
+  /// selected by `offerId` from `getDynamicOffers`.
+  ///
+  /// `selectedCredentials` may be empty if at least one offer is selected.
+  /// Unknown offer ids fail the whole submission.
+  func submitResponseWithOffers(selectedCredentials: [PresentableCredentialKey], selectedFieldPaths: [[String]], selectedOfferIds: [String], options: ResponseOptions, completion: @escaping (Result<Oid4vpResult, Error>) -> Void)
   /// Get credential requirements from the permission request
   ///
   /// @return List of credential requirements
@@ -689,6 +742,11 @@ protocol Oid4vp {
   ///
   /// @return List of credential query ID strings
   func getCredentialQueryIds() throws -> [String]
+  /// Get the dynamic credential offers for the current session.
+  ///
+  /// Empty when no providers are registered, none match the request, or the
+  /// negotiated version is not v1. Call after `handleAuthorizationRequest`.
+  func getDynamicOffers() throws -> [DynamicOfferData]
   /// Cancel and cleanup the current session
   func cancel() throws
 }
@@ -800,6 +858,31 @@ class Oid4vpSetup {
     } else {
       submitResponseChannel.setMessageHandler(nil)
     }
+    /// Submit the response, additionally issuing the dynamic credential offers
+    /// selected by `offerId` from `getDynamicOffers`.
+    ///
+    /// `selectedCredentials` may be empty if at least one offer is selected.
+    /// Unknown offer ids fail the whole submission.
+    let submitResponseWithOffersChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.sprucekit_mobile.Oid4vp.submitResponseWithOffers\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      submitResponseWithOffersChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let selectedCredentialsArg = args[0] as! [PresentableCredentialKey]
+        let selectedFieldPathsArg = args[1] as! [[String]]
+        let selectedOfferIdsArg = args[2] as! [String]
+        let optionsArg = args[3] as! ResponseOptions
+        api.submitResponseWithOffers(selectedCredentials: selectedCredentialsArg, selectedFieldPaths: selectedFieldPathsArg, selectedOfferIds: selectedOfferIdsArg, options: optionsArg) { result in
+          switch result {
+          case .success(let res):
+            reply(wrapResult(res))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      submitResponseWithOffersChannel.setMessageHandler(nil)
+    }
     /// Get credential requirements from the permission request
     ///
     /// @return List of credential requirements
@@ -847,6 +930,23 @@ class Oid4vpSetup {
       }
     } else {
       getCredentialQueryIdsChannel.setMessageHandler(nil)
+    }
+    /// Get the dynamic credential offers for the current session.
+    ///
+    /// Empty when no providers are registered, none match the request, or the
+    /// negotiated version is not v1. Call after `handleAuthorizationRequest`.
+    let getDynamicOffersChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.sprucekit_mobile.Oid4vp.getDynamicOffers\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      getDynamicOffersChannel.setMessageHandler { _, reply in
+        do {
+          let result = try api.getDynamicOffers()
+          reply(wrapResult(result))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      getDynamicOffersChannel.setMessageHandler(nil)
     }
     /// Cancel and cleanup the current session
     let cancelChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.sprucekit_mobile.Oid4vp.cancel\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)

--- a/flutter/ios/Classes/Oid4vpAdapter.swift
+++ b/flutter/ios/Classes/Oid4vpAdapter.swift
@@ -90,6 +90,11 @@ class Oid4vpAdapter: Oid4vp {
     /// keys when it satisfies multiple queries — those are distinct
     /// `Oid4vpPresentableCredential` instances on the Rust side.
     private var credentialsByKey: [PresentableCredentialKey: Oid4vpPresentableCredential] = [:]
+    /// Dynamic credential offers for the current session, keyed by `offerId`
+    /// (surfacing order kept in `dynamicOfferIds`). Dart echoes ids back;
+    /// these records are the authoritative ones passed to the Rust session.
+    private var dynamicOfferIds: [String] = []
+    private var dynamicOffersById: [String: SpruceIDMobileSdkRs.DynamicCredentialOffer] = [:]
 
     init(credentialPackAdapter: CredentialPackAdapter) {
         self.credentialPackAdapter = credentialPackAdapter
@@ -143,7 +148,12 @@ class Oid4vpAdapter: Oid4vp {
                     credentials.append(contentsOf: packCredentials)
                 }
 
-                if credentials.isEmpty {
+                // Snapshot registered providers for the lifetime of this
+                // holder. With providers, an empty credential pack is valid:
+                // the whole response may be issued on the fly.
+                let providers = SprucekitMobilePlugin.dynamicCredentialProviders
+
+                if credentials.isEmpty && providers.isEmpty {
                     completion(.success(Oid4vpError(message: "No credentials found in provided packs")))
                     return
                 }
@@ -152,12 +162,13 @@ class Oid4vpAdapter: Oid4vp {
                 let signer = try Oid4vpSigner(keyId: keyId)
 
                 // Create holder (version-agnostic facade)
-                let newHolder = try await Oid4vpHolder.newWithCredentials(
+                let newHolder = try await Oid4vpHolder.newWithCredentialsAndProviders(
                     providedCredentials: credentials,
                     trustedDids: trustedDids,
                     signer: signer,
                     contextMap: contextMap,
-                    keystore: KeyManager()
+                    keystore: KeyManager(),
+                    providers: providers
                 )
 
                 lock.lock()
@@ -187,7 +198,12 @@ class Oid4vpAdapter: Oid4vp {
                 lock.unlock()
 
                 // Handle URL format (remove "authorize" if present, similar to Showcase)
-                let processedUrl = url.replacingOccurrences(of: "authorize", with: "")
+                // A JSON authorization-request body must pass through
+                // verbatim, so only munge URL-shaped inputs.
+                let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
+                let processedUrl = trimmed.hasPrefix("{")
+                    ? trimmed
+                    : url.replacingOccurrences(of: "authorize", with: "")
 
                 // Start a session, restricting negotiation to `supportedVersions`.
                 let session = try await holder.startWithSupportedVersions(
@@ -218,12 +234,21 @@ class Oid4vpAdapter: Oid4vp {
                     }
                 }
 
+                // Dynamic offers from registered providers; always empty
+                // for non-v1 sessions.
+                let offers = session.dynamicOffers()
+
                 lock.lock()
                 self.session = session
                 self.credentialsByKey = keyMap
+                self.dynamicOfferIds = offers.map { $0.offerId }
+                self.dynamicOffersById = Dictionary(
+                    offers.map { ($0.offerId, $0) },
+                    uniquingKeysWith: { first, _ in first }
+                )
                 lock.unlock()
 
-                if credentialData.isEmpty {
+                if credentialData.isEmpty && offers.isEmpty {
                     completion(.success(HandleAuthRequestError(
                         message: "No matching credentials found for this verification request"
                     )))
@@ -387,11 +412,90 @@ class Oid4vpAdapter: Oid4vp {
         return groupedByQuery(session).map { $0.qid }
     }
 
+    func getDynamicOffers() throws -> [DynamicOfferData] {
+        lock.lock()
+        let offerIds = self.dynamicOfferIds
+        let offersById = self.dynamicOffersById
+        lock.unlock()
+
+        return offerIds.compactMap { offersById[$0] }.map { offer in
+            DynamicOfferData(
+                offerId: offer.offerId,
+                credentialQueryId: offer.credentialQueryId,
+                title: offer.title
+            )
+        }
+    }
+
+    func submitResponseWithOffers(
+        selectedCredentials: [PresentableCredentialKey],
+        selectedFieldPaths: [[String]],
+        selectedOfferIds: [String],
+        options: ResponseOptions,
+        completion: @escaping (Result<Oid4vpResult, Error>) -> Void
+    ) {
+        Task {
+            do {
+                lock.lock()
+                guard let session = self.session else {
+                    lock.unlock()
+                    completion(.success(Oid4vpError(message: "Session not initialized")))
+                    return
+                }
+
+                let resolvedCredentials = selectedCredentials.compactMap { self.credentialsByKey[$0] }
+                let resolvedOffers = selectedOfferIds.compactMap { self.dynamicOffersById[$0] }
+                lock.unlock()
+
+                // Each offer may be selected at most once — a duplicate id
+                // would be issued twice and still pass the size check below.
+                if Set(selectedOfferIds).count != selectedOfferIds.count {
+                    completion(.success(Oid4vpError(message: "Duplicate dynamic offer id selected")))
+                    return
+                }
+
+                if resolvedOffers.count != selectedOfferIds.count {
+                    completion(.success(Oid4vpError(message: "Unknown dynamic offer id selected")))
+                    return
+                }
+
+                if resolvedCredentials.isEmpty && resolvedOffers.isEmpty {
+                    completion(.success(Oid4vpError(message: "No valid credentials or offers selected")))
+                    return
+                }
+
+                // `shouldStripQuotes` and `removeVpPathPrefix` are Draft
+                // 18-only knobs not surfaced by the pigeon API; keep off.
+                let responseOptions = SpruceIDMobileSdkRs.Oid4vpResponseOptions(
+                    forceArraySerialization: options.forceArraySerialization,
+                    shouldStripQuotes: false,
+                    removeVpPathPrefix: false
+                )
+
+                // Selected offers are issued while creating the response.
+                let permissionResponse = try await session.createPermissionResponseWithOffers(
+                    selectedCredentials: resolvedCredentials,
+                    selectedFields: selectedFieldPaths,
+                    selectedOffers: resolvedOffers,
+                    responseOptions: responseOptions
+                )
+
+                _ = try await session.submitPermissionResponse(response: permissionResponse)
+
+                completion(.success(Oid4vpSuccess(message: "Presentation submitted successfully")))
+            } catch {
+                completion(.success(Oid4vpError(message: error.localizedDescription)))
+            }
+        }
+    }
+
     func cancel() throws {
         lock.lock()
         holder = nil
         session = nil
         credentialsByKey = [:]
+        dynamicOfferIds = []
+        dynamicOffersById = [:]
         lock.unlock()
     }
 }

--- a/flutter/ios/Classes/SprucekitMobilePlugin.swift
+++ b/flutter/ios/Classes/SprucekitMobilePlugin.swift
@@ -1,10 +1,36 @@
 import Flutter
+import SpruceIDMobileSdkRs
 import UIKit
 
 /// SprucekitMobilePlugin
 ///
 /// Flutter plugin providing access to SpruceKit Mobile SDK functionality.
 public class SprucekitMobilePlugin: NSObject, FlutterPlugin {
+
+    /// Dynamic credential providers registered by the host application.
+    /// Providers issue per-presentation credentials natively; offers surface
+    /// through `Oid4vp.getDynamicOffers` and selected offers are issued
+    /// during `Oid4vp.submitResponseWithOffers`.
+    ///
+    /// Register before any OID4VP flow starts; a snapshot is taken per
+    /// `Oid4vp.createHolder` and lives for that holder. Global to the
+    /// process; lock-guarded so a late registration cannot race an in-flight
+    /// `createHolder` snapshot.
+    public static var dynamicCredentialProviders: [DynamicCredentialProvider] {
+        get {
+            providersLock.lock()
+            defer { providersLock.unlock() }
+            return _dynamicCredentialProviders
+        }
+        set {
+            providersLock.lock()
+            defer { providersLock.unlock() }
+            _dynamicCredentialProviders = newValue
+        }
+    }
+
+    private static let providersLock = NSLock()
+    private static var _dynamicCredentialProviders: [DynamicCredentialProvider] = []
 
     public static func register(with registrar: FlutterPluginRegistrar) {
         let messenger = registrar.messenger()

--- a/flutter/lib/pigeon/oid4vci.g.dart
+++ b/flutter/lib/pigeon/oid4vci.g.dart
@@ -458,6 +458,59 @@ class Oid4vciError extends Oid4vciResult {
 ;
 }
 
+/// Issuance interrupted: the issuer requires an OID4VP presentation before it
+/// will release the credential (issuer error `presentation_required`).
+///
+/// Recovery: run the OID4VP flow with [authorizationRequestJson] as the
+/// request string, then re-run the issuance from the same offer URL. A second
+/// `Oid4vciPresentationRequired` on the retry is a failure.
+///
+/// Only reachable when `supportedVersions` is empty (auto) or contains
+/// [Oid4vciVersion.legacy]: the v1 HTTP client discards error-response
+/// bodies, so a pure-v1 exchange cannot detect it.
+class Oid4vciPresentationRequired extends Oid4vciResult {
+  Oid4vciPresentationRequired({
+    required this.authorizationRequestJson,
+  });
+
+  /// The OID4VP authorization request JSON, verbatim from the issuer's
+  /// `presentation_required` error body.
+  String authorizationRequestJson;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      authorizationRequestJson,
+    ];
+  }
+
+  Object encode() {
+    return _toList();  }
+
+  static Oid4vciPresentationRequired decode(Object result) {
+    result as List<Object?>;
+    return Oid4vciPresentationRequired(
+      authorizationRequestJson: result[0]! as String,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! Oid4vciPresentationRequired || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(encode(), other.encode());
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => Object.hashAll(_toList())
+;
+}
+
 
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
@@ -499,6 +552,9 @@ class _PigeonCodec extends StandardMessageCodec {
     }    else if (value is Oid4vciError) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
+    }    else if (value is Oid4vciPresentationRequired) {
+      buffer.putUint8(140);
+      writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
     }
@@ -533,6 +589,8 @@ class _PigeonCodec extends StandardMessageCodec {
         return Oid4vciSuccess.decode(readValue(buffer)!);
       case 139:
         return Oid4vciError.decode(readValue(buffer)!);
+      case 140:
+        return Oid4vciPresentationRequired.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }

--- a/flutter/lib/pigeon/oid4vp.g.dart
+++ b/flutter/lib/pigeon/oid4vp.g.dart
@@ -598,6 +598,61 @@ class CredentialRequirementData {
   int get hashCode => Object.hashAll(_toList());
 }
 
+/// A dynamic credential offer surfaced by a registered native
+/// `DynamicCredentialProvider`.
+///
+/// Offers are issued only if the user selects them: pass the `offerId` to
+/// `submitResponseWithOffers`. Only OID4VP-v1 sessions surface offers.
+class DynamicOfferData {
+  DynamicOfferData({
+    required this.offerId,
+    required this.credentialQueryId,
+    required this.title,
+  });
+
+  /// Provider-scoped identifier, echoed back via `submitResponseWithOffers`.
+  String offerId;
+
+  /// The DCQL credential-query id this offer satisfies.
+  String credentialQueryId;
+
+  /// Human-readable label for the consent UI.
+  String title;
+
+  List<Object?> _toList() {
+    return <Object?>[offerId, credentialQueryId, title];
+  }
+
+  Object encode() {
+    return _toList();
+  }
+
+  static DynamicOfferData decode(Object result) {
+    result as List<Object?>;
+    return DynamicOfferData(
+      offerId: result[0]! as String,
+      credentialQueryId: result[1]! as String,
+      title: result[2]! as String,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! DynamicOfferData || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(encode(), other.encode());
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => Object.hashAll(_toList());
+}
+
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
   @override
@@ -641,6 +696,9 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is CredentialRequirementData) {
       buffer.putUint8(140);
       writeValue(buffer, value.encode());
+    } else if (value is DynamicOfferData) {
+      buffer.putUint8(141);
+      writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
     }
@@ -674,6 +732,8 @@ class _PigeonCodec extends StandardMessageCodec {
         return CredentialQueryGroupData.decode(readValue(buffer)!);
       case 140:
         return CredentialRequirementData.decode(readValue(buffer)!);
+      case 141:
+        return DynamicOfferData.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -825,6 +885,42 @@ class Oid4vp {
     return pigeonVar_replyValue as Oid4vpResult;
   }
 
+  /// Submit the response, additionally issuing the dynamic credential offers
+  /// selected by `offerId` from `getDynamicOffers`.
+  ///
+  /// `selectedCredentials` may be empty if at least one offer is selected.
+  /// Unknown offer ids fail the whole submission.
+  Future<Oid4vpResult> submitResponseWithOffers(
+    List<PresentableCredentialKey> selectedCredentials,
+    List<List<String>> selectedFieldPaths,
+    List<String> selectedOfferIds,
+    ResponseOptions options,
+  ) async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.sprucekit_mobile.Oid4vp.submitResponseWithOffers$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[
+        selectedCredentials,
+        selectedFieldPaths,
+        selectedOfferIds,
+        options,
+      ],
+    );
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    final Object pigeonVar_replyValue = _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: false,
+    )!;
+    return pigeonVar_replyValue as Oid4vpResult;
+  }
+
   /// Get credential requirements from the permission request
   ///
   /// @return List of credential requirements
@@ -891,6 +987,29 @@ class Oid4vp {
       isNullValid: false,
     )!;
     return (pigeonVar_replyValue as List<Object?>).cast<String>();
+  }
+
+  /// Get the dynamic credential offers for the current session.
+  ///
+  /// Empty when no providers are registered, none match the request, or the
+  /// negotiated version is not v1. Call after `handleAuthorizationRequest`.
+  Future<List<DynamicOfferData>> getDynamicOffers() async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.sprucekit_mobile.Oid4vp.getDynamicOffers$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    final Object pigeonVar_replyValue = _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: false,
+    )!;
+    return (pigeonVar_replyValue as List<Object?>).cast<DynamicOfferData>();
   }
 
   /// Cancel and cleanup the current session

--- a/flutter/pigeons/oid4vci.dart
+++ b/flutter/pigeons/oid4vci.dart
@@ -154,6 +154,24 @@ class Oid4vciError implements Oid4vciResult {
   Oid4vciError({required this.message});
 }
 
+/// Issuance interrupted: the issuer requires an OID4VP presentation before it
+/// will release the credential (issuer error `presentation_required`).
+///
+/// Recovery: run the OID4VP flow with [authorizationRequestJson] as the
+/// request string, then re-run the issuance from the same offer URL. A second
+/// `Oid4vciPresentationRequired` on the retry is a failure.
+///
+/// Only reachable when `supportedVersions` is empty (auto) or contains
+/// [Oid4vciVersion.legacy]: the v1 HTTP client discards error-response
+/// bodies, so a pure-v1 exchange cannot detect it.
+class Oid4vciPresentationRequired implements Oid4vciResult {
+  /// The OID4VP authorization request JSON, verbatim from the issuer's
+  /// `presentation_required` error body.
+  String authorizationRequestJson;
+
+  Oid4vciPresentationRequired({required this.authorizationRequestJson});
+}
+
 /// OID4VCI credential issuance API
 ///
 /// Handles the OpenID for Verifiable Credential Issuance flow

--- a/flutter/pigeons/oid4vp.dart
+++ b/flutter/pigeons/oid4vp.dart
@@ -168,6 +168,28 @@ class CredentialRequirementData {
   });
 }
 
+/// A dynamic credential offer surfaced by a registered native
+/// `DynamicCredentialProvider`.
+///
+/// Offers are issued only if the user selects them: pass the `offerId` to
+/// `submitResponseWithOffers`. Only OID4VP-v1 sessions surface offers.
+class DynamicOfferData {
+  /// Provider-scoped identifier, echoed back via `submitResponseWithOffers`.
+  String offerId;
+
+  /// The DCQL credential-query id this offer satisfies.
+  String credentialQueryId;
+
+  /// Human-readable label for the consent UI.
+  String title;
+
+  DynamicOfferData({
+    required this.offerId,
+    required this.credentialQueryId,
+    required this.title,
+  });
+}
+
 /// OID4VP credential presentation API
 ///
 /// Handles the OpenID for Verifiable Presentation flow
@@ -225,6 +247,19 @@ abstract class Oid4vp {
     ResponseOptions options,
   );
 
+  /// Submit the response, additionally issuing the dynamic credential offers
+  /// selected by `offerId` from `getDynamicOffers`.
+  ///
+  /// `selectedCredentials` may be empty if at least one offer is selected.
+  /// Unknown offer ids fail the whole submission.
+  @async
+  Oid4vpResult submitResponseWithOffers(
+    List<PresentableCredentialKey> selectedCredentials,
+    List<List<String>> selectedFieldPaths,
+    List<String> selectedOfferIds,
+    ResponseOptions options,
+  );
+
   /// Get credential requirements from the permission request
   ///
   /// @return List of credential requirements
@@ -239,6 +274,12 @@ abstract class Oid4vp {
   ///
   /// @return List of credential query ID strings
   List<String> getCredentialQueryIds();
+
+  /// Get the dynamic credential offers for the current session.
+  ///
+  /// Empty when no providers are registered, none match the request, or the
+  /// negotiated version is not v1. Call after `handleAuthorizationRequest`.
+  List<DynamicOfferData> getDynamicOffers();
 
   /// Cancel and cleanup the current session
   void cancel();

--- a/flutter/test/dcp_surfacing_test.dart
+++ b/flutter/test/dcp_surfacing_test.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sprucekit_mobile/sprucekit_mobile.dart';
+
+/// Tests for the two DCP surfacing seams:
+///  - `Oid4vciPresentationRequired`, the typed issuance interruption that
+///    carries the issuer's OID4VP authorization request for the retry loop;
+///  - `DynamicOfferData` + `getDynamicOffers`/`submitResponseWithOffers`, the
+///    Dart view of natively-registered dynamic credential providers.
+///
+/// The host platform is faked at the pigeon channel layer, so these cover
+/// only the Dart surface (codec, channel wiring, typed dispatch).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  /// Installs a fake host handler for one pigeon host-API channel, removed
+  /// again after the test.
+  void mockHost(
+    String channelName,
+    MessageCodec<Object?> codec,
+    Future<Object?> Function(Object? message) handler,
+  ) {
+    final channel = BasicMessageChannel<Object?>(channelName, codec);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockDecodedMessageHandler<Object?>(channel, handler);
+    addTearDown(
+      () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockDecodedMessageHandler<Object?>(channel, null),
+    );
+  }
+
+  group('Oid4vciPresentationRequired', () {
+    test('survives a wire round-trip through the Oid4vci channel codec', () {
+      final result = Oid4vciPresentationRequired(
+        authorizationRequestJson: '{"response_type":"vp_token","nonce":"n1"}',
+      );
+
+      final encoded = Oid4vci.pigeonChannelCodec.encodeMessage(result);
+      final decoded =
+          Oid4vci.pigeonChannelCodec.decodeMessage(encoded)
+              as Oid4vciPresentationRequired;
+
+      expect(decoded, equals(result));
+      expect(
+        decoded.authorizationRequestJson,
+        '{"response_type":"vp_token","nonce":"n1"}',
+      );
+      // The retry loop dispatches on the sealed result type.
+      expect(decoded, isA<Oid4vciResult>());
+    });
+
+    test('is surfaced as a typed runIssuance result', () async {
+      const authRequestJson = '{"response_type":"vp_token","nonce":"abc123"}';
+
+      mockHost(
+        'dev.flutter.pigeon.sprucekit_mobile.Oid4vci.runIssuance',
+        Oid4vci.pigeonChannelCodec,
+        (message) async {
+          final args = message! as List<Object?>;
+          expect(args[0], 'openid-credential-offer://issuer.example/offer');
+          // The retry contract requires auto version negotiation ([]): a
+          // pure-v1 exchange can never observe presentation_required.
+          expect(args[6], isEmpty);
+          return <Object?>[
+            Oid4vciPresentationRequired(
+              authorizationRequestJson: authRequestJson,
+            ),
+          ];
+        },
+      );
+
+      final result = await Oid4vci().runIssuance(
+        'openid-credential-offer://issuer.example/offer',
+        'client-id',
+        'https://wallet.example/redirect',
+        'key-id',
+        DidMethod.jwk,
+        null,
+        const <Oid4vciVersion>[],
+      );
+
+      // Dispatch via `is` chains on the sealed result.
+      expect(result, isA<Oid4vciPresentationRequired>());
+      expect(result, isNot(isA<Oid4vciSuccess>()));
+      expect(result, isNot(isA<Oid4vciError>()));
+      expect(
+        (result as Oid4vciPresentationRequired).authorizationRequestJson,
+        authRequestJson,
+      );
+    });
+  });
+
+  group('Dynamic credential offers', () {
+    final offer = DynamicOfferData(
+      offerId: 'offer-1',
+      credentialQueryId: 'binding_vc_0',
+      title: 'Vehicle binding credential',
+    );
+
+    test('survive a wire round-trip through the Oid4vp channel codec', () {
+      final encoded = Oid4vp.pigeonChannelCodec.encodeMessage(offer);
+      final decoded =
+          Oid4vp.pigeonChannelCodec.decodeMessage(encoded) as DynamicOfferData;
+
+      expect(decoded, equals(offer));
+      expect(decoded.offerId, 'offer-1');
+      expect(decoded.credentialQueryId, 'binding_vc_0');
+      expect(decoded.title, 'Vehicle binding credential');
+    });
+
+    test('getDynamicOffers returns the host-surfaced offers', () async {
+      mockHost(
+        'dev.flutter.pigeon.sprucekit_mobile.Oid4vp.getDynamicOffers',
+        Oid4vp.pigeonChannelCodec,
+        (message) async => <Object?>[
+          <Object?>[offer],
+        ],
+      );
+
+      final offers = await Oid4vp().getDynamicOffers();
+      expect(offers, hasLength(1));
+      expect(offers.single, equals(offer));
+    });
+
+    test('submitResponseWithOffers sends credentials, fields, offer ids and '
+        'options', () async {
+      Object? sent;
+      mockHost(
+        'dev.flutter.pigeon.sprucekit_mobile.Oid4vp.submitResponseWithOffers',
+        Oid4vp.pigeonChannelCodec,
+        (message) async {
+          sent = message;
+          return <Object?>[Oid4vpSuccess(message: 'ok')];
+        },
+      );
+
+      final key = PresentableCredentialKey(
+        credentialId: 'cred-1',
+        credentialQueryId: 'mdl_0',
+      );
+      final result = await Oid4vp().submitResponseWithOffers(
+        <PresentableCredentialKey>[key],
+        const <List<String>>[
+          ['field.a', 'field.b'],
+        ],
+        const <String>['offer-1'],
+        ResponseOptions(forceArraySerialization: false),
+      );
+
+      expect(result, isA<Oid4vpSuccess>());
+
+      final args = sent! as List<Object?>;
+      expect((args[0]! as List<Object?>).single, equals(key));
+      expect(args[1], <Object?>[
+        <Object?>['field.a', 'field.b'],
+      ]);
+      // Offers travel back as ids only — the native adapter holds the
+      // authoritative offer records.
+      expect(args[2], <Object?>['offer-1']);
+      expect(args[3], isA<ResponseOptions>());
+    });
+
+    test('offers-only submission is accepted by the Dart surface', () async {
+      mockHost(
+        'dev.flutter.pigeon.sprucekit_mobile.Oid4vp.submitResponseWithOffers',
+        Oid4vp.pigeonChannelCodec,
+        (message) async {
+          final args = message! as List<Object?>;
+          expect(args[0], isEmpty);
+          expect(args[1], isEmpty);
+          expect(args[2], <Object?>['offer-1']);
+          return <Object?>[Oid4vpSuccess(message: 'ok')];
+        },
+      );
+
+      final result = await Oid4vp().submitResponseWithOffers(
+        const <PresentableCredentialKey>[],
+        const <List<String>>[],
+        const <String>['offer-1'],
+        ResponseOptions(forceArraySerialization: false),
+      );
+      expect(result, isA<Oid4vpSuccess>());
+    });
+  });
+}

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -11155,6 +11155,51 @@ public static func newWithCredentials(providedCredentials: [ParsedCredential], t
         )
 }
     
+    /**
+     * Create a holder with stored credentials plus registered
+     * [`DynamicCredentialProvider`]s, which issue credentials on device
+     * during a presentation.
+     *
+     * Providers participate in v1 sessions only: Draft 18 / Draft 13
+     * sessions report no dynamic offers.
+     */
+public static func newWithCredentialsAndProviders(providedCredentials: [ParsedCredential], trustedDids: [String], signer: Oid4vpPresentationSigner, contextMap: [String: String]?, keystore: KeyStore?, providers: [DynamicCredentialProvider])async throws  -> Oid4vpHolder  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_mobile_sdk_rs_fn_constructor_oid4vpholder_new_with_credentials_and_providers(FfiConverterSequenceTypeParsedCredential.lower(providedCredentials),FfiConverterSequenceString.lower(trustedDids),FfiConverterCallbackInterfaceOid4vpPresentationSigner_lower(signer),FfiConverterOptionDictionaryStringString.lower(contextMap),FfiConverterOptionTypeKeyStore.lower(keystore),FfiConverterSequenceTypeDynamicCredentialProvider.lower(providers)
+                )
+            },
+            pollFunc: ffi_mobile_sdk_rs_rust_future_poll_u64,
+            completeFunc: ffi_mobile_sdk_rs_rust_future_complete_u64,
+            freeFunc: ffi_mobile_sdk_rs_rust_future_free_u64,
+            liftFunc: FfiConverterTypeOid4vpHolder_lift,
+            errorHandler: FfiConverterTypeOid4vpFacadeError_lift
+        )
+}
+    
+    /**
+     * Create a holder with registered [`DynamicCredentialProvider`]s, which
+     * issue credentials on device during a presentation.
+     *
+     * Providers participate in v1 sessions only: Draft 18 / Draft 13
+     * sessions report no dynamic offers.
+     */
+public static func newWithProviders(vdcCollection: VdcCollection, trustedDids: [String], signer: Oid4vpPresentationSigner, contextMap: [String: String]?, keystore: KeyStore?, providers: [DynamicCredentialProvider])async throws  -> Oid4vpHolder  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_mobile_sdk_rs_fn_constructor_oid4vpholder_new_with_providers(FfiConverterTypeVdcCollection_lower(vdcCollection),FfiConverterSequenceString.lower(trustedDids),FfiConverterCallbackInterfaceOid4vpPresentationSigner_lower(signer),FfiConverterOptionDictionaryStringString.lower(contextMap),FfiConverterOptionTypeKeyStore.lower(keystore),FfiConverterSequenceTypeDynamicCredentialProvider.lower(providers)
+                )
+            },
+            pollFunc: ffi_mobile_sdk_rs_rust_future_poll_u64,
+            completeFunc: ffi_mobile_sdk_rs_rust_future_complete_u64,
+            freeFunc: ffi_mobile_sdk_rs_rust_future_free_u64,
+            liftFunc: FfiConverterTypeOid4vpHolder_lift,
+            errorHandler: FfiConverterTypeOid4vpFacadeError_lift
+        )
+}
+    
 
     
 open func newDraft18Holder()async throws  -> Draft18Holder  {
@@ -11593,9 +11638,30 @@ public protocol Oid4vpSessionProtocol: AnyObject, Sendable {
     
     func createPermissionResponse(selectedCredentials: [Oid4vpPresentableCredential], selectedFields: [[String]], responseOptions: Oid4vpResponseOptions) async throws  -> Oid4vpPermissionResponse
     
+    /**
+     * Create the permission response, additionally issuing the dynamic
+     * credential offers selected from [`Oid4vpSession::dynamic_offers`].
+     *
+     * Either `selected_credentials` or `selected_offers` (or both) may be
+     * non-empty. Selecting offers on a Draft 18 / Draft 13 session returns
+     * [`Oid4vpFacadeError::VersionMismatch`]: the dynamic-credential hook is
+     * OID4VP-v1 only.
+     */
+    func createPermissionResponseWithOffers(selectedCredentials: [Oid4vpPresentableCredential], selectedFields: [[String]], selectedOffers: [DynamicCredentialOffer], responseOptions: Oid4vpResponseOptions) async throws  -> Oid4vpPermissionResponse
+    
     func credentials()  -> [Oid4vpPresentableCredential]
     
     func domain()  -> String?
+    
+    /**
+     * Dynamic credential offers surfaced for this session by the holder's
+     * [`DynamicCredentialProvider`]s. Stored credentials are listed
+     * separately by [`Oid4vpSession::credentials`].
+     *
+     * Always empty for Draft 18 / Draft 13 sessions: the dynamic-credential
+     * hook is OID4VP-v1 only.
+     */
+    func dynamicOffers()  -> [DynamicCredentialOffer]
     
     func isMultiCredentialMatching()  -> Bool
     
@@ -11690,6 +11756,32 @@ open func createPermissionResponse(selectedCredentials: [Oid4vpPresentableCreden
         )
 }
     
+    /**
+     * Create the permission response, additionally issuing the dynamic
+     * credential offers selected from [`Oid4vpSession::dynamic_offers`].
+     *
+     * Either `selected_credentials` or `selected_offers` (or both) may be
+     * non-empty. Selecting offers on a Draft 18 / Draft 13 session returns
+     * [`Oid4vpFacadeError::VersionMismatch`]: the dynamic-credential hook is
+     * OID4VP-v1 only.
+     */
+open func createPermissionResponseWithOffers(selectedCredentials: [Oid4vpPresentableCredential], selectedFields: [[String]], selectedOffers: [DynamicCredentialOffer], responseOptions: Oid4vpResponseOptions)async throws  -> Oid4vpPermissionResponse  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_mobile_sdk_rs_fn_method_oid4vpsession_create_permission_response_with_offers(
+                    self.uniffiCloneHandle(),
+                    FfiConverterSequenceTypeOid4vpPresentableCredential.lower(selectedCredentials),FfiConverterSequenceSequenceString.lower(selectedFields),FfiConverterSequenceTypeDynamicCredentialOffer.lower(selectedOffers),FfiConverterTypeOid4vpResponseOptions_lower(responseOptions)
+                )
+            },
+            pollFunc: ffi_mobile_sdk_rs_rust_future_poll_u64,
+            completeFunc: ffi_mobile_sdk_rs_rust_future_complete_u64,
+            freeFunc: ffi_mobile_sdk_rs_rust_future_free_u64,
+            liftFunc: FfiConverterTypeOid4vpPermissionResponse_lift,
+            errorHandler: FfiConverterTypeOid4vpFacadeError_lift
+        )
+}
+    
 open func credentials() -> [Oid4vpPresentableCredential]  {
     return try!  FfiConverterSequenceTypeOid4vpPresentableCredential.lift(try! rustCall() {
     uniffi_mobile_sdk_rs_fn_method_oid4vpsession_credentials(
@@ -11701,6 +11793,22 @@ open func credentials() -> [Oid4vpPresentableCredential]  {
 open func domain() -> String?  {
     return try!  FfiConverterOptionString.lift(try! rustCall() {
     uniffi_mobile_sdk_rs_fn_method_oid4vpsession_domain(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+    
+    /**
+     * Dynamic credential offers surfaced for this session by the holder's
+     * [`DynamicCredentialProvider`]s. Stored credentials are listed
+     * separately by [`Oid4vpSession::credentials`].
+     *
+     * Always empty for Draft 18 / Draft 13 sessions: the dynamic-credential
+     * hook is OID4VP-v1 only.
+     */
+open func dynamicOffers() -> [DynamicCredentialOffer]  {
+    return try!  FfiConverterSequenceTypeDynamicCredentialOffer.lift(try! rustCall() {
+    uniffi_mobile_sdk_rs_fn_method_oid4vpsession_dynamic_offers(
             self.uniffiCloneHandle(),$0
     )
 })
@@ -36832,10 +36940,16 @@ private let initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_method_oid4vpsession_create_permission_response() != 9863) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_mobile_sdk_rs_checksum_method_oid4vpsession_create_permission_response_with_offers() != 3415) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_mobile_sdk_rs_checksum_method_oid4vpsession_credentials() != 57886) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_oid4vpsession_domain() != 36441) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mobile_sdk_rs_checksum_method_oid4vpsession_dynamic_offers() != 51100) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_oid4vpsession_is_multi_credential_matching() != 60605) {
@@ -37196,6 +37310,12 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_constructor_oid4vpholder_new_with_credentials() != 50170) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mobile_sdk_rs_checksum_constructor_oid4vpholder_new_with_credentials_and_providers() != 51910) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mobile_sdk_rs_checksum_constructor_oid4vpholder_new_with_providers() != 62264) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_constructor_holder_new() != 44642) {

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -36940,7 +36940,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_method_oid4vpsession_create_permission_response() != 9863) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mobile_sdk_rs_checksum_method_oid4vpsession_create_permission_response_with_offers() != 3415) {
+    if (uniffi_mobile_sdk_rs_checksum_method_oid4vpsession_create_permission_response_with_offers() != 41495) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_oid4vpsession_credentials() != 57886) {
@@ -36949,7 +36949,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_method_oid4vpsession_domain() != 36441) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mobile_sdk_rs_checksum_method_oid4vpsession_dynamic_offers() != 51100) {
+    if (uniffi_mobile_sdk_rs_checksum_method_oid4vpsession_dynamic_offers() != 7083) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_oid4vpsession_is_multi_credential_matching() != 60605) {
@@ -37312,10 +37312,10 @@ private let initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_constructor_oid4vpholder_new_with_credentials() != 50170) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mobile_sdk_rs_checksum_constructor_oid4vpholder_new_with_credentials_and_providers() != 51910) {
+    if (uniffi_mobile_sdk_rs_checksum_constructor_oid4vpholder_new_with_credentials_and_providers() != 47197) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mobile_sdk_rs_checksum_constructor_oid4vpholder_new_with_providers() != 62264) {
+    if (uniffi_mobile_sdk_rs_checksum_constructor_oid4vpholder_new_with_providers() != 53369) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_constructor_holder_new() != 44642) {

--- a/rust/src/oid4vci/error.rs
+++ b/rust/src/oid4vci/error.rs
@@ -76,6 +76,14 @@ mod tests {
             other => panic!("unexpected error variant: {other:?}"),
         }
     }
+
+    #[test]
+    fn presentation_required_display_is_the_verbatim_authorization_request() {
+        let error = Oid4vciError::PresentationRequired {
+            authorization_request: r#"{"response_type":"vp_token"}"#.into(),
+        };
+        assert_eq!(error.to_string(), r#"{"response_type":"vp_token"}"#);
+    }
 }
 
 // use ssi::{

--- a/rust/src/oid4vp/facade.rs
+++ b/rust/src/oid4vp/facade.rs
@@ -17,6 +17,7 @@ use super::draft18::{
     presentation::{Draft18PresentationError, Draft18PresentationSigner},
     Draft18Holder,
 };
+use super::dynamic_credential::{DynamicCredentialOffer, DynamicCredentialProvider};
 use super::holder::{AuthRequest, Holder};
 use super::permission_request::{
     PermissionRequest, PermissionRequestError, PermissionResponse, RequestedField, ResponseOptions,
@@ -106,6 +107,7 @@ pub struct Oid4vpHolder {
     signer: Arc<Box<dyn Oid4vpPresentationSigner>>,
     context_map: Option<HashMap<String, String>>,
     keystore: Option<Arc<dyn KeyStore>>,
+    providers: Vec<Arc<dyn DynamicCredentialProvider>>,
 }
 
 impl std::fmt::Debug for Oid4vpHolder {
@@ -114,6 +116,7 @@ impl std::fmt::Debug for Oid4vpHolder {
             .field("trusted_dids", &self.trusted_dids)
             .field("context_map", &self.context_map)
             .field("keystore", &self.keystore.as_ref().map(|_| "KeyStore"))
+            .field("providers", &self.providers.len())
             .finish()
     }
 }
@@ -266,12 +269,33 @@ impl Oid4vpHolder {
         context_map: Option<HashMap<String, String>>,
         keystore: Option<Arc<dyn KeyStore>>,
     ) -> Result<Arc<Self>, Oid4vpFacadeError> {
+        Self::new_with_providers(
+            vdc_collection,
+            trusted_dids,
+            signer,
+            context_map,
+            keystore,
+            vec![],
+        )
+        .await
+    }
+
+    #[uniffi::constructor]
+    pub async fn new_with_providers(
+        vdc_collection: Arc<VdcCollection>,
+        trusted_dids: Vec<String>,
+        signer: Box<dyn Oid4vpPresentationSigner>,
+        context_map: Option<HashMap<String, String>>,
+        keystore: Option<Arc<dyn KeyStore>>,
+        providers: Vec<Arc<dyn DynamicCredentialProvider>>,
+    ) -> Result<Arc<Self>, Oid4vpFacadeError> {
         Ok(Arc::new(Self {
             source: Oid4vpHolderSource::Collection(vdc_collection),
             trusted_dids,
             signer: Arc::new(signer),
             context_map,
             keystore,
+            providers,
         }))
     }
 
@@ -283,12 +307,33 @@ impl Oid4vpHolder {
         context_map: Option<HashMap<String, String>>,
         keystore: Option<Arc<dyn KeyStore>>,
     ) -> Result<Arc<Self>, Oid4vpFacadeError> {
+        Self::new_with_credentials_and_providers(
+            provided_credentials,
+            trusted_dids,
+            signer,
+            context_map,
+            keystore,
+            vec![],
+        )
+        .await
+    }
+
+    #[uniffi::constructor]
+    pub async fn new_with_credentials_and_providers(
+        provided_credentials: Vec<Arc<ParsedCredential>>,
+        trusted_dids: Vec<String>,
+        signer: Box<dyn Oid4vpPresentationSigner>,
+        context_map: Option<HashMap<String, String>>,
+        keystore: Option<Arc<dyn KeyStore>>,
+        providers: Vec<Arc<dyn DynamicCredentialProvider>>,
+    ) -> Result<Arc<Self>, Oid4vpFacadeError> {
         Ok(Arc::new(Self {
             source: Oid4vpHolderSource::Credentials(provided_credentials),
             trusted_dids,
             signer: Arc::new(signer),
             context_map,
             keystore,
+            providers,
         }))
     }
 
@@ -383,24 +428,28 @@ impl Oid4vpHolder {
         });
 
         match &self.source {
-            Oid4vpHolderSource::Collection(vdc_collection) => Holder::new(
+            Oid4vpHolderSource::Collection(vdc_collection) => Holder::new_with_providers(
                 vdc_collection.clone(),
                 self.trusted_dids.clone(),
                 signer,
                 self.context_map.clone(),
                 self.keystore.clone(),
+                self.providers.clone(),
             )
             .await
             .map_err(Into::into),
-            Oid4vpHolderSource::Credentials(credentials) => Holder::new_with_credentials(
-                credentials.clone(),
-                self.trusted_dids.clone(),
-                signer,
-                self.context_map.clone(),
-                self.keystore.clone(),
-            )
-            .await
-            .map_err(Into::into),
+            Oid4vpHolderSource::Credentials(credentials) => {
+                Holder::new_with_credentials_and_providers(
+                    credentials.clone(),
+                    self.trusted_dids.clone(),
+                    signer,
+                    self.context_map.clone(),
+                    self.keystore.clone(),
+                    self.providers.clone(),
+                )
+                .await
+                .map_err(Into::into)
+            }
         }
     }
 
@@ -496,6 +545,13 @@ impl Oid4vpSession {
         }
     }
 
+    pub fn dynamic_offers(&self) -> Vec<DynamicCredentialOffer> {
+        match &self.inner {
+            Oid4vpSessionInner::V1 { request, .. } => request.dynamic_offers(),
+            Oid4vpSessionInner::Draft18 { .. } => vec![],
+        }
+    }
+
     pub fn is_multi_credential_selection(&self) -> bool {
         self.requirements().len() > 1
     }
@@ -585,6 +641,52 @@ impl Oid4vpSession {
                 Ok(Arc::new(Oid4vpPermissionResponse {
                     inner: Oid4vpPermissionResponseInner::Draft18(response),
                 }))
+            }
+        }
+    }
+
+    pub async fn create_permission_response_with_offers(
+        &self,
+        selected_credentials: Vec<Arc<Oid4vpPresentableCredential>>,
+        selected_fields: Vec<Vec<String>>,
+        selected_offers: Vec<DynamicCredentialOffer>,
+        response_options: Oid4vpResponseOptions,
+    ) -> Result<Arc<Oid4vpPermissionResponse>, Oid4vpFacadeError> {
+        match &self.inner {
+            Oid4vpSessionInner::V1 { request, .. } => {
+                let credentials = selected_credentials
+                    .into_iter()
+                    .map(|credential| match &credential.inner {
+                        Oid4vpPresentableCredentialInner::V1(inner) => Ok(inner.clone()),
+                        _ => Err(Oid4vpFacadeError::VersionMismatch),
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                let response = request
+                    .create_permission_response_with_offers(
+                        credentials,
+                        selected_fields,
+                        selected_offers,
+                        ResponseOptions {
+                            force_array_serialization: response_options.force_array_serialization,
+                        },
+                    )
+                    .await?;
+
+                Ok(Arc::new(Oid4vpPermissionResponse {
+                    inner: Oid4vpPermissionResponseInner::V1(response),
+                }))
+            }
+            Oid4vpSessionInner::Draft18 { .. } => {
+                if !selected_offers.is_empty() {
+                    return Err(Oid4vpFacadeError::VersionMismatch);
+                }
+                self.create_permission_response(
+                    selected_credentials,
+                    selected_fields,
+                    response_options,
+                )
+                .await
             }
         }
     }
@@ -1875,5 +1977,283 @@ mod tests {
             result,
             Err(Oid4vpFacadeError::ConflictingVersions)
         ));
+    }
+
+    use crate::oid4vp::dynamic_credential::{
+        DcqlCredentialQueryJson, DynamicCredentialError, IssuedCredential, PresentationBinding,
+    };
+    use std::sync::Mutex;
+
+    const FAKE_OFFER_ID: &str = "fake-offer";
+    const FAKE_TITLE: &str = "Fake dynamic credential";
+    const FAKE_VP_TOKEN_ITEM: &str = "issued-vp-token-item";
+
+    /// A fake provider that offers a credential for every DCQL credential
+    /// query and records the [`PresentationBinding`] it was issued against.
+    #[derive(Debug, Default)]
+    struct FakeProvider {
+        issued_binding: Mutex<Option<PresentationBinding>>,
+    }
+
+    #[async_trait::async_trait]
+    impl DynamicCredentialProvider for FakeProvider {
+        async fn offers(&self, query: DcqlCredentialQueryJson) -> Vec<DynamicCredentialOffer> {
+            let query = query.parse().expect("valid DCQL credential query JSON");
+            vec![DynamicCredentialOffer {
+                offer_id: FAKE_OFFER_ID.to_string(),
+                credential_query_id: query.id().to_string(),
+                title: FAKE_TITLE.to_string(),
+            }]
+        }
+
+        async fn issue(
+            &self,
+            offer_id: String,
+            binding: PresentationBinding,
+        ) -> Result<IssuedCredential, DynamicCredentialError> {
+            if offer_id != FAKE_OFFER_ID {
+                return Err(DynamicCredentialError::IssuanceFailed(format!(
+                    "unknown offer id: {offer_id}"
+                )));
+            }
+            *self.issued_binding.lock().unwrap() = Some(binding);
+            Ok(IssuedCredential {
+                vp_token_item: FAKE_VP_TOKEN_ITEM.to_string(),
+            })
+        }
+    }
+
+    async fn holder_with_provider(provider: Arc<FakeProvider>) -> Arc<Oid4vpHolder> {
+        Oid4vpHolder::new_with_credentials_and_providers(
+            vec![alumni_credential()],
+            Vec::new(),
+            Box::new(TestSigner { jwk: load_jwk() }),
+            Some(default_ld_json_context()),
+            None,
+            vec![provider],
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn facade_v1_session_surfaces_dynamic_offers() {
+        let provider = Arc::new(FakeProvider::default());
+        let holder = holder_with_provider(provider).await;
+
+        let session = holder.start(v1_request()).await.unwrap();
+        assert_eq!(session.version(), Oid4vpVersion::V1);
+
+        let offers = session.dynamic_offers();
+        assert_eq!(offers.len(), 1);
+        assert_eq!(offers[0].offer_id, FAKE_OFFER_ID);
+        assert_eq!(offers[0].credential_query_id, "alumni_vc_0");
+        assert_eq!(offers[0].title, FAKE_TITLE);
+    }
+
+    #[tokio::test]
+    async fn facade_draft18_session_has_no_dynamic_offers() {
+        let provider = Arc::new(FakeProvider::default());
+        let holder = holder_with_provider(provider).await;
+
+        // Same holder, same registered provider — but the dynamic-credential
+        // hook is v1-only, so a draft-18 session surfaces no offers.
+        let session = holder.start(draft18_request()).await.unwrap();
+        assert_eq!(session.version(), Oid4vpVersion::Draft18);
+        assert!(session.dynamic_offers().is_empty());
+    }
+
+    #[tokio::test]
+    async fn facade_offers_only_response_issues_into_vp_token() {
+        let provider = Arc::new(FakeProvider::default());
+        let holder = holder_with_provider(provider.clone()).await;
+
+        let session = holder.start(v1_request()).await.unwrap();
+        let offers = session.dynamic_offers();
+        assert_eq!(offers.len(), 1);
+
+        // Zero stored credentials selected; only the issued offer.
+        let response = session
+            .create_permission_response_with_offers(
+                vec![],
+                vec![],
+                offers,
+                Oid4vpResponseOptions::default(),
+            )
+            .await
+            .unwrap();
+
+        let vp_token: Value = serde_json::from_str(&response.vp_token().unwrap()).unwrap();
+        let items = vp_token
+            .get("alumni_vc_0")
+            .and_then(|v| v.as_array())
+            .expect("vp_token contains an array for alumni_vc_0");
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].as_str(), Some(FAKE_VP_TOKEN_ITEM));
+
+        // The provider was issued against this presentation's live binding.
+        let binding = provider
+            .issued_binding
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("provider was asked to issue");
+        assert_eq!(binding.nonce, "nonce-123");
+        assert_eq!(
+            binding.client_id,
+            "redirect_uri:https://wallet.example/callback"
+        );
+    }
+
+    #[tokio::test]
+    async fn facade_mixed_stored_and_offer_response() {
+        let provider = Arc::new(FakeProvider::default());
+        let holder = holder_with_provider(provider).await;
+
+        let session = holder.start(v1_request()).await.unwrap();
+        let requirement = session.requirements().pop().unwrap();
+        let requested_fields = session
+            .requested_fields(requirement.credentials.first().unwrap())
+            .unwrap();
+        let offers = session.dynamic_offers();
+
+        // A stored credential and an issued offer in one response.
+        let response = session
+            .create_permission_response_with_offers(
+                requirement.credentials.clone(),
+                vec![requested_fields
+                    .iter()
+                    .map(|field| field.path.clone())
+                    .collect()],
+                offers,
+                Oid4vpResponseOptions::default(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.selected_credentials().len(), 1);
+        let vp_token: Value = serde_json::from_str(&response.vp_token().unwrap()).unwrap();
+        let items = vp_token
+            .get("alumni_vc_0")
+            .and_then(|v| v.as_array())
+            .expect("vp_token contains an array for alumni_vc_0");
+        assert_eq!(items.len(), 2, "stored + issued items share the query id");
+        assert!(items
+            .iter()
+            .any(|item| item.as_str() == Some(FAKE_VP_TOKEN_ITEM)));
+        assert!(items
+            .iter()
+            .any(|item| item.to_string().contains("AlumniCredential")));
+    }
+
+    #[tokio::test]
+    async fn facade_draft18_rejects_selected_offers() {
+        let provider = Arc::new(FakeProvider::default());
+        let holder = holder_with_provider(provider).await;
+
+        let session = holder.start(draft18_request()).await.unwrap();
+        let requirement = session.requirements().pop().unwrap();
+        let requested_fields = session
+            .requested_fields(requirement.credentials.first().unwrap())
+            .unwrap();
+        let selected_fields = vec![requested_fields
+            .iter()
+            .map(|field| field.path.clone())
+            .collect::<Vec<_>>()];
+
+        let result = session
+            .create_permission_response_with_offers(
+                requirement.credentials.clone(),
+                selected_fields.clone(),
+                vec![DynamicCredentialOffer {
+                    offer_id: FAKE_OFFER_ID.to_string(),
+                    credential_query_id: "alumni_descriptor".to_string(),
+                    title: FAKE_TITLE.to_string(),
+                }],
+                Oid4vpResponseOptions::default(),
+            )
+            .await;
+        assert!(matches!(result, Err(Oid4vpFacadeError::VersionMismatch)));
+
+        // With no offers selected the method delegates to the plain draft-18
+        // path.
+        let response = session
+            .create_permission_response_with_offers(
+                requirement.credentials.clone(),
+                selected_fields,
+                vec![],
+                Oid4vpResponseOptions::default(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.version(), Oid4vpVersion::Draft18);
+    }
+
+    #[tokio::test]
+    async fn facade_empty_credential_pack_with_provider_issues_offers_only_response() {
+        let provider = Arc::new(FakeProvider::default());
+
+        // No stored credentials at all — allowed when a provider is
+        // registered; the whole response may be issued on the fly.
+        let holder = Oid4vpHolder::new_with_credentials_and_providers(
+            vec![],
+            Vec::new(),
+            Box::new(TestSigner { jwk: load_jwk() }),
+            Some(default_ld_json_context()),
+            None,
+            vec![provider],
+        )
+        .await
+        .unwrap();
+
+        let session = holder.start(v1_request()).await.unwrap();
+        assert_eq!(session.version(), Oid4vpVersion::V1);
+        assert!(session.credentials().is_empty());
+
+        let offers = session.dynamic_offers();
+        assert_eq!(offers.len(), 1);
+
+        let response = session
+            .create_permission_response_with_offers(
+                vec![],
+                vec![],
+                offers,
+                Oid4vpResponseOptions::default(),
+            )
+            .await
+            .unwrap();
+
+        let vp_token: Value = serde_json::from_str(&response.vp_token().unwrap()).unwrap();
+        let items = vp_token
+            .get("alumni_vc_0")
+            .and_then(|v| v.as_array())
+            .expect("vp_token contains an array for alumni_vc_0");
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].as_str(), Some(FAKE_VP_TOKEN_ITEM));
+    }
+
+    #[tokio::test]
+    async fn facade_unknown_offer_id_errors() {
+        let provider = Arc::new(FakeProvider::default());
+        let holder = holder_with_provider(provider).await;
+
+        let session = holder.start(v1_request()).await.unwrap();
+
+        // An offer that was never surfaced (no owning provider) is rejected by
+        // the underlying permission request.
+        let result = session
+            .create_permission_response_with_offers(
+                vec![],
+                vec![],
+                vec![DynamicCredentialOffer {
+                    offer_id: "no-such-offer".to_string(),
+                    credential_query_id: "alumni_vc_0".to_string(),
+                    title: "Unknown".to_string(),
+                }],
+                Oid4vpResponseOptions::default(),
+            )
+            .await;
+
+        assert!(matches!(result, Err(Oid4vpFacadeError::V1(_))));
     }
 }

--- a/rust/src/oid4vp/facade.rs
+++ b/rust/src/oid4vp/facade.rs
@@ -280,6 +280,11 @@ impl Oid4vpHolder {
         .await
     }
 
+    /// Create a holder with registered [`DynamicCredentialProvider`]s, which
+    /// issue credentials on device during a presentation.
+    ///
+    /// Providers participate in v1 sessions only: Draft 18 / Draft 13
+    /// sessions report no dynamic offers.
     #[uniffi::constructor]
     pub async fn new_with_providers(
         vdc_collection: Arc<VdcCollection>,
@@ -318,6 +323,12 @@ impl Oid4vpHolder {
         .await
     }
 
+    /// Create a holder with stored credentials plus registered
+    /// [`DynamicCredentialProvider`]s, which issue credentials on device
+    /// during a presentation.
+    ///
+    /// Providers participate in v1 sessions only: Draft 18 / Draft 13
+    /// sessions report no dynamic offers.
     #[uniffi::constructor]
     pub async fn new_with_credentials_and_providers(
         provided_credentials: Vec<Arc<ParsedCredential>>,
@@ -545,6 +556,12 @@ impl Oid4vpSession {
         }
     }
 
+    /// Dynamic credential offers surfaced for this session by the holder's
+    /// [`DynamicCredentialProvider`]s. Stored credentials are listed
+    /// separately by [`Oid4vpSession::credentials`].
+    ///
+    /// Always empty for Draft 18 / Draft 13 sessions: the dynamic-credential
+    /// hook is OID4VP-v1 only.
     pub fn dynamic_offers(&self) -> Vec<DynamicCredentialOffer> {
         match &self.inner {
             Oid4vpSessionInner::V1 { request, .. } => request.dynamic_offers(),
@@ -645,6 +662,13 @@ impl Oid4vpSession {
         }
     }
 
+    /// Create the permission response, additionally issuing the dynamic
+    /// credential offers selected from [`Oid4vpSession::dynamic_offers`].
+    ///
+    /// Either `selected_credentials` or `selected_offers` (or both) may be
+    /// non-empty. Selecting offers on a Draft 18 / Draft 13 session returns
+    /// [`Oid4vpFacadeError::VersionMismatch`]: the dynamic-credential hook is
+    /// OID4VP-v1 only.
     pub async fn create_permission_response_with_offers(
         &self,
         selected_credentials: Vec<Arc<Oid4vpPresentableCredential>>,


### PR DESCRIPTION
#346 shipped the DynamicCredentialProvider machinery in the Rust core, but there was no way to actually reach it from Flutter. Host apps can now register native providers with the plugin (SprucekitMobilePlugin.dynamicCredentialProviders on both platforms), and the OID4VP flow picks them up: Dart can list the dynamic offers for a session (getDynamicOffers) and include them when submitting the response (submitResponseWithOffers), so a presentation can carry credentials issued on the fly next to stored ones. Heads up: this only works on v1 sessions — draft-18/13 always report zero offers.

On the OID4VCI side, issuers that require a presentation before releasing a credential used to surface as an opaque error string. That's now a typed result (Oid4vciPresentationRequired) carrying the authorization request JSON, so apps can run the presentation and retry the issuance. Two things are source-breaking for exhaustive switches: Oid4vciResult gains that new variant (Dart), and the OID4VCI error enum gains one too (Kotlin/Swift/Rust). Everything else is additive; comes with facade tests plus a plugin test suite for the new surface.