### PR TITLE
Unpin swiftlint

### DIFF
--- a/ios/MobileSdk/project.yml
+++ b/ios/MobileSdk/project.yml
@@ -9,10 +9,7 @@ packages:
     from: 1.2.0
   SwiftLint:
     url: https://github.com/realm/SwiftLint
-    # Pinned: tag 0.63.3 exists without a published GitHub Release, so SPM
-    # resolves to it and then 404s on SwiftLintBinary.artifactbundle.zip.
-    # Track upstream fix: https://github.com/realm/SwiftLint/issues/6669
-    exactVersion: 0.63.2
+    from: 0.63.3
 settings:
   ENABLE_USER_SCRIPT_SANDBOXING: YES
   GENERATE_INFOPLIST_FILE: YES


### PR DESCRIPTION
## Description

[Unpin SwiftLint in SpruceKit ios/MobileSdk/project.yml](https://linear.app/spruceid/issue/ACC-1415/unpin-swiftlint-in-sprucekit-iosmobilesdkprojectyml)

As mentioned in the issue, https://github.com/realm/SwiftLint/issues/6669 is closed and 0.64.0 is released
