### PR TITLE
ACC-1985: Forbid British spelling in external-facing software

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,21 @@ jobs:
       - name: Check dependency licenses
         run: ./gradlew licensee -Prust-target=arm64
 
+  spelling:
+    name: US English (user-facing copy)
+    runs-on: ubuntu-latest
+    if: github.actor != 'sprucekit-mobile-monorepo[bot]'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check user-facing copy for British spelling
+        uses: crate-ci/typos@v1.49.0
+        with:
+          files: |
+            android/Showcase/src
+            ios/Showcase
+            flutter/example/lib
+
   flutter:
     runs-on: ubuntu-latest
     if: github.actor != 'sprucekit-mobile-monorepo[bot]'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,9 @@ Changes to the Rust layer require regenerating bindings before platform work:
 
 ## CI
 
-CI runs on push to main and PRs with four jobs (rust, ios, android, flutter). See `.github/workflows/ci.yml`.
+CI runs on push to main and PRs with five jobs (rust, ios, android, spelling, flutter). See `.github/workflows/ci.yml`.
+
+The `spelling` job runs `typos` over the Showcase apps and the Flutter example to keep user-facing copy in US English. Exemptions are in `_typos.toml`.
 
 `RUSTFLAGS="-Dwarnings"` is set globally -- all Rust warnings are errors in CI.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,6 +174,14 @@ touch local.properties  # if missing
 ./gradlew :showcase:lint -Prust-target=arm64
 ```
 
+**US English** — copy shown to a person is US English, enforced by the `spelling` CI job over the Showcase apps and the Flutter example. Exemptions live in `_typos.toml`:
+
+```bash
+typos android/Showcase/src ios/Showcase flutter/example/lib
+```
+
+Install it with `brew install typos-cli` or `cargo install typos-cli`. When a flagged word is a name we do not own — an ISO mDL claim key, a third-party API — add it to `_typos.toml` rather than renaming it.
+
 ## Releases
 
 ### SDKs

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,26 @@
+# US English is enforced on user-facing copy by the `spelling` CI job, which
+# checks the Showcase apps and the Flutter example -- the surfaces a person
+# actually reads. The SDK and Rust core are out of scope.
+#
+# `locale = "en-us"` catches most British spellings on its own; extend-words
+# fills the gaps where typos accepts both variants.
+
+[default]
+locale = "en-us"
+
+# Embedded trust-anchor certificates are base64, not prose.
+extend-ignore-re = ["[A-Za-z0-9+/]{20,}={0,2}"]
+
+[default.extend-words]
+acknowledgement = "acknowledgment"
+amongst = "among"
+cancelled = "canceled"
+cancelling = "canceling"
+programme = "program"
+whilst = "while"
+
+[default.extend-identifiers]
+# ISO mDL claim keys. The wire spells these in British English, so the keys
+# stay as-is; only copy shown to a person is Americanized.
+eye_colour = "eye_colour"
+hair_colour = "hair_colour"

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/AddToWalletView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/credentials/AddToWalletView.kt
@@ -66,7 +66,7 @@ fun AddToWalletView(
     // fires — used by flows (like VCALM) that might need to continue in
     // place rather than always going home.
     navigateHomeOnSuccess: Boolean = true,
-    // Used to override behaviour for "Accept" button - used by protocols such as VCALM
+    // Used to override behavior for "Accept" button - used by protocols such as VCALM
     onAcceptCredential: (suspend (rawCredential: String) -> Unit)? = null,
 ) {
     val credentialPacksViewModel: CredentialPacksViewModel = activityHiltViewModel()

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/verifier/VerifierHomeView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/verifier/VerifierHomeView.kt
@@ -157,7 +157,7 @@ fun VerifierHomeBody(
                 }
             )
             VerifierListItem(
-                title = "Mobile Driver's Licence",
+                title = "Mobile Driver's License",
                 description = "Verifies an ISO formatted mobile driver's license by reading a QR code",
                 type = VerifierListItemTagType.SCAN_QR_CODE,
                 modifier = Modifier.clickable {
@@ -165,7 +165,7 @@ fun VerifierHomeBody(
                 }
             )
             VerifierListItem(
-                title = "Mobile Driver's Licence - Over 18",
+                title = "Mobile Driver's License - Over 18",
                 description = "Verifies an ISO formatted mobile driver's license by reading a QR code",
                 type = VerifierListItemTagType.SCAN_QR_CODE,
                 modifier = Modifier.clickable {

--- a/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleOID4VCIView.kt
+++ b/android/Showcase/src/main/java/com/spruceid/mobilesdkexample/wallet/HandleOID4VCIView.kt
@@ -184,7 +184,7 @@ fun HandleOID4VCIView(
                 promptForPin = false
                 pendingTxCodeState = null
                 pinInput = ""
-                err = "Transaction code cancelled"
+                err = "Transaction code canceled"
             },
             title = { Text("Enter Transaction Code") },
             text = {
@@ -235,7 +235,7 @@ fun HandleOID4VCIView(
                     promptForPin = false
                     pendingTxCodeState = null
                     pinInput = ""
-                    err = "Transaction code cancelled"
+                    err = "Transaction code canceled"
                 }) { Text("Cancel") }
             },
         )

--- a/flutter/example/lib/demos/oid4vci_demo.dart
+++ b/flutter/example/lib/demos/oid4vci_demo.dart
@@ -194,7 +194,7 @@ class _Oid4vciDemoState extends State<Oid4vciDemo> {
       await _api.releaseSession(sessionId);
       setState(() {
         _loading = false;
-        _error = 'Sign-in cancelled or browser error';
+        _error = 'Sign-in canceled or browser error';
       });
       return;
     }
@@ -281,7 +281,7 @@ class _Oid4vciDemoState extends State<Oid4vciDemo> {
       _loading = false;
       _sessionId = null;
       _txCodeMetadata = null;
-      _error = 'PIN entry cancelled';
+      _error = 'PIN entry canceled';
     });
   }
 

--- a/flutter/example/lib/demos/vcalm_demo.dart
+++ b/flutter/example/lib/demos/vcalm_demo.dart
@@ -390,7 +390,7 @@ class _VcalmDemoState extends State<VcalmDemo> {
         } else {
           setState(
             () => _presentationStatus =
-                'Presentation cancelled (domain mismatch).',
+                'Presentation canceled (domain mismatch).',
           );
         }
         return;

--- a/ios/Showcase/Targets/AppUIKit/Sources/ScanningView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/ScanningView.swift
@@ -92,7 +92,7 @@ struct ScanningComponent: View {
     }
 
     /// Checking camera permission
-    func checkCameraPermisssion() {
+    func checkCameraPermission() {
         Task {
             switch AVCaptureDevice.authorizationStatus(for: .video) {
             case .authorized:
@@ -216,7 +216,7 @@ struct ScanningComponent: View {
 
             }
         }
-        .onAppear(perform: checkCameraPermisssion)
+        .onAppear(perform: checkCameraPermission)
         .alert(isPresented: $showError) {
             Alert(
                 title: Text(errorMessage),

--- a/ios/Showcase/Targets/AppUIKit/Sources/Utils.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/Utils.swift
@@ -17,9 +17,9 @@ struct HideViewModifier: ViewModifier {
 }
 
 extension View {
-    func hide(if isHiddden: Bool) -> some View {
+    func hide(if isHidden: Bool) -> some View {
         ModifiedContent(content: self,
-                        modifier: HideViewModifier(isHidden: isHiddden)
+                        modifier: HideViewModifier(isHidden: isHidden)
         )
     }
 }

--- a/ios/Showcase/Targets/AppUIKit/Sources/credentials/AddToWalletView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/credentials/AddToWalletView.swift
@@ -30,7 +30,7 @@ struct AddToWalletView: View {
 
     var onSuccess: (() -> Void)?
     var navigateHomeOnSuccess: Bool = true
-    // Used to override behaviour for "Accept" button - used by protocols such as VCALM
+    // Used to override behavior for "Accept" button - used by protocols such as VCALM
     var onAcceptCredential: ((String) async throws -> Void)?
 
     init(

--- a/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleOID4VCIView.swift
+++ b/ios/Showcase/Targets/AppUIKit/Sources/wallet/HandleOID4VCIView.swift
@@ -157,7 +157,7 @@ struct HandleOID4VCIView: View {
                             err = "Missing authorization code in callback"
                         }
                     } else {
-                        err = "Sign-in cancelled"
+                        err = "Sign-in canceled"
                     }
                 case .requiresTxCode(let txState):
                     self.pendingTxState = txState
@@ -264,7 +264,7 @@ struct HandleOID4VCIView: View {
             Button("Cancel", role: .cancel) {
                 pendingTxState = nil
                 pinInput = ""
-                err = "Transaction code cancelled"
+                err = "Transaction code canceled"
             }
         } message: {
             Text("Please enter the PIN provided with the QR code.")


### PR DESCRIPTION
## Description

User-facing copy is now US English, enforced by a spelling CI job running [typos](https://github.com/crate-ci/typos) over the Showcase apps and the Flutter example. The SDK and Rust core are out of scope.

`locale = "en-us"` covers most British spellings on its own, but it treats "cancelled" as an accepted US variant and has no mapping for "programme", "whilst", "grey" and others. `_typos.toml` adds an extend-words table for those gaps. The word list matches https://github.com/spruceid/safe-mobile/pull/166 so the two repos stay consistent.
