### PR TITLE
Add per-field consent to Flutter vcalm submitPresentation

### DIFF
--- a/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/Vcalm.g.kt
+++ b/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/Vcalm.g.kt
@@ -833,12 +833,22 @@ interface Vcalm {
    * The chosen cryptosuite is server-driven.
    *
    * @param selected Stable keys of the credentials the user selected
+   * @param selectedFields Per-query field consent, keyed by VPR query index
+   *   (the same index [matchedCredentials]/[requestedFields] report). A
+   *   missing key means "no narrowing" — everything that query named is
+   *   disclosed; a present-but-empty list means the user deselected every
+   *   field. Pass an empty map when there is no per-field consent UI. Paths
+   *   must equal what [requestedFields] returned (plain string equality, no
+   *   prefix semantics). Narrowing only applies to credentials carrying an
+   *   `ecdsa-sd-2023` base proof; on the full-disclosure path it is ignored.
+   *   Keys outside the u32 range are rejected with a [VcalmProblem]
+   *   (`problemType == "submit-error"`).
    * @param allowDomainMismatch Proceed even if the VPR `domain` does not match
    *   the exchange channel host (§3.4.3.2 anti-replay). Set only after explicit
    *   user consent — never as a default. A domain mismatch otherwise returns a
    *   [VcalmProblem] with `problemType == "domain-mismatch"`.
    */
-  fun submitPresentation(selected: List<VcalmCredentialKey>, allowDomainMismatch: Boolean, callback: (Result<VcalmStepResult>) -> Unit)
+  fun submitPresentation(selected: List<VcalmCredentialKey>, selectedFields: Map<Long, List<String>>, allowDomainMismatch: Boolean, callback: (Result<VcalmStepResult>) -> Unit)
   /** Preview the credentials offered in the current Offer. */
   fun offeredCredentials(callback: (Result<List<VcalmOfferedCredentialData>>) -> Unit)
   /** Accept the current Offer (verify + store), then advance the exchange. */
@@ -943,8 +953,9 @@ interface Vcalm {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val selectedArg = args[0] as List<VcalmCredentialKey>
-            val allowDomainMismatchArg = args[1] as Boolean
-            api.submitPresentation(selectedArg, allowDomainMismatchArg) { result: Result<VcalmStepResult> ->
+            val selectedFieldsArg = args[1] as Map<Long, List<String>>
+            val allowDomainMismatchArg = args[2] as Boolean
+            api.submitPresentation(selectedArg, selectedFieldsArg, allowDomainMismatchArg) { result: Result<VcalmStepResult> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(VcalmPigeonUtils.wrapError(error))

--- a/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/VcalmAdapter.kt
+++ b/flutter/android/src/main/kotlin/com/spruceid/sprucekit_mobile/VcalmAdapter.kt
@@ -259,10 +259,24 @@ internal class VcalmAdapter(
 
     override fun submitPresentation(
         selected: List<VcalmCredentialKey>,
+        selectedFields: Map<Long, List<String>>,
         allowDomainMismatch: Boolean,
         callback: (Result<VcalmStepResult>) -> Unit
     ) {
-        Log.d(TAG, "submitPresentation: ${selected.size} selected key(s), allowDomainMismatch=$allowDomainMismatch")
+        Log.d(TAG, "submitPresentation: ${selected.size} selected key(s), ${selectedFields.size} narrowed quer(ies), allowDomainMismatch=$allowDomainMismatch")
+        // Rust takes the query index as u32. Reject out-of-range keys loudly —
+        // Long.toUInt() would silently wrap one onto another query's index and
+        // narrow the wrong credential.
+        val badIndex = selectedFields.keys.firstOrNull { it !in 0..0xFFFF_FFFFL }
+        if (badIndex != null) {
+            Log.e(TAG, "submitPresentation: query index $badIndex is outside the u32 range")
+            return callback(Result.success(VcalmProblem(
+                problemType = "submit-error",
+                status = null,
+                title = "Invalid selectedFields query index",
+                detail = "index=$badIndex is outside the u32 range"
+            )))
+        }
         CoroutineScope(Dispatchers.IO).launch {
             try {
                 val h = currentHolder()
@@ -271,7 +285,11 @@ internal class VcalmAdapter(
                 // Suite is server-driven — no suite parameter.
                 val creds = selected.mapNotNull { keyMap[it] }
                 Log.d(TAG, "submitPresentation: resolved ${creds.size}/${selected.size} handle(s)")
-                val step = h.submitPresentation(creds, allowDomainMismatch)
+                val step = h.submitPresentation(
+                    creds,
+                    selectedFields.entries.associate { (k, v) -> k.toUInt() to v },
+                    allowDomainMismatch,
+                )
                 Log.d(TAG, "submitPresentation: step=${step::class.simpleName}")
                 callback(Result.success(toPigeonStep(step)))
             } catch (e: VcalmException.DomainChannelMismatch) {

--- a/flutter/example/lib/demos/vcalm_demo.dart
+++ b/flutter/example/lib/demos/vcalm_demo.dart
@@ -373,7 +373,13 @@ class _VcalmDemoState extends State<VcalmDemo> {
         'submitPresentation: key=${key.credentialId}, '
         'allowDomainMismatch=$allowDomainMismatch',
       );
-      final step = await _vcalm.submitPresentation([key], allowDomainMismatch);
+      // Empty selectedFields = no per-field consent UI in this demo, so every
+      // requested field is disclosed.
+      final step = await _vcalm.submitPresentation(
+        [key],
+        const {},
+        allowDomainMismatch,
+      );
       _log('submitPresentation step: ${step.runtimeType}');
       if (!mounted) return;
 

--- a/flutter/ios/Classes/Vcalm.g.swift
+++ b/flutter/ios/Classes/Vcalm.g.swift
@@ -751,11 +751,21 @@ protocol Vcalm {
   /// The chosen cryptosuite is server-driven.
   ///
   /// @param selected Stable keys of the credentials the user selected
+  /// @param selectedFields Per-query field consent, keyed by VPR query index
+  ///   (the same index [matchedCredentials]/[requestedFields] report). A
+  ///   missing key means "no narrowing" — everything that query named is
+  ///   disclosed; a present-but-empty list means the user deselected every
+  ///   field. Pass an empty map when there is no per-field consent UI. Paths
+  ///   must equal what [requestedFields] returned (plain string equality, no
+  ///   prefix semantics). Narrowing only applies to credentials carrying an
+  ///   `ecdsa-sd-2023` base proof; on the full-disclosure path it is ignored.
+  ///   Keys outside the u32 range are rejected with a [VcalmProblem]
+  ///   (`problemType == "submit-error"`).
   /// @param allowDomainMismatch Proceed even if the VPR `domain` does not match
   ///   the exchange channel host (§3.4.3.2 anti-replay). Set only after explicit
   ///   user consent — never as a default. A domain mismatch otherwise returns a
   ///   [VcalmProblem] with `problemType == "domain-mismatch"`.
-  func submitPresentation(selected: [VcalmCredentialKey], allowDomainMismatch: Bool, completion: @escaping (Result<VcalmStepResult, Error>) -> Void)
+  func submitPresentation(selected: [VcalmCredentialKey], selectedFields: [Int64: [String]], allowDomainMismatch: Bool, completion: @escaping (Result<VcalmStepResult, Error>) -> Void)
   /// Preview the credentials offered in the current Offer.
   func offeredCredentials(completion: @escaping (Result<[VcalmOfferedCredentialData], Error>) -> Void)
   /// Accept the current Offer (verify + store), then advance the exchange.
@@ -864,6 +874,16 @@ class VcalmSetup {
     /// The chosen cryptosuite is server-driven.
     ///
     /// @param selected Stable keys of the credentials the user selected
+    /// @param selectedFields Per-query field consent, keyed by VPR query index
+    ///   (the same index [matchedCredentials]/[requestedFields] report). A
+    ///   missing key means "no narrowing" — everything that query named is
+    ///   disclosed; a present-but-empty list means the user deselected every
+    ///   field. Pass an empty map when there is no per-field consent UI. Paths
+    ///   must equal what [requestedFields] returned (plain string equality, no
+    ///   prefix semantics). Narrowing only applies to credentials carrying an
+    ///   `ecdsa-sd-2023` base proof; on the full-disclosure path it is ignored.
+    ///   Keys outside the u32 range are rejected with a [VcalmProblem]
+    ///   (`problemType == "submit-error"`).
     /// @param allowDomainMismatch Proceed even if the VPR `domain` does not match
     ///   the exchange channel host (§3.4.3.2 anti-replay). Set only after explicit
     ///   user consent — never as a default. A domain mismatch otherwise returns a
@@ -873,8 +893,9 @@ class VcalmSetup {
       submitPresentationChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
         let selectedArg = args[0] as! [VcalmCredentialKey]
-        let allowDomainMismatchArg = args[1] as! Bool
-        api.submitPresentation(selected: selectedArg, allowDomainMismatch: allowDomainMismatchArg) { result in
+        let selectedFieldsArg = args[1] as! [Int64: [String]]
+        let allowDomainMismatchArg = args[2] as! Bool
+        api.submitPresentation(selected: selectedArg, selectedFields: selectedFieldsArg, allowDomainMismatch: allowDomainMismatchArg) { result in
           switch result {
           case .success(let res):
             reply(wrapResult(res))

--- a/flutter/ios/Classes/VcalmAdapter.swift
+++ b/flutter/ios/Classes/VcalmAdapter.swift
@@ -296,11 +296,29 @@ class VcalmAdapter: Vcalm {
 
     func submitPresentation(
         selected: [VcalmCredentialKey],
+        selectedFields: [Int64: [String]],
         allowDomainMismatch: Bool,
         completion: @escaping (Result<VcalmStepResult, Error>) -> Void
     ) {
         Task {
             do {
+                // Rust takes the query index as UInt32. Reject out-of-range keys
+                // loudly — the trapping UInt32(_:) initializer would crash the
+                // host app on a bad key instead of reporting it.
+                var narrowed: [UInt32: [String]] = [:]
+                for (key, fields) in selectedFields {
+                    guard let index = UInt32(exactly: key) else {
+                        log("submitPresentation: query index \(key) is outside the u32 range")
+                        completion(.success(VcalmProblem(
+                            problemType: "submit-error",
+                            status: nil,
+                            title: "Invalid selectedFields query index",
+                            detail: "index=\(key) is outside the u32 range"
+                        )))
+                        return
+                    }
+                    narrowed[index] = fields
+                }
                 guard let holder = currentHolder() else {
                     completion(.success(VcalmProblem(
                         problemType: "no-holder",
@@ -313,11 +331,11 @@ class VcalmAdapter: Vcalm {
                 lock.lock()
                 let resolved = selected.compactMap { self.credentialsByKey[$0] }
                 lock.unlock()
-                log("submitPresentation: resolved \(resolved.count)/\(selected.count) handle(s), allowDomainMismatch=\(allowDomainMismatch)")
+                log("submitPresentation: resolved \(resolved.count)/\(selected.count) handle(s), \(selectedFields.count) narrowed quer(ies), allowDomainMismatch=\(allowDomainMismatch)")
                 // Suite is server-driven — no suite parameter.
                 let step = try await holder.submitPresentation(
                     selectedCredentials: resolved,
-                    selectedFields: [:],
+                    selectedFields: narrowed,
                     allowDomainMismatch: allowDomainMismatch
                 )
                 completion(.success(try await toPigeonStep(step)))

--- a/flutter/lib/pigeon/vcalm.g.dart
+++ b/flutter/lib/pigeon/vcalm.g.dart
@@ -818,18 +818,28 @@ class Vcalm {
   /// The chosen cryptosuite is server-driven.
   ///
   /// @param selected Stable keys of the credentials the user selected
+  /// @param selectedFields Per-query field consent, keyed by VPR query index
+  ///   (the same index [matchedCredentials]/[requestedFields] report). A
+  ///   missing key means "no narrowing" — everything that query named is
+  ///   disclosed; a present-but-empty list means the user deselected every
+  ///   field. Pass an empty map when there is no per-field consent UI. Paths
+  ///   must equal what [requestedFields] returned (plain string equality, no
+  ///   prefix semantics). Narrowing only applies to credentials carrying an
+  ///   `ecdsa-sd-2023` base proof; on the full-disclosure path it is ignored.
+  ///   Keys outside the u32 range are rejected with a [VcalmProblem]
+  ///   (`problemType == "submit-error"`).
   /// @param allowDomainMismatch Proceed even if the VPR `domain` does not match
   ///   the exchange channel host (§3.4.3.2 anti-replay). Set only after explicit
   ///   user consent — never as a default. A domain mismatch otherwise returns a
   ///   [VcalmProblem] with `problemType == "domain-mismatch"`.
-  Future<VcalmStepResult> submitPresentation(List<VcalmCredentialKey> selected, bool allowDomainMismatch) async {
+  Future<VcalmStepResult> submitPresentation(List<VcalmCredentialKey> selected, Map<int, List<String>> selectedFields, bool allowDomainMismatch) async {
     final pigeonVar_channelName = 'dev.flutter.pigeon.sprucekit_mobile.Vcalm.submitPresentation$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[selected, allowDomainMismatch]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[selected, selectedFields, allowDomainMismatch]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(

--- a/flutter/pigeons/vcalm.dart
+++ b/flutter/pigeons/vcalm.dart
@@ -211,6 +211,16 @@ abstract class Vcalm {
   /// The chosen cryptosuite is server-driven.
   ///
   /// @param selected Stable keys of the credentials the user selected
+  /// @param selectedFields Per-query field consent, keyed by VPR query index
+  ///   (the same index [matchedCredentials]/[requestedFields] report). A
+  ///   missing key means "no narrowing" — everything that query named is
+  ///   disclosed; a present-but-empty list means the user deselected every
+  ///   field. Pass an empty map when there is no per-field consent UI. Paths
+  ///   must equal what [requestedFields] returned (plain string equality, no
+  ///   prefix semantics). Narrowing only applies to credentials carrying an
+  ///   `ecdsa-sd-2023` base proof; on the full-disclosure path it is ignored.
+  ///   Keys outside the u32 range are rejected with a [VcalmProblem]
+  ///   (`problemType == "submit-error"`).
   /// @param allowDomainMismatch Proceed even if the VPR `domain` does not match
   ///   the exchange channel host (§3.4.3.2 anti-replay). Set only after explicit
   ///   user consent — never as a default. A domain mismatch otherwise returns a
@@ -218,6 +228,7 @@ abstract class Vcalm {
   @async
   VcalmStepResult submitPresentation(
     List<VcalmCredentialKey> selected,
+    Map<int, List<String>> selectedFields,
     bool allowDomainMismatch,
   );
 


### PR DESCRIPTION
## Description

This wires the `selected_fields` parameter from #358 through the Pigeon contract and both native adapters, with validation of query indices on both sides. 

### Other changes

N/A

### Optional section

N/A

## Tested

Flutter demo app