### PR TITLE
Add parameter to pass selected fields to submit_presentation

### DIFF
--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleVCALMView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleVCALMView.kt
@@ -193,6 +193,8 @@ fun HandleVCALMView(
     var credentialClaims by remember { mutableStateOf(mapOf<String, JSONObject>()) }
 
     var requirements by remember { mutableStateOf<List<VcalmRequirement>?>(null) }
+    // Field paths the user consents to disclose, keyed by queryIndex
+    var fieldSelections by remember { mutableStateOf<Map<UInt, Set<String>>>(emptyMap()) }
     var picks by remember { mutableStateOf<Map<UInt, ParsedCredential>>(emptyMap()) }
     var redirectUrl by remember { mutableStateOf<String?>(null) }
     var pendingWalletCredentials by remember { mutableStateOf<List<String>?>(null) }
@@ -200,6 +202,7 @@ fun HandleVCALMView(
     var offerAcceptError by remember { mutableStateOf(false) }
     var domainMismatch by remember { mutableStateOf<VcalmException.DomainChannelMismatch?>(null) }
     var pendingSelection by remember { mutableStateOf<List<ParsedCredential>>(emptyList()) }
+    var pendingFieldPaths by remember { mutableStateOf<Map<UInt, List<String>>>(emptyMap()) }
 
     fun unwrap(originalUrl: String): String {
         var url = originalUrl
@@ -247,17 +250,20 @@ fun HandleVCALMView(
 
     // Submit presentation after automatically/manually selecting credentials to fit requirements
     suspend fun trySubmitPresentation(
-        selected: List<ParsedCredential>, allowDomainMismatch: Boolean
+        selected: List<ParsedCredential>,
+        selectedFields: Map<UInt, List<String>>,
+        allowDomainMismatch: Boolean
     ) {
         val previousState = state
         state = VCALMState.Loading
         try {
-            val result = holder!!.submitPresentation(selected, allowDomainMismatch)
+            val result = holder!!.submitPresentation(selected, selectedFields, allowDomainMismatch)
             requirements = null
             domainMismatch = null
             handleStep(result)
         } catch (e: VcalmException.DomainChannelMismatch) {
             pendingSelection = selected
+            pendingFieldPaths = selectedFields
             domainMismatch = e
             // Fall back to previous screen, allow user to allow domain channel mismatch and continue
             state = previousState
@@ -278,7 +284,7 @@ fun HandleVCALMView(
             if (requestedFields.isEmpty()) {
                 // No fields requested — this is a DID-authentication-only request
                 // Can submit immediately
-                trySubmitPresentation(emptyList(), false)
+                trySubmitPresentation(emptyList(), emptyMap(), false)
                 return
             }
 
@@ -295,6 +301,9 @@ fun HandleVCALMView(
             picks = built.filter { it.candidates.size == 1 }
                 .associate { it.queryIndex to it.candidates.first() }
             requirements = built
+            fieldSelections = built.associate { req ->
+                req.queryIndex to req.fields.map { it.path }.toSet()
+            }
             // If no requirement has more than one candidate, skip straight to selective disclosure
             state = if (built.all { it.candidates.size <= 1 }) {
                 VCALMState.SelectFields
@@ -341,8 +350,12 @@ fun HandleVCALMView(
     }
 
     suspend fun submitPicks() {
-        val selected = requirements.orEmpty().mapNotNull { picks[it.queryIndex] }
-        trySubmitPresentation(selected, false)
+        val reqs = requirements.orEmpty()
+        val selected = reqs.mapNotNull { picks[it.queryIndex] }
+        val selectedFields = reqs.associate {
+            it.queryIndex to fieldSelections[it.queryIndex].orEmpty().toList()
+        }
+        trySubmitPresentation(selected, selectedFields, false)
     }
 
     suspend fun acceptOffer() {
@@ -487,6 +500,10 @@ fun HandleVCALMView(
                 requirements = reqs,
                 picks = picks,
                 credentialClaims = credentialClaims,
+                fieldSelections = fieldSelections,
+                onFieldToggle = { queryIndex, selected ->
+                    fieldSelections = fieldSelections + (queryIndex to selected)
+                },
                 onSubmit = { coroutineScope.launch { submitPicks() } },
                 onCancel = { navController.navigate(Screen.HomeScreen.route) { popUpTo(0) } },
             )
@@ -508,7 +525,7 @@ fun HandleVCALMView(
             onContinueAnyway = {
                 domainMismatch = null
                 coroutineScope.launch {
-                    trySubmitPresentation(pendingSelection, true)
+                    trySubmitPresentation(pendingSelection, pendingFieldPaths, true)
                 }
             },
         )
@@ -734,6 +751,8 @@ fun VcalmFieldsSelector(
     requirements: List<VcalmRequirement>,
     picks: Map<UInt, ParsedCredential>,
     credentialClaims: Map<String, JSONObject>,
+    fieldSelections: Map<UInt, Set<String>>,
+    onFieldToggle: (UInt, Set<String>) -> Unit,
     onSubmit: () -> Unit,
     onCancel: () -> Unit,
 ) {
@@ -805,20 +824,20 @@ fun VcalmFieldsSelector(
                     }
                 }
             } else {
-                var selectedFields by remember(currentRequirement.queryIndex) {
-                    mutableStateOf(currentRequirement.fields.map { it.path }.toSet())
-                }
+                // Field toggles propogate to HandleVCALMView
+                val selectedFields = fieldSelections[currentRequirement.queryIndex].orEmpty()
                 currentRequirement.fields.forEach { field ->
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Checkbox(
                             enabled = !field.required,
                             checked = selectedFields.contains(field.path) || field.required,
                             onCheckedChange = { v ->
-                                selectedFields = if (!v) {
+                                val updated = if (!v) {
                                     selectedFields.minus(field.path)
                                 } else {
                                     selectedFields.plus(field.path)
                                 }
+                                onFieldToggle(currentRequirement.queryIndex, updated)
                             })
                         Text(
                             buildAnnotatedString {

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleVCALMView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleVCALMView.kt
@@ -92,6 +92,9 @@ data class VcalmRequirement(
     val fields: List<VcalmRequestedField>,
 )
 
+fun isSubjectPath(path: String): Boolean =
+    path == "credentialSubject" || path.startsWith("credentialSubject.")
+
 // Iterate the UNION of requested queries (`fieldsByQuery`) and matched ones, so a requested query
 // with no matching wallet credential still becomes a requirement (with empty candidates) and
 // surfaces as "no matching credential" — instead of being silently dropped.
@@ -99,7 +102,8 @@ fun buildVcalmRequirements(
     requestedFields: List<VcalmRequestedField>,
     matched: List<VcalmMatchedCredentials>,
 ): List<VcalmRequirement> {
-    val fieldsByQuery = requestedFields.filter { it.path != "type" && it.path != "@context" }
+    // Only `credentialSubject` claims are surfaced in the consent UI. Everything else is always disclosed by the   SDK
+    val fieldsByQuery = requestedFields.filter { isSubjectPath(it.path) }
         .groupBy { it.queryIndex }
     val candidatesByQuery =
         matched.associate { it.queryIndex to it.credentials.map { c -> c.credential } }

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleVCALMView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleVCALMView.kt
@@ -352,9 +352,8 @@ fun HandleVCALMView(
     suspend fun submitPicks() {
         val reqs = requirements.orEmpty()
         val selected = reqs.mapNotNull { picks[it.queryIndex] }
-        val selectedFields = reqs.associate {
-            it.queryIndex to fieldSelections[it.queryIndex].orEmpty().toList()
-        }
+        val selectedFields = reqs.filter { it.fields.isNotEmpty() }
+            .associate { it.queryIndex to fieldSelections[it.queryIndex].orEmpty().toList() }
         trySubmitPresentation(selected, selectedFields, false)
     }
 
@@ -824,7 +823,7 @@ fun VcalmFieldsSelector(
                     }
                 }
             } else {
-                // Field toggles propogate to HandleVCALMView
+                // Field toggles propagate to HandleVCALMView
                 val selectedFields = fieldSelections[currentRequirement.queryIndex].orEmpty()
                 currentRequirement.fields.forEach { field ->
                     Row(verticalAlignment = Alignment.CenterVertically) {

--- a/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/VcalmAdapter.kt
+++ b/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/VcalmAdapter.kt
@@ -267,7 +267,6 @@ internal class VcalmAdapter(
                 // Suite is server-driven — no suite parameter.
                 val creds = selected.mapNotNull { keyMap[it] }
                 Log.d(TAG, "submitPresentation: resolved ${creds.size}/${selected.size} handle(s)")
-                val step = h.submitPresentation(creds, allowDomainMismatch)
                 Log.d(TAG, "submitPresentation: step=${step::class.simpleName}")
                 callback(Result.success(toPigeonStep(step)))
             } catch (e: VcalmException.DomainChannelMismatch) {

--- a/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/VcalmAdapter.kt
+++ b/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/VcalmAdapter.kt
@@ -267,6 +267,7 @@ internal class VcalmAdapter(
                 // Suite is server-driven — no suite parameter.
                 val creds = selected.mapNotNull { keyMap[it] }
                 Log.d(TAG, "submitPresentation: resolved ${creds.size}/${selected.size} handle(s)")
+                val step = h.submitPresentation(creds, allowDomainMismatch)
                 Log.d(TAG, "submitPresentation: step=${step::class.simpleName}")
                 callback(Result.success(toPigeonStep(step)))
             } catch (e: VcalmException.DomainChannelMismatch) {

--- a/flutter/ios/Classes/VcalmAdapter.swift
+++ b/flutter/ios/Classes/VcalmAdapter.swift
@@ -289,6 +289,7 @@ class VcalmAdapter: Vcalm {
                 // Suite is server-driven — no suite parameter.
                 let step = try await holder.submitPresentation(
                     selectedCredentials: resolved,
+                    selectedFields: [:],
                     allowDomainMismatch: allowDomainMismatch
                 )
                 completion(.success(try await toPigeonStep(step)))

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleVCALMView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleVCALMView.swift
@@ -183,6 +183,8 @@ struct HandleVCALMView: View {
     @State private var holder: VcalmHolder?
 
     @State private var requirements: [VcalmRequirement]?
+    // Field paths the user consents to disclose, keyed by queryIndex
+    @State private var fieldSelections: [UInt32: Set<String>] = [:]
     @State private var readyForFieldSelection: Bool = false
     @State private var picks: [UInt32: ParsedCredential] = [:]
     @State private var redirectUrl: String?
@@ -192,6 +194,7 @@ struct HandleVCALMView: View {
     @State private var offerAcceptError: Bool = false
     @State private var domainMismatch: VcalmDomainMismatch?
     @State private var pendingSelection: [ParsedCredential] = []
+    @State private var pendingFieldPaths: [UInt32: [String]] = [:]
     // Set right before `onContinueAnyway` nils out `domainMismatch` itself,
     // so the `.sheet(isPresented:)` binding's write-back (which SwiftUI
     // calls for ANY dismissal, not just a user-initiated one) doesn't also
@@ -232,12 +235,14 @@ struct HandleVCALMView: View {
     // Submit presentation after automatically/manually selecting credentials to fit requirements
     func trySubmitPresentation(
         selected: [ParsedCredential],
+        selectedFields: [UInt32: [String]],
         allowDomainMismatch: Bool
     ) async {
         guard let holder else { return }
         do {
             let result = try await holder.submitPresentation(
                 selectedCredentials: selected,
+                selectedFields: selectedFields,
                 allowDomainMismatch: allowDomainMismatch
             )
             requirements = nil
@@ -245,6 +250,7 @@ struct HandleVCALMView: View {
             await handleStep(result)
         } catch VcalmError.DomainChannelMismatch(let domain, let channel) {
             pendingSelection = selected
+            pendingFieldPaths = selectedFields
             domainMismatch = VcalmDomainMismatch(
                 domain: domain,
                 channel: channel
@@ -268,6 +274,7 @@ struct HandleVCALMView: View {
                 // Can submit immediately
                 await trySubmitPresentation(
                     selected: [],
+                    selectedFields: [:],
                     allowDomainMismatch: false
                 )
                 return
@@ -293,6 +300,11 @@ struct HandleVCALMView: View {
             }
             picks = autoPicks
             requirements = built
+            fieldSelections = Dictionary(
+                uniqueKeysWithValues: built.map {
+                    ($0.queryIndex, Set($0.fields.map { $0.path }))
+                }
+            )
             // If no requirement has more than one candidate, skip straight to selective disclosure
             readyForFieldSelection = built.allSatisfy {
                 $0.candidates.count <= 1
@@ -339,10 +351,17 @@ struct HandleVCALMView: View {
     }
 
     func submitPicks() async {
-        let selected = (requirements ?? []).compactMap { picks[$0.queryIndex] }
+        let reqs = requirements ?? []
+        let selected = reqs.compactMap { picks[$0.queryIndex] }
+        let selectedFields = Dictionary(
+            uniqueKeysWithValues: reqs.map {
+                ($0.queryIndex, Array(fieldSelections[$0.queryIndex] ?? []))
+            }
+        )
         loading = true
         await trySubmitPresentation(
             selected: selected,
+            selectedFields: selectedFields,
             allowDomainMismatch: false
         )
         loading = false
@@ -490,12 +509,9 @@ struct HandleVCALMView: View {
                     requirements: requirements,
                     picks: picks,
                     credentialClaims: credentialClaims,
-                    onSubmit: {
-                        Task {
-                            await submitPicks()
-                        }
-                    },
-                    onCancel: back
+                    onSubmit: { Task { await submitPicks() } },
+                    onCancel: back,
+                    fieldSelections: $fieldSelections
                 )
             } else {
                 LoadingView(loadingText: "Loading...")
@@ -523,12 +539,14 @@ struct HandleVCALMView: View {
                     onCancel: { cancelDomainMismatch() },
                     onContinueAnyway: {
                         let selection = pendingSelection
+                        let fields = pendingFieldPaths
                         suppressDomainMismatchCancel = true
                         self.domainMismatch = nil
                         Task {
                             loading = true
                             await trySubmitPresentation(
                                 selected: selection,
+                                selectedFields: fields,
                                 allowDomainMismatch: true
                             )
                             loading = false
@@ -760,6 +778,7 @@ struct VcalmFieldsSelector: View {
     let onCancel: () -> Void
 
     @State private var currentIndex: Int = 0
+    @Binding var fieldSelections: [UInt32: Set<String>]
 
     var currentRequirement: VcalmRequirement {
         requirements[currentIndex]
@@ -767,6 +786,15 @@ struct VcalmFieldsSelector: View {
 
     var hasMoreRequirements: Bool {
         currentIndex + 1 < requirements.count
+    }
+
+    // Field toggles write to HandleVCALMView
+    func selectionBinding(_ queryIndex: UInt32) -> Binding<Set<String>> {
+        Binding {
+            fieldSelections[queryIndex] ?? []
+        } set: { newValue in
+            fieldSelections[queryIndex] = newValue
+        }
     }
 
     var body: some View {
@@ -797,7 +825,10 @@ struct VcalmFieldsSelector: View {
                 VcalmFieldsSelectorFields(
                     requirement: currentRequirement,
                     currentCredential: picks[currentRequirement.queryIndex],
-                    credentialClaims: credentialClaims
+                    credentialClaims: credentialClaims,
+                    selectedFields: selectionBinding(
+                        currentRequirement.queryIndex
+                    )
                 )
                 .id(currentRequirement.queryIndex)
             }
@@ -849,22 +880,7 @@ struct VcalmFieldsSelectorFields: View {
     let currentCredential: ParsedCredential?
     let credentialClaims: [String: [String: GenericJSON]]
 
-    // Optional fields are pre-selected but can be unchecked, mandatory
-    // fields are always selected but disabled
-    @State private var selectedFields: Set<String>
-
-    init(
-        requirement: VcalmRequirement,
-        currentCredential: ParsedCredential?,
-        credentialClaims: [String: [String: GenericJSON]]
-    ) {
-        self.requirement = requirement
-        self.currentCredential = currentCredential
-        self.credentialClaims = credentialClaims
-        self._selectedFields = State(
-            initialValue: Set(requirement.fields.map { $0.path })
-        )
-    }
+    @Binding var selectedFields: Set<String>
 
     func fieldBinding(_ field: VcalmRequestedField) -> Binding<Bool> {
         Binding {
@@ -884,7 +900,8 @@ struct VcalmFieldsSelectorFields: View {
             let allClaims =
                 currentCredential.flatMap { credentialClaims[$0.id()] } ?? [:]
             // @context is not meaningful to show the user as a disclosed field.
-            let allClaimNames = allClaims.keys.filter { $0 != "@context" }.sorted()
+            let allClaimNames = allClaims.keys.filter { $0 != "@context" }
+                .sorted()
             ForEach(Array(allClaimNames), id: \.self) { claimName in
                 SelectiveDisclosureItem(
                     fieldName: claimName,

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleVCALMView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleVCALMView.swift
@@ -37,15 +37,17 @@ struct VcalmRequirement {
 /// of requirements. Iterates the union of both so a requested query with no
 /// matching credential still becomes a requirement with empty candidates,
 /// instead of being silently dropped.
+func isSubjectPath(_ path: String) -> Bool {
+    path == "credentialSubject" || path.hasPrefix("credentialSubject.")
+}
+
 func buildVcalmRequirements(
     requestedFields: [VcalmRequestedField],
     matched: [VcalmMatchedCredentials]
 ) -> [VcalmRequirement] {
-    // The QBE example's structural keys carry no user data and don't map to
-    // a credential claim, so they're excluded from the requirement's fields.
+    // Only `credentialSubject` claims are surfaced in the consent UI. Everything else is always disclosed by the   SDK
     var fieldsByQuery: [UInt32: [VcalmRequestedField]] = [:]
-    for field in requestedFields
-    where field.path != "type" && field.path != "@context" {
+    for field in requestedFields where isSubjectPath(field.path) {
         fieldsByQuery[field.queryIndex, default: []].append(field)
     }
 

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleVCALMView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleVCALMView.swift
@@ -354,7 +354,7 @@ struct HandleVCALMView: View {
         let reqs = requirements ?? []
         let selected = reqs.compactMap { picks[$0.queryIndex] }
         let selectedFields = Dictionary(
-            uniqueKeysWithValues: reqs.map {
+            uniqueKeysWithValues: reqs.filter { !$0.fields.isEmpty }.map {
                 ($0.queryIndex, Array(fieldSelections[$0.queryIndex] ?? []))
             }
         )

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7432,7 +7432,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "vcalm-rs"
 version = "0.1.0"
-source = "git+https://github.com/spruceid/vcalm-rs?rev=cd97bd7#cd97bd77d5ca184209b6e9df723aec47e0150275"
+source = "git+https://github.com/spruceid/vcalm-rs?rev=d6f791e#d6f791ebce5a35d26591d6d47933ad75c468164e"
 dependencies = [
  "async-trait",
  "futures",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -39,7 +39,7 @@ oid4vci_legacy = { package = "oid4vci", git = "https://github.com/spruceid/oid4v
 openid4vp = { git = "https://github.com/spruceid/openid4vp", rev = "6127287" }
 openidvp_draft18 = { package = "openid4vp", git = "https://github.com/spruceid/openid4vp", rev = "2446e7"}
 ssi = { version = "0.14", features = ["secp256r1", "secp384r1"] }
-vcalm-rs = { git = "https://github.com/spruceid/vcalm-rs", rev = "cd97bd7" }
+vcalm-rs = { git = "https://github.com/spruceid/vcalm-rs", rev = "d6f791e" }
 
 anyhow = "1"
 async-trait = "0.1"

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -15323,38 +15323,27 @@ public protocol VcalmHolderProtocol: AnyObject, Sendable {
     /**
      * Build, sign and POST a verifiable presentation.
      *
-     * `selected_credentials` are the credentials the user chose. `selected_fields`
-     * is keyed by VPR query index: the entry for `i` is the field paths the user
-     * consented to disclose for query `i`.
+     * `selected_credentials` are the credentials the user chose (e.g. from
+     * `matched_credentials()`). `selected_fields` is keyed by VPR query index:
+     * the entry for `i` is the field paths the user consented to disclose for
+     * query `i`.
      *
-     * Four things to get right:
-     *
-     * * **A missing key is not an empty list.** If a query index is absent, that
-     * query is not narrowed and everything it named is disclosed. An entry that
-     * is present but empty means "the user deselected every field". So an empty
-     * map is the correct input for a caller with no per-field consent UI, and is
-     * NOT a way to disclose nothing. Send an entry only for a query that
-     * actually offered the user a choice.
-     * * **Paths must match `requested_fields()` exactly.** Selection is string
-     * equality against the example-derived paths, with no prefix or wildcard
-     * semantics: `credentialSubject.address` does not select
-     * `credentialSubject.address.street`. Pass the strings back unmodified.
-     * * **Only `credentialSubject.*` paths can be narrowed.** Structural
-     * properties an example names — `type`, `@context`, `credentialStatus` — are
-     * always disclosed, because the verifier's example states what the response
-     * credential must contain. They are not consent surface and should not be
-     * shown as checkboxes.
-     * * **Narrowing applies only to a credential with an `ecdsa-sd-2023` base
-     * proof**, under a VPR that requests selective disclosure. Otherwise the
-     * whole credential is presented and `selected_fields` is ignored, so a UI
-     * must not offer field checkboxes there. `matched_credentials()` reports
-     * `selective_disclosure` per credential for exactly this decision.
-     *
-     * Dropping fields from a query that is not explicitly optional is refused
-     * rather than signed, since the verifier's example makes every field it names
-     * required. If an optional query has every subject field deselected, that
-     * credential is dropped from the presentation — a derived credential with no
-     * `credentialSubject` would not be valid.
+     * A MISSING key means "no narrowing" — everything that query named is
+     * disclosed; a present-but-empty list means the user deselected every field.
+     * An empty map is therefore the right input for a caller with no per-field
+     * consent UI. Paths must equal what `requested_fields()` returned (plain
+     * string equality, no prefix semantics, so `credentialSubject.address` does
+     * not select `credentialSubject.address.street`). Only `credentialSubject.*`
+     * paths narrow: structural properties like `credentialStatus` are always
+     * disclosed, since the example states what the response credential must
+     * contain, and so should not be rendered as checkboxes. Dropping subject
+     * paths from a query that is not explicitly optional is refused with
+     * `RequiredFieldsDeselected`; an optional query with every subject field
+     * deselected drops that credential from the presentation rather than deriving
+     * a credential with no `credentialSubject`. Narrowing takes effect only for a
+     * credential carrying an `ecdsa-sd-2023` base proof — on the full-disclosure
+     * path `selected_fields` is ignored, and `matched_credentials()` reports
+     * `selective_disclosure` per credential for exactly that decision.
      */
     func submitPresentation(selectedCredentials: [ParsedCredential], selectedFields: [UInt32: [String]], allowDomainMismatch: Bool) async throws  -> StepResult
     
@@ -15556,38 +15545,27 @@ open func startExchange(input: String, authHeader: String?)async throws  -> Step
     /**
      * Build, sign and POST a verifiable presentation.
      *
-     * `selected_credentials` are the credentials the user chose. `selected_fields`
-     * is keyed by VPR query index: the entry for `i` is the field paths the user
-     * consented to disclose for query `i`.
+     * `selected_credentials` are the credentials the user chose (e.g. from
+     * `matched_credentials()`). `selected_fields` is keyed by VPR query index:
+     * the entry for `i` is the field paths the user consented to disclose for
+     * query `i`.
      *
-     * Four things to get right:
-     *
-     * * **A missing key is not an empty list.** If a query index is absent, that
-     * query is not narrowed and everything it named is disclosed. An entry that
-     * is present but empty means "the user deselected every field". So an empty
-     * map is the correct input for a caller with no per-field consent UI, and is
-     * NOT a way to disclose nothing. Send an entry only for a query that
-     * actually offered the user a choice.
-     * * **Paths must match `requested_fields()` exactly.** Selection is string
-     * equality against the example-derived paths, with no prefix or wildcard
-     * semantics: `credentialSubject.address` does not select
-     * `credentialSubject.address.street`. Pass the strings back unmodified.
-     * * **Only `credentialSubject.*` paths can be narrowed.** Structural
-     * properties an example names — `type`, `@context`, `credentialStatus` — are
-     * always disclosed, because the verifier's example states what the response
-     * credential must contain. They are not consent surface and should not be
-     * shown as checkboxes.
-     * * **Narrowing applies only to a credential with an `ecdsa-sd-2023` base
-     * proof**, under a VPR that requests selective disclosure. Otherwise the
-     * whole credential is presented and `selected_fields` is ignored, so a UI
-     * must not offer field checkboxes there. `matched_credentials()` reports
-     * `selective_disclosure` per credential for exactly this decision.
-     *
-     * Dropping fields from a query that is not explicitly optional is refused
-     * rather than signed, since the verifier's example makes every field it names
-     * required. If an optional query has every subject field deselected, that
-     * credential is dropped from the presentation — a derived credential with no
-     * `credentialSubject` would not be valid.
+     * A MISSING key means "no narrowing" — everything that query named is
+     * disclosed; a present-but-empty list means the user deselected every field.
+     * An empty map is therefore the right input for a caller with no per-field
+     * consent UI. Paths must equal what `requested_fields()` returned (plain
+     * string equality, no prefix semantics, so `credentialSubject.address` does
+     * not select `credentialSubject.address.street`). Only `credentialSubject.*`
+     * paths narrow: structural properties like `credentialStatus` are always
+     * disclosed, since the example states what the response credential must
+     * contain, and so should not be rendered as checkboxes. Dropping subject
+     * paths from a query that is not explicitly optional is refused with
+     * `RequiredFieldsDeselected`; an optional query with every subject field
+     * deselected drops that credential from the presentation rather than deriving
+     * a credential with no `credentialSubject`. Narrowing takes effect only for a
+     * credential carrying an `ecdsa-sd-2023` base proof — on the full-disclosure
+     * path `selected_fields` is ignored, and `matched_credentials()` reports
+     * `selective_disclosure` per credential for exactly that decision.
      */
 open func submitPresentation(selectedCredentials: [ParsedCredential], selectedFields: [UInt32: [String]], allowDomainMismatch: Bool)async throws  -> StepResult  {
     return
@@ -36622,7 +36600,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_method_vcalmholder_start_exchange() != 15267) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mobile_sdk_rs_checksum_method_vcalmholder_submit_presentation() != 21087) {
+    if (uniffi_mobile_sdk_rs_checksum_method_vcalmholder_submit_presentation() != 8604) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_vdccollection_add() != 62104) {

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -15323,7 +15323,7 @@ public protocol VcalmHolderProtocol: AnyObject, Sendable {
     /**
      * Build, sign and POST a verifiable presentation.
      */
-    func submitPresentation(selectedCredentials: [ParsedCredential], allowDomainMismatch: Bool) async throws  -> StepResult
+    func submitPresentation(selectedCredentials: [ParsedCredential], selectedFields: [UInt32: [String]], allowDomainMismatch: Bool) async throws  -> StepResult
     
 }
 open class VcalmHolder: VcalmHolderProtocol, @unchecked Sendable {
@@ -15523,13 +15523,13 @@ open func startExchange(input: String, authHeader: String?)async throws  -> Step
     /**
      * Build, sign and POST a verifiable presentation.
      */
-open func submitPresentation(selectedCredentials: [ParsedCredential], allowDomainMismatch: Bool)async throws  -> StepResult  {
+open func submitPresentation(selectedCredentials: [ParsedCredential], selectedFields: [UInt32: [String]], allowDomainMismatch: Bool)async throws  -> StepResult  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_mobile_sdk_rs_fn_method_vcalmholder_submit_presentation(
                     self.uniffiCloneHandle(),
-                    FfiConverterSequenceTypeParsedCredential.lower(selectedCredentials),FfiConverterBool.lower(allowDomainMismatch)
+                    FfiConverterSequenceTypeParsedCredential.lower(selectedCredentials),FfiConverterDictionaryUInt32SequenceString.lower(selectedFields),FfiConverterBool.lower(allowDomainMismatch)
                 )
             },
             pollFunc: ffi_mobile_sdk_rs_rust_future_poll_rust_buffer,
@@ -33726,6 +33726,32 @@ fileprivate struct FfiConverterSequenceTypeUuid: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterDictionaryUInt32SequenceString: FfiConverterRustBuffer {
+    public static func write(_ value: [UInt32: [String]], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for (key, value) in value {
+            FfiConverterUInt32.write(key, into: &buf)
+            FfiConverterSequenceString.write(value, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [UInt32: [String]] {
+        let len: Int32 = try readInt(&buf)
+        var dict = [UInt32: [String]]()
+        dict.reserveCapacity(Int(len))
+        for _ in 0..<len {
+            let key = try FfiConverterUInt32.read(from: &buf)
+            let value = try FfiConverterSequenceString.read(from: &buf)
+            dict[key] = value
+        }
+        return dict
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterDictionaryStringBool: FfiConverterRustBuffer {
     public static func write(_ value: [String: Bool], into buf: inout [UInt8]) {
         let len = Int32(value.count)
@@ -36518,7 +36544,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_method_vcalmholder_start_exchange() != 15267) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mobile_sdk_rs_checksum_method_vcalmholder_submit_presentation() != 47400) {
+    if (uniffi_mobile_sdk_rs_checksum_method_vcalmholder_submit_presentation() != 6342) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_vdccollection_add() != 62104) {

--- a/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/rust/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -15322,6 +15322,39 @@ public protocol VcalmHolderProtocol: AnyObject, Sendable {
     
     /**
      * Build, sign and POST a verifiable presentation.
+     *
+     * `selected_credentials` are the credentials the user chose. `selected_fields`
+     * is keyed by VPR query index: the entry for `i` is the field paths the user
+     * consented to disclose for query `i`.
+     *
+     * Four things to get right:
+     *
+     * * **A missing key is not an empty list.** If a query index is absent, that
+     * query is not narrowed and everything it named is disclosed. An entry that
+     * is present but empty means "the user deselected every field". So an empty
+     * map is the correct input for a caller with no per-field consent UI, and is
+     * NOT a way to disclose nothing. Send an entry only for a query that
+     * actually offered the user a choice.
+     * * **Paths must match `requested_fields()` exactly.** Selection is string
+     * equality against the example-derived paths, with no prefix or wildcard
+     * semantics: `credentialSubject.address` does not select
+     * `credentialSubject.address.street`. Pass the strings back unmodified.
+     * * **Only `credentialSubject.*` paths can be narrowed.** Structural
+     * properties an example names — `type`, `@context`, `credentialStatus` — are
+     * always disclosed, because the verifier's example states what the response
+     * credential must contain. They are not consent surface and should not be
+     * shown as checkboxes.
+     * * **Narrowing applies only to a credential with an `ecdsa-sd-2023` base
+     * proof**, under a VPR that requests selective disclosure. Otherwise the
+     * whole credential is presented and `selected_fields` is ignored, so a UI
+     * must not offer field checkboxes there. `matched_credentials()` reports
+     * `selective_disclosure` per credential for exactly this decision.
+     *
+     * Dropping fields from a query that is not explicitly optional is refused
+     * rather than signed, since the verifier's example makes every field it names
+     * required. If an optional query has every subject field deselected, that
+     * credential is dropped from the presentation — a derived credential with no
+     * `credentialSubject` would not be valid.
      */
     func submitPresentation(selectedCredentials: [ParsedCredential], selectedFields: [UInt32: [String]], allowDomainMismatch: Bool) async throws  -> StepResult
     
@@ -15522,6 +15555,39 @@ open func startExchange(input: String, authHeader: String?)async throws  -> Step
     
     /**
      * Build, sign and POST a verifiable presentation.
+     *
+     * `selected_credentials` are the credentials the user chose. `selected_fields`
+     * is keyed by VPR query index: the entry for `i` is the field paths the user
+     * consented to disclose for query `i`.
+     *
+     * Four things to get right:
+     *
+     * * **A missing key is not an empty list.** If a query index is absent, that
+     * query is not narrowed and everything it named is disclosed. An entry that
+     * is present but empty means "the user deselected every field". So an empty
+     * map is the correct input for a caller with no per-field consent UI, and is
+     * NOT a way to disclose nothing. Send an entry only for a query that
+     * actually offered the user a choice.
+     * * **Paths must match `requested_fields()` exactly.** Selection is string
+     * equality against the example-derived paths, with no prefix or wildcard
+     * semantics: `credentialSubject.address` does not select
+     * `credentialSubject.address.street`. Pass the strings back unmodified.
+     * * **Only `credentialSubject.*` paths can be narrowed.** Structural
+     * properties an example names — `type`, `@context`, `credentialStatus` — are
+     * always disclosed, because the verifier's example states what the response
+     * credential must contain. They are not consent surface and should not be
+     * shown as checkboxes.
+     * * **Narrowing applies only to a credential with an `ecdsa-sd-2023` base
+     * proof**, under a VPR that requests selective disclosure. Otherwise the
+     * whole credential is presented and `selected_fields` is ignored, so a UI
+     * must not offer field checkboxes there. `matched_credentials()` reports
+     * `selective_disclosure` per credential for exactly this decision.
+     *
+     * Dropping fields from a query that is not explicitly optional is refused
+     * rather than signed, since the verifier's example makes every field it names
+     * required. If an optional query has every subject field deselected, that
+     * credential is dropped from the presentation — a derived credential with no
+     * `credentialSubject` would not be valid.
      */
 open func submitPresentation(selectedCredentials: [ParsedCredential], selectedFields: [UInt32: [String]], allowDomainMismatch: Bool)async throws  -> StepResult  {
     return
@@ -29784,6 +29850,8 @@ public enum VcalmError: Swift.Error, Equatable, Hashable, Foundation.LocalizedEr
     )
     case SdDeriveFailed(String
     )
+    case RequiredFieldsDeselected(queryIndex: UInt32, dropped: String
+    )
     case UnsupportedCredentialFormat(String
     )
 
@@ -29866,7 +29934,11 @@ public struct FfiConverterTypeVcalmError: FfiConverterRustBuffer {
         case 18: return .SdDeriveFailed(
             try FfiConverterString.read(from: &buf)
             )
-        case 19: return .UnsupportedCredentialFormat(
+        case 19: return .RequiredFieldsDeselected(
+            queryIndex: try FfiConverterUInt32.read(from: &buf), 
+            dropped: try FfiConverterString.read(from: &buf)
+            )
+        case 20: return .UnsupportedCredentialFormat(
             try FfiConverterString.read(from: &buf)
             )
 
@@ -29971,8 +30043,14 @@ public struct FfiConverterTypeVcalmError: FfiConverterRustBuffer {
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .UnsupportedCredentialFormat(v1):
+        case let .RequiredFieldsDeselected(queryIndex,dropped):
             writeInt(&buf, Int32(19))
+            FfiConverterUInt32.write(queryIndex, into: &buf)
+            FfiConverterString.write(dropped, into: &buf)
+            
+        
+        case let .UnsupportedCredentialFormat(v1):
+            writeInt(&buf, Int32(20))
             FfiConverterString.write(v1, into: &buf)
             
         }
@@ -36544,7 +36622,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_method_vcalmholder_start_exchange() != 15267) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mobile_sdk_rs_checksum_method_vcalmholder_submit_presentation() != 6342) {
+    if (uniffi_mobile_sdk_rs_checksum_method_vcalmholder_submit_presentation() != 21087) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_vdccollection_add() != 62104) {

--- a/rust/src/vcalm/mod.rs
+++ b/rust/src/vcalm/mod.rs
@@ -108,6 +108,7 @@ impl VcalmHolder {
     pub async fn submit_presentation(
         self: Arc<Self>,
         selected_credentials: Vec<Arc<ParsedCredential>>,
+        selected_fields: HashMap<u32, Vec<String>>,
         allow_domain_mismatch: bool,
     ) -> Result<StepResult, VcalmError> {
         Ok(self
@@ -115,6 +116,7 @@ impl VcalmHolder {
             .clone()
             .submit_presentation(
                 selected_credentials.into_iter().map(to_stored).collect(),
+                selected_fields,
                 allow_domain_mismatch,
             )
             .await?

--- a/rust/src/vcalm/mod.rs
+++ b/rust/src/vcalm/mod.rs
@@ -105,6 +105,28 @@ impl VcalmHolder {
     }
 
     /// Build, sign and POST a verifiable presentation.
+    ///
+    /// `selected_credentials` are the credentials the user chose (e.g. from
+    /// `matched_credentials()`). `selected_fields` is keyed by VPR query index:
+    /// the entry for `i` is the field paths the user consented to disclose for
+    /// query `i`.
+    ///
+    /// A MISSING key means "no narrowing" — everything that query named is
+    /// disclosed; a present-but-empty list means the user deselected every field.
+    /// An empty map is therefore the right input for a caller with no per-field
+    /// consent UI. Paths must equal what `requested_fields()` returned (plain
+    /// string equality, no prefix semantics, so `credentialSubject.address` does
+    /// not select `credentialSubject.address.street`). Only `credentialSubject.*`
+    /// paths narrow: structural properties like `credentialStatus` are always
+    /// disclosed, since the example states what the response credential must
+    /// contain, and so should not be rendered as checkboxes. Dropping subject
+    /// paths from a query that is not explicitly optional is refused with
+    /// `RequiredFieldsDeselected`; an optional query with every subject field
+    /// deselected drops that credential from the presentation rather than deriving
+    /// a credential with no `credentialSubject`. Narrowing takes effect only for a
+    /// credential carrying an `ecdsa-sd-2023` base proof — on the full-disclosure
+    /// path `selected_fields` is ignored, and `matched_credentials()` reports
+    /// `selective_disclosure` per credential for exactly that decision.
     pub async fn submit_presentation(
         self: Arc<Self>,
         selected_credentials: Vec<Arc<ParsedCredential>>,

--- a/rust/src/vcalm/wire.rs
+++ b/rust/src/vcalm/wire.rs
@@ -372,6 +372,8 @@ pub enum VcalmError {
     NoPresentableProof { credential_types: String },
     #[error("selective-disclosure derive failed: {0}")]
     SdDeriveFailed(String),
+    #[error("selection dropped required field(s) [{dropped}] from required query {query_index}")]
+    RequiredFieldsDeselected { query_index: u32, dropped: String },
     #[error("unsupported credential format: {0}")]
     UnsupportedCredentialFormat(String),
 }
@@ -404,6 +406,13 @@ impl From<vcalm_rs::error::VcalmError> for VcalmError {
                 Self::NoPresentableProof { credential_types }
             }
             E::SdDeriveFailed(v) => Self::SdDeriveFailed(v),
+            E::RequiredFieldsDeselected {
+                query_index,
+                dropped,
+            } => Self::RequiredFieldsDeselected {
+                query_index,
+                dropped,
+            },
             E::UnsupportedCredentialFormat(v) => Self::UnsupportedCredentialFormat(v),
         }
     }


### PR DESCRIPTION
## Description
- See associated [PR on `vcalm-rs`](https://github.com/spruceid/vcalm-rs/pull/2)
- Implemented UI such as sprucekit-mobile's Showcase lets users uncheck optional fields, but this isn't ever passed to the protocol (`VcalmHolder::submit_presentation`) to be referenced during SD derive
- This PR propogates the state tracking selected fields to the HandleVCALMView level, so it can be passed into `VcalmHolder::submit_presentation`

## Tested
- Only selected fields from UI are being passed to `submit_presentation`
- Unit test in the rust layer ensures that deselected fields are not disclosed 