### PR TITLE
Fix wallet crash on credentials with http image links

### DIFF
--- a/android/Showcase/src/androidTest/java/com/spruceid/mobilesdkexample/ExampleInstrumentedTest.kt
+++ b/android/Showcase/src/androidTest/java/com/spruceid/mobilesdkexample/ExampleInstrumentedTest.kt
@@ -17,6 +17,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("com.spruceid.mobilesdk", appContext.packageName)
+        assertEquals("com.spruceid.mobilesdkexample", appContext.packageName)
     }
 }

--- a/android/Showcase/src/androidTest/java/com/spruceid/mobilesdkexample/credentials/CredentialImageTest.kt
+++ b/android/Showcase/src/androidTest/java/com/spruceid/mobilesdkexample/credentials/CredentialImageTest.kt
@@ -1,0 +1,81 @@
+package com.spruceid.mobilesdkexample.credentials
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Needs a device: `android.util.Base64` and `BitmapFactory` are unavailable to JVM tests.
+ */
+@RunWith(AndroidJUnit4::class)
+class CredentialImageTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    /** A 1x1 transparent PNG. */
+    private val pngBase64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+
+    /** Renders inside a tagged container so an absent image can be told from an absent hierarchy. */
+    private fun setContentInContainer(image: String, alt: String) {
+        composeTestRule.setContent {
+            Box(Modifier.testTag("container")) {
+                CredentialImage(image, alt)
+            }
+        }
+        composeTestRule.onNodeWithTag("container").assertExists()
+    }
+
+    @Test
+    fun httpLinkRendersRemotelyInsteadOfCrashing() {
+        setContentInContainer("http://example.com/logo.png", "issuer logo")
+
+        // The node exists because we took the AsyncImage branch; the load itself fails silently.
+        composeTestRule.onNodeWithContentDescription("issuer logo").assertExists()
+    }
+
+    @Test
+    fun httpsLinkRendersRemotely() {
+        setContentInContainer("https://example.com/logo.png", "issuer logo")
+
+        composeTestRule.onNodeWithContentDescription("issuer logo").assertExists()
+    }
+
+    @Test
+    fun inlineBase64ImageRenders() {
+        setContentInContainer("data:image/png;base64,$pngBase64", "portrait")
+
+        composeTestRule.onNodeWithContentDescription("portrait").assertIsDisplayed()
+    }
+
+    @Test
+    fun bareBase64ImageRenders() {
+        setContentInContainer(pngBase64, "portrait")
+
+        composeTestRule.onNodeWithContentDescription("portrait").assertIsDisplayed()
+    }
+
+    @Test
+    fun base64ThatCannotBeDecodedIsSkippedInsteadOfCrashing() {
+        // One leftover character is the only length `Base64.decode` actually rejects.
+        setContentInContainer("data:image/png;base64,A", "portrait")
+
+        composeTestRule.onNodeWithContentDescription("portrait").assertDoesNotExist()
+    }
+
+    @Test
+    fun validBase64ThatIsNotAnImageIsSkippedInsteadOfCrashing() {
+        // Decodes cleanly, but BitmapFactory can't make an image of it.
+        setContentInContainer("aGVsbG8gd29ybGQ=", "portrait")
+
+        composeTestRule.onNodeWithContentDescription("portrait").assertDoesNotExist()
+    }
+}

--- a/android/Showcase/src/debug/AndroidManifest.xml
+++ b/android/Showcase/src/debug/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Debug only, so release keeps the platform default: lets http:// image links and local
+     backends load without a network security config. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:usesCleartextTraffic="true" />
+</manifest>

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/CredentialImage.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/CredentialImage.kt
@@ -1,6 +1,5 @@
 package com.spruceid.mobilesdkexample.credentials
 
-import android.graphics.BitmapFactory
 import android.util.Base64
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -11,12 +10,13 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.spruceid.mobilesdkexample.utils.BitmapImage
+import com.spruceid.mobilesdkexample.utils.isRemoteImageUrl
 import com.spruceid.mobilesdkexample.utils.jsonArrayToByteArray
 import org.json.JSONArray
 
 @Composable
 fun CredentialImage(image: String, alt: String) {
-    if (image.startsWith("https://")) {
+    if (image.isRemoteImageUrl()) {
         AsyncImage(
             model = image,
             contentDescription = alt,
@@ -26,22 +26,27 @@ fun CredentialImage(image: String, alt: String) {
             contentScale = ContentScale.Fit,
         )
     } else {
-        val byteArray = Base64.decode(
-            image
-                .replace("data:image/png;base64,", "")
-                .replace("data:image/jpeg;base64,", ""),
-            Base64.DEFAULT
-        ).apply {
-            BitmapFactory.decodeByteArray(this, 0, size)
+        // `Base64.decode` throws on bad length or padding, which must not take the app down.
+        val byteArray = remember(image) {
+            runCatching {
+                Base64.decode(
+                    image
+                        .replace("data:image/png;base64,", "")
+                        .replace("data:image/jpeg;base64,", ""),
+                    Base64.DEFAULT
+                )
+            }.getOrNull()
         }
 
-        BitmapImage(
-            byteArray,
-            contentDescription = alt,
-            modifier = Modifier
-                .width(50.dp)
-                .padding(end = 12.dp)
-        )
+        if (byteArray != null) {
+            BitmapImage(
+                byteArray,
+                contentDescription = alt,
+                modifier = Modifier
+                    .width(50.dp)
+                    .padding(end = 12.dp)
+            )
+        }
     }
 }
 

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/utils/Utils.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/utils/Utils.kt
@@ -2,7 +2,6 @@ package com.spruceid.mobilesdkexample.utils
 
 import android.content.Context
 import android.content.pm.PackageManager
-import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.compose.foundation.Image
@@ -73,17 +72,20 @@ fun String.isImage(): Boolean {
             contains("data:image")
 }
 
+/** Whether the value links to a remotely hosted image rather than holding an inline base64 one. */
+fun String.isRemoteImageUrl(): Boolean {
+    return startsWith("http://", ignoreCase = true) ||
+            startsWith("https://", ignoreCase = true)
+}
+
 @Composable
 fun BitmapImage(
     byteArray: ByteArray,
     contentDescription: String,
     modifier: Modifier,
 ) {
-    fun convertImageByteArrayToBitmap(imageData: ByteArray): Bitmap {
-        return BitmapFactory.decodeByteArray(imageData, 0, imageData.size)
-    }
-
-    val bitmap = convertImageByteArrayToBitmap(byteArray)
+    // Null when the bytes aren't a decodable image, so skip rendering rather than crash.
+    val bitmap = BitmapFactory.decodeByteArray(byteArray, 0, byteArray.size) ?: return
 
     Image(
         bitmap = bitmap.asImageBitmap(),

--- a/ios/Showcase/Targets/AppUIKit/Sources/credentials/CredentialImage.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/credentials/CredentialImage.swift
@@ -5,7 +5,7 @@ struct CredentialImage: View {
     var image: String
 
     var body: some View {
-        if image.contains("https://") {
+        if image.isRemoteImageUrl {
             return AnyView(
                 AsyncImage(url: URL(string: image)) { image in
                     image

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/WalletUtils.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/WalletUtils.swift
@@ -56,7 +56,7 @@ extension String {
 
     /// Whether the value links to a remotely hosted image rather than holding an inline base64 one.
     var isRemoteImageUrl: Bool {
-        let value = self.lowercased()
+        let value = self.prefix(8).lowercased()
         return value.hasPrefix("http://") || value.hasPrefix("https://")
     }
 }

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/WalletUtils.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/WalletUtils.swift
@@ -53,6 +53,12 @@ extension String {
     func replaceEscaping() -> String {
         return self.replacingOccurrences(of: "\\/", with: "/")
     }
+
+    /// Whether the value links to a remotely hosted image rather than holding an inline base64 one.
+    var isRemoteImageUrl: Bool {
+        let value = self.lowercased()
+        return value.hasPrefix("http://") || value.hasPrefix("https://")
+    }
 }
 
 extension Data {


### PR DESCRIPTION
[SKIT-852
](https://linear.app/spruceid/issue/SKIT-852/fix-android-wallet-crash-with-http-image-links)

## Description

`CredentialImage` only treated `https://` values as remote links, so an `http://` image fell through to the branch that decodes inline base64. `Base64.decode` skips characters outside the base64 alphabet instead of rejecting them, so `http://example.com/logo.png` lost its `:` and `.` and decoded cleanly into 18 bytes of garbage. BitmapFactory returned null for those bytes, and BitmapImage dereferenced the result through a non-null `Bitmap` return type, so opening the wallet crashed with `NullPointerException: decodeByteArray(...) must not be null`.

## Tested

Added a `CredentialImageTest.kt` to test all 6 branches